### PR TITLE
Add OpenAI proxy function and secure frontend calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.*
 # supabase
 !src/lib/
 !src/lib/supabase.ts
+
+# Azure Functions (local settings)
+api/local.settings.json

--- a/api/openai-proxy/function.json
+++ b/api/openai-proxy/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post", "options"],
+      "route": "openai-proxy"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/openai-proxy/index.js
+++ b/api/openai-proxy/index.js
@@ -1,0 +1,82 @@
+// Node 18+ on Azure Functions has global fetch.
+const ALLOWED_ORIGINS = []; // e.g., ["https://your-swa.azurestaticapps.net"]; empty = same-origin via SWA
+
+function cors(req) {
+  // If front-end and API are served by SWA together, you can omit CORS completely.
+  // Keep this utility for local dev across ports.
+  const origin = req.headers && req.headers.origin;
+  const allow =
+    !ALLOWED_ORIGINS.length || (origin && ALLOWED_ORIGINS.includes(origin))
+      ? origin || "*"
+      : "null";
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS"
+  };
+}
+
+function badRequest(body, req) {
+  return { status: 400, body: JSON.stringify(body), headers: { "Content-Type": "application/json", ...cors(req) } };
+}
+function serverError(body, req) {
+  return { status: 500, body: JSON.stringify(body), headers: { "Content-Type": "application/json", ...cors(req) } };
+}
+function noContent(req) {
+  return { status: 204, headers: cors(req) };
+}
+
+module.exports = async function (context, req) {
+  // CORS preflight
+  if (req.method === "OPTIONS") return noContent(req);
+
+  const key = process.env.OPENAI_API_KEY;
+  if (req.method === "GET") {
+    // Health check endpoint: returns 204 if configured
+    if (!key) return serverError({ error: "OPENAI_API_KEY not configured" }, req);
+    return noContent(req);
+  }
+
+  if (req.method !== "POST") {
+    return badRequest({ error: "Use POST /api/openai-proxy" }, req);
+  }
+  if (!key) return serverError({ error: "OPENAI_API_KEY not configured" }, req);
+
+  let payload = {};
+  try {
+    payload = typeof req.body === "string" ? JSON.parse(req.body) : (req.body || {});
+  } catch {
+    return badRequest({ error: "Invalid JSON body" }, req);
+  }
+
+  // Expect { messages: ChatMessage[], model?, temperature? }
+  const { messages, model = "gpt-4o-mini", temperature = 0.7 } = payload || {};
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return badRequest({ error: "Missing 'messages' array" }, req);
+  }
+
+  try {
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${key}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model,
+        temperature,
+        messages
+      })
+    });
+
+    const text = await r.text(); // pass through OpenAI response as-is
+    return {
+      status: r.status,
+      body: text,
+      headers: { "Content-Type": "application/json", ...cors(req) }
+    };
+  } catch (err) {
+    context.log("Proxy error:", err);
+    return serverError({ error: "Failed calling OpenAI" }, req);
+  }
+};

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,12 +1,19 @@
-const API_URL = "https://api.openai.com/v1/chat/completions";
-const API_KEY = process.env.OPENAI_API_KEY;
+const PROXY_URL = "/api/openai-proxy";
 
 export type ChatMessage = {
   role: "system" | "user" | "assistant";
   content: string;
 };
 
-export const isOpenAiConfigured = typeof API_KEY === "string" && API_KEY.length > 0;
+// Optional: runtime health probe (client-side way to check config)
+export async function isOpenAiConfigured(): Promise<boolean> {
+  try {
+    const res = await fetch(PROXY_URL, { method: "GET" });
+    return res.status === 204;
+  } catch {
+    return false;
+  }
+}
 
 function buildErrorMessage(status: number, body: any) {
   if (body && typeof body === "object" && "error" in body) {
@@ -14,6 +21,7 @@ function buildErrorMessage(status: number, body: any) {
     if (err && typeof err === "object" && "message" in err) {
       return String(err.message);
     }
+    if (typeof err === "string") return err;
   }
   if (status >= 400 && status < 500) return `Request failed with status ${status}.`;
   if (status >= 500) return "OpenAI service is currently unavailable.";
@@ -21,16 +29,9 @@ function buildErrorMessage(status: number, body: any) {
 }
 
 export async function fetchAssistantReply(messages: ChatMessage[]): Promise<string> {
-  if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set OPENAI_API_KEY in your environment.");
-  }
-
-  const response = await fetch(API_URL, {
+  const response = await fetch(PROXY_URL, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${API_KEY}`,
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       model: "gpt-4o-mini",
       temperature: 0.7,
@@ -38,7 +39,13 @@ export async function fetchAssistantReply(messages: ChatMessage[]): Promise<stri
     }),
   });
 
-  const body = await response.json();
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // pass
+  }
+
   if (!response.ok) {
     throw new Error(buildErrorMessage(response.status, body));
   }


### PR DESCRIPTION
## Summary
- add Azure Function proxy for relaying chat completion requests to OpenAI
- ignore local Azure Functions settings from version control
- update the frontend OpenAI client and chat component to call the proxy instead of using an embedded key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d56f2e72c08327a9637b63801359c5