### PR TITLE
Add booking agent with OpenAI tool support

### DIFF
--- a/src/components/BarberSelector.tsx
+++ b/src/components/BarberSelector.tsx
@@ -3,17 +3,9 @@ import React from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
-export type Barber = {
-  id: "joao" | "maria" | "carlos";
-  name: string;
-  icon: keyof typeof MaterialCommunityIcons.glyphMap;
-};
+import { BARBERS, type Barber as DomainBarber } from "../lib/domain";
 
-const BARBERS: Barber[] = [
-  { id: "joao", name: "João", icon: "account" },
-  { id: "maria", name: "Maria", icon: "account-outline" },
-  { id: "carlos", name: "Carlos", icon: "account-tie" },
-];
+export type Barber = DomainBarber;
 
 type Props = {
   selected: Barber;

--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -1,0 +1,387 @@
+import {
+  SERVICES,
+  BARBERS,
+  BARBER_MAP,
+  openingHour,
+  closingHour,
+  minutesToTime,
+  timeToMinutes,
+  addMinutes,
+  overlap,
+  pad,
+} from "./domain";
+import {
+  getBookings,
+  createBooking,
+  cancelBooking,
+  type BookingWithCustomer,
+} from "./bookings";
+import { callOpenAIChatCompletion, isOpenAiConfigured } from "./openai";
+
+export type ConversationMessage = {
+  role: "assistant" | "user";
+  content: string;
+};
+
+export type AgentRunOptions = {
+  systemPrompt: string;
+  contextSummary: string;
+  conversation: ConversationMessage[];
+  onBookingsMutated?: () => Promise<void> | void;
+};
+
+const TOOL_DEFINITIONS = [
+  {
+    type: "function",
+    function: {
+      name: "list_bookings",
+      description:
+        "Return the existing bookings. If a date is provided, only return bookings for that day. Always include the booking id, service id, barber id, and timeslot.",
+      parameters: {
+        type: "object",
+        properties: {
+          date: {
+            type: "string",
+            description: "Date in YYYY-MM-DD format",
+          },
+        },
+        required: ["date"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_availability",
+      description:
+        "Return available start times for a specific date, service, and barber. Only include options that do not conflict with existing bookings and stay inside opening hours.",
+      parameters: {
+        type: "object",
+        properties: {
+          date: { type: "string", description: "Date in YYYY-MM-DD format" },
+          service_id: {
+            type: "string",
+            enum: SERVICES.map((s) => s.id),
+            description: "ID of the requested service",
+          },
+          barber_id: {
+            type: "string",
+            enum: BARBERS.map((b) => b.id),
+            description: "ID of the requested barber",
+          },
+        },
+        required: ["date", "service_id", "barber_id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "book_service",
+      description:
+        "Create a booking for the user. Confirm there are no conflicts before creating the booking.",
+      parameters: {
+        type: "object",
+        properties: {
+          date: { type: "string", description: "Date in YYYY-MM-DD format" },
+          start: { type: "string", description: "Start time in HH:MM format" },
+          service_id: {
+            type: "string",
+            enum: SERVICES.map((s) => s.id),
+            description: "ID of the service to book",
+          },
+          barber_id: {
+            type: "string",
+            enum: BARBERS.map((b) => b.id),
+            description: "ID of the barber to book",
+          },
+          customer_name: {
+            type: "string",
+            description: "Optional name of the customer for reference",
+          },
+        },
+        required: ["date", "start", "service_id", "barber_id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "cancel_booking",
+      description:
+        "Cancel an existing booking. The booking can be referenced by its id or by date/start/barber combination.",
+      parameters: {
+        type: "object",
+        properties: {
+          booking_id: { type: "string", description: "Existing booking id" },
+          date: { type: "string", description: "Date in YYYY-MM-DD format" },
+          start: { type: "string", description: "Start time in HH:MM format" },
+          barber_id: {
+            type: "string",
+            enum: BARBERS.map((b) => b.id),
+            description: "ID of the barber handling the booking",
+          },
+        },
+      },
+    },
+  },
+] as const;
+
+type ChatCompletionMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+  }[];
+};
+
+async function listBookings(args: { date?: string }): Promise<unknown> {
+  if (!args?.date) {
+    return { error: "date is required" };
+  }
+  const rows = await getBookings(args.date);
+  return rows.map((b) => serializeBooking(b));
+}
+
+function serializeBooking(b: BookingWithCustomer) {
+  return {
+    id: b.id,
+    date: b.date,
+    start: b.start,
+    end: b.end,
+    service_id: b.service,
+    barber_id: b.barber,
+    service_name: SERVICES.find((s) => s.id === b.service)?.name ?? b.service,
+    barber_name: BARBER_MAP[b.barber as keyof typeof BARBER_MAP]?.name ?? b.barber,
+    customer_name: b._customer
+      ? `${b._customer.first_name}${b._customer.last_name ? ` ${b._customer.last_name}` : ""}`
+      : null,
+  };
+}
+
+async function getAvailability(args: {
+  date: string;
+  service_id: string;
+  barber_id: string;
+}) {
+  if (!args?.date || !args?.service_id || !args?.barber_id) {
+    return { error: "Missing date, service_id, or barber_id" };
+  }
+  const service = SERVICES.find((s) => s.id === args.service_id);
+  if (!service) return { error: `Unknown service ${args.service_id}` };
+
+  const startMinutes = openingHour * 60;
+  const endMinutes = closingHour * 60;
+  const dayBookings = await getBookings(args.date);
+  const relevant = dayBookings.filter((b) => b.barber === args.barber_id);
+
+  const slots: { start: string; end: string }[] = [];
+  for (let t = startMinutes; t <= endMinutes - service.minutes; t += 30) {
+    const start = minutesToTime(t);
+    const end = addMinutes(start, service.minutes);
+    if (timeToMinutes(end) > endMinutes) continue;
+    const hasConflict = relevant.some((b) => overlap(start, end, b.start, b.end));
+    if (!hasConflict) slots.push({ start, end });
+  }
+  return {
+    service_id: service.id,
+    barber_id: args.barber_id,
+    date: args.date,
+    slots,
+  };
+}
+
+async function bookService(
+  args: { date: string; start: string; service_id: string; barber_id: string; customer_name?: string },
+  onMutated?: () => Promise<void> | void,
+) {
+  const { date, start, service_id, barber_id } = args || {};
+  if (!date || !start || !service_id || !barber_id) {
+    return { error: "Missing date, start, service_id, or barber_id" };
+  }
+  const service = SERVICES.find((s) => s.id === service_id);
+  if (!service) return { error: `Unknown service ${service_id}` };
+
+  const startMinutes = timeToMinutes(start);
+  if (startMinutes < openingHour * 60) return { error: "Start time is before opening hours" };
+  const end = addMinutes(start, service.minutes);
+  if (timeToMinutes(end) > closingHour * 60) return { error: "Selected time exceeds closing hours" };
+
+  const dayBookings = await getBookings(date);
+  const conflict = dayBookings.find((b) => b.barber === barber_id && overlap(start, end, b.start, b.end));
+  if (conflict) {
+    return {
+      error: "conflict",
+      conflicting_booking: serializeBooking(conflict),
+    };
+  }
+
+  const bookingId = await createBooking({
+    date,
+    start,
+    end,
+    service: service.id,
+    barber: barber_id,
+    customer_id: null,
+  });
+
+  await onMutated?.();
+
+  return {
+    success: true,
+    booking: {
+      id: bookingId,
+      date,
+      start,
+      end,
+      service_id: service.id,
+      barber_id,
+    },
+  };
+}
+
+async function cancelService(
+  args: { booking_id?: string; date?: string; start?: string; barber_id?: string },
+  onMutated?: () => Promise<void> | void,
+) {
+  const { booking_id, date, start, barber_id } = args || {};
+  let id = booking_id;
+
+  if (!id) {
+    if (!date || !start || !barber_id) {
+      return { error: "Provide booking_id or date/start/barber_id" };
+    }
+    const rows = await getBookings(date);
+    const found = rows.find((b) => b.barber === barber_id && b.start === start);
+    if (!found) {
+      return { error: "Booking not found" };
+    }
+    id = found.id;
+  }
+
+  await cancelBooking(id);
+  await onMutated?.();
+
+  return { success: true, canceled_id: id };
+}
+
+export async function runBookingAgent(options: AgentRunOptions): Promise<string> {
+  if (!isOpenAiConfigured) {
+    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+  }
+
+  const { systemPrompt, contextSummary, conversation, onBookingsMutated } = options;
+
+  const messages: ChatCompletionMessage[] = [
+    {
+      role: "system",
+      content: [
+        systemPrompt,
+        "You have tool access to manage the booking agenda.",
+        "Use the provided functions to check availability before confirming a booking.",
+        `Opening hours: ${pad(openingHour)}:00-${pad(closingHour)}:00.`,
+        "Context summary:",
+        contextSummary,
+      ].join("\n"),
+    },
+    ...conversation.map((m) => ({ role: m.role, content: m.content })),
+  ];
+
+  const toolHandlers: Record<string, (args: any) => Promise<unknown>> = {
+    list_bookings: (args: any) => listBookings(args),
+    get_availability: (args: any) => getAvailability(args),
+    book_service: (args: any) => bookService(args, onBookingsMutated),
+    cancel_booking: (args: any) => cancelService(args, onBookingsMutated),
+  };
+
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const response = await callOpenAIChatCompletion({
+      messages,
+      tools: TOOL_DEFINITIONS,
+      model: "gpt-4o-mini",
+      temperature: 0,
+    });
+
+    const choice = response?.choices?.[0];
+    if (!choice) throw new Error("OpenAI agent returned no choices.");
+    const message = choice.message;
+    if (!message) throw new Error("OpenAI agent returned no message.");
+
+    if (message.tool_calls && message.tool_calls.length > 0) {
+      messages.push({
+        role: "assistant",
+        content: message.content ?? "",
+        tool_calls: message.tool_calls,
+      });
+
+      for (const call of message.tool_calls) {
+        const handler = toolHandlers[call.function.name];
+        if (!handler) {
+          messages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify({ error: `Unknown tool: ${call.function.name}` }),
+          });
+          continue;
+        }
+        let args: any;
+        try {
+          args = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+        } catch (err) {
+          messages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify({ error: "Invalid JSON arguments", raw: call.function.arguments }),
+          });
+          continue;
+        }
+        try {
+          const result = await handler(args);
+          messages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify(result ?? null),
+          });
+        } catch (err: any) {
+          messages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify({ error: err?.message ?? String(err) }),
+          });
+        }
+      }
+      continue;
+    }
+
+    const content = normalizeContent(message.content);
+    if (!content) {
+      throw new Error("Agent did not return a textual response.");
+    }
+    return content;
+  }
+
+  throw new Error("Agent stopped without a final response.");
+}
+
+function normalizeContent(input: any): string | null {
+  if (input == null) return null;
+  if (typeof input === "string") return input.trim() || null;
+  if (Array.isArray(input)) {
+    const text = input
+      .map((part) => {
+        if (!part) return "";
+        if (typeof part === "string") return part;
+        if (typeof part === "object" && "text" in part) {
+          return String((part as any).text ?? "");
+        }
+        return "";
+      })
+      .join("");
+    return text.trim() || null;
+  }
+  return null;
+}

--- a/src/lib/bookings.ts
+++ b/src/lib/bookings.ts
@@ -1,0 +1,90 @@
+import { supabase } from "./supabase";
+import type { ServiceId } from "./domain";
+
+export type DbBooking = {
+  id: string;
+  date: string;
+  start: string;
+  end: string;
+  service: ServiceId;
+  barber: string;
+  customer_id?: string | null;
+};
+
+export type Customer = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  phone?: string | null;
+  email?: string | null;
+  date_of_birth?: string | null;
+};
+
+export type BookingWithCustomer = DbBooking & { _customer?: Customer };
+
+export async function getBookings(dateKey: string): Promise<BookingWithCustomer[]> {
+  const { data, error, status } = await supabase
+    .from("bookings")
+    .select('id,date,start,"end",service,barber,customer_id')
+    .eq("date", dateKey)
+    .order("start");
+
+  console.log("[getBookings]", { dateKey, status, data, error });
+  if (error) throw error;
+
+  const rows = (data ?? []) as DbBooking[];
+  const ids = Array.from(new Set(rows.map((r) => r.customer_id).filter(Boolean))) as string[];
+  let customerMap = new Map<string, Customer>();
+
+  if (ids.length) {
+    const { data: people, error: e2 } = await supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .in("id", ids);
+    if (e2) throw e2;
+    customerMap = new Map((people ?? []).map((c) => [c.id, c as Customer]));
+  }
+
+  return rows.map((r) => ({ ...r, _customer: r.customer_id ? customerMap.get(r.customer_id) : undefined }));
+}
+
+export async function createBooking(payload: {
+  date: string;
+  start: string;
+  end: string;
+  service: ServiceId;
+  barber: string;
+  customer_id?: string | null;
+}) {
+  const { data, error, status } = await supabase.from("bookings").insert(payload).select("id").single();
+  console.log("[createBooking]", { payload, status, error });
+  if (error) throw error;
+  return data?.id ?? null;
+}
+
+export async function cancelBooking(id: string) {
+  const { data, error, status } = await supabase.from("bookings").delete().eq("id", id);
+  console.log("[cancelBooking]", { id, status, data, error });
+  if (error) throw error;
+}
+
+export async function listCustomers(query: string) {
+  const q = (query || "").trim();
+  let req = supabase
+    .from("customers")
+    .select("id,first_name,last_name,phone,email,date_of_birth")
+    .order("first_name")
+    .limit(20);
+
+  if (q) {
+    req = supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%,email.ilike.%${q}%,phone.ilike.%${q}%`)
+      .limit(20);
+  }
+
+  const { data, error } = await req;
+  if (error) throw error;
+  return (data ?? []) as Customer[];
+}

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,0 +1,70 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+export type ServiceId = "cut" | "cutshave";
+export type Service = {
+  id: ServiceId;
+  name: string;
+  minutes: number;
+  icon: keyof typeof MaterialCommunityIcons.glyphMap;
+};
+
+export type BarberId = "joao" | "maria" | "carlos";
+export type Barber = {
+  id: BarberId;
+  name: string;
+  icon: keyof typeof MaterialCommunityIcons.glyphMap;
+};
+
+export const SERVICES: Service[] = [
+  { id: "cut", name: "Cut", minutes: 30, icon: "content-cut" },
+  { id: "cutshave", name: "Cut & Shave", minutes: 60, icon: "razor-double-edge" },
+];
+
+export const BARBERS: Barber[] = [
+  { id: "joao", name: "João", icon: "account" },
+  { id: "maria", name: "Maria", icon: "account-outline" },
+  { id: "carlos", name: "Carlos", icon: "account-tie" },
+];
+
+export const BARBER_MAP = Object.fromEntries(BARBERS.map((b) => [b.id, b])) as Record<string, Barber>;
+
+export const openingHour = 9;
+export const closingHour = 18;
+
+export const pad = (n: number) => n.toString().padStart(2, "0");
+
+export function toDateKey(d: Date) {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function minutesToTime(mins: number) {
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return `${pad(h)}:${pad(m)}`;
+}
+
+export function timeToMinutes(t: string) {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+export function addMinutes(t: string, minutes: number) {
+  return minutesToTime(timeToMinutes(t) + minutes);
+}
+
+export function overlap(aS: string, aE: string, bS: string, bE: string) {
+  const as = timeToMinutes(aS);
+  const ae = timeToMinutes(aE);
+  const bs = timeToMinutes(bS);
+  const be = timeToMinutes(bE);
+  return Math.max(as, bs) < Math.min(ae, be);
+}
+
+export function humanDate(dk: string) {
+  const d = new Date(`${dk}T00:00:00`);
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary
- refactor shared booking/domain helpers into dedicated modules
- add a tool-enabled OpenAI booking agent that can check availability, create, and cancel appointments
- wire the assistant chat UI to the agent and refresh bookings after agent actions

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68d6c7731f388327804715c6fe6913ef