### PR TITLE
Add Supabase-backed service management

### DIFF
--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -14,6 +14,7 @@ import { Ionicons } from "@expo/vector-icons";
 
 import { isOpenAiConfigured } from "../lib/openai";
 import { runBookingAgent } from "../lib/bookingAgent";
+import type { Service } from "../lib/domain";
 
 type DisplayMessage = {
   role: "assistant" | "user";
@@ -34,12 +35,13 @@ type AssistantChatProps = {
   systemPrompt: string;
   contextSummary: string;
   onBookingsMutated?: () => Promise<void> | void;
+  services: Service[];
 };
 
 const INITIAL_ASSISTANT_MESSAGE =
   "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.";
 
-export default function AssistantChat({ colors, systemPrompt, contextSummary, onBookingsMutated }: AssistantChatProps) {
+export default function AssistantChat({ colors, systemPrompt, contextSummary, onBookingsMutated, services }: AssistantChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([
     { role: "assistant", content: INITIAL_ASSISTANT_MESSAGE },
   ]);
@@ -73,6 +75,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
         contextSummary,
         conversation: nextMessages,
         onBookingsMutated,
+        services,
       });
       setMessages((prev) => [...prev, { role: "assistant", content: reply }]);
     } catch (e: any) {

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo, useState } from "react";
+import { View, Text, TextInput, Pressable, StyleSheet, Alert } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import type { Service } from "../lib/domain";
+import { createService } from "../lib/services";
+
+const DEFAULT_COLORS = {
+  text: "#e5e7eb",
+  subtext: "#cbd5e1",
+  border: "rgba(255,255,255,0.12)",
+  surface: "rgba(255,255,255,0.06)",
+  accent: "#60a5fa",
+  accentFgOn: "#091016",
+  danger: "#ef4444",
+};
+
+type Props = {
+  onCreated?: (service: Service) => void;
+  colors?: typeof DEFAULT_COLORS;
+};
+
+export default function ServiceForm({ onCreated, colors = DEFAULT_COLORS }: Props) {
+  const [name, setName] = useState("");
+  const [minutesText, setMinutesText] = useState("30");
+  const [priceText, setPriceText] = useState("30.00");
+  const [iconName, setIconName] = useState("content-cut");
+  const [saving, setSaving] = useState(false);
+
+  const minutes = useMemo(() => {
+    const numeric = Number(minutesText);
+    return Number.isFinite(numeric) ? Math.round(numeric) : NaN;
+  }, [minutesText]);
+
+  const priceCents = useMemo(() => parsePrice(priceText), [priceText]);
+  const iconValid = useMemo(() => !!MaterialCommunityIcons.glyphMap[iconName as keyof typeof MaterialCommunityIcons.glyphMap], [iconName]);
+
+  const errors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = "Name is required";
+    if (!Number.isFinite(minutes) || minutes <= 0) errs.minutes = "Enter minutes > 0";
+    if (!Number.isFinite(priceCents) || priceCents < 0) errs.price = "Enter a valid price";
+    if (!iconValid) errs.icon = "Unknown icon";
+    return errs;
+  }, [name, minutes, priceCents, iconValid]);
+
+  const valid = Object.keys(errors).length === 0 && !saving;
+
+  const handleSubmit = async () => {
+    if (!valid) return;
+    setSaving(true);
+    try {
+      const created = await createService({
+        name: name.trim(),
+        estimated_minutes: minutes,
+        price_cents: priceCents,
+        icon: iconName as keyof typeof MaterialCommunityIcons.glyphMap,
+      });
+      Alert.alert("Service created", `${created.name} (${created.estimated_minutes} min)`);
+      setName("");
+      setMinutesText("30");
+      setPriceText("30.00");
+      setIconName("content-cut");
+      onCreated?.(created);
+    } catch (err: any) {
+      Alert.alert("Create service failed", err?.message ?? String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+      <Text style={[styles.title, { color: colors.text }]}>Register a service</Text>
+      <Text style={[styles.subtitle, { color: colors.subtext }]}>Services define the duration and price of each booking.</Text>
+
+      <FormField
+        label="Name"
+        value={name}
+        onChangeText={setName}
+        placeholder="Cut & Style"
+        error={errors.name}
+        colors={colors}
+      />
+
+      <View style={styles.row}>
+        <FormField
+          label="Duration (minutes)"
+          value={minutesText}
+          onChangeText={(text) => setMinutesText(text.replace(/[^0-9]/g, ""))}
+          keyboardType="number-pad"
+          placeholder="45"
+          error={errors.minutes}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+        <FormField
+          label="Price"
+          value={priceText}
+          onChangeText={(text) => setPriceText(text.replace(/[^0-9.,]/g, ""))}
+          keyboardType="decimal-pad"
+          placeholder="30.00"
+          error={errors.price}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+      </View>
+
+      <FormField
+        label="Icon (MaterialCommunityIcons)"
+        value={iconName}
+        onChangeText={(text) => setIconName(text.trim())}
+        autoCapitalize="none"
+        placeholder="content-cut"
+        error={errors.icon}
+        colors={colors}
+      />
+
+      <View style={styles.iconPreview}>
+        <Text style={[styles.previewLabel, { color: colors.subtext }]}>Preview:</Text>
+        <MaterialCommunityIcons
+          name={(iconValid ? iconName : "help-circle") as keyof typeof MaterialCommunityIcons.glyphMap}
+          size={26}
+          color={iconValid ? colors.accent : colors.danger}
+        />
+      </View>
+
+      <Pressable
+        onPress={handleSubmit}
+        disabled={!valid}
+        style={[
+          styles.button,
+          {
+            backgroundColor: valid ? colors.accent : "rgba(255,255,255,0.08)",
+            borderColor: valid ? colors.accent : colors.border,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="Create service"
+      >
+        <Text style={[styles.buttonText, { color: valid ? colors.accentFgOn : colors.subtext }]}>
+          {saving ? "Saving…" : "Create service"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function FormField({ label, error, colors, style, ...rest }: {
+  label: string;
+  error?: string;
+  colors: typeof DEFAULT_COLORS;
+  style?: any;
+} & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={[{ marginBottom: 12 }, style]}>
+      <Text style={[styles.label, { color: colors.subtext }]}>{label}</Text>
+      <TextInput
+        {...rest}
+        placeholderTextColor="#94a3b8"
+        style={[styles.input, { borderColor: error ? colors.danger : colors.border, color: colors.text }]}
+      />
+      {error ? <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text> : null}
+    </View>
+  );
+}
+
+function parsePrice(input: string): number {
+  if (!input) return NaN;
+  const normalized = input.replace(/[^0-9.,]/g, "").replace(/,/g, ".");
+  const value = Number.parseFloat(normalized);
+  if (!Number.isFinite(value)) return NaN;
+  return Math.round(value * 100);
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+  },
+  title: { fontSize: 18, fontWeight: "800" },
+  subtitle: { fontSize: 13, fontWeight: "600" },
+  row: { flexDirection: "row", gap: 12 },
+  label: { fontSize: 12, fontWeight: "700", marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    fontWeight: "700",
+    backgroundColor: "rgba(15,23,42,0.35)",
+  },
+  errorText: { marginTop: 4, fontSize: 12, fontWeight: "700" },
+  iconPreview: { flexDirection: "row", alignItems: "center", gap: 10 },
+  previewLabel: { fontSize: 12, fontWeight: "700" },
+  button: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  buttonText: { fontSize: 14, fontWeight: "800" },
+});

--- a/src/lib/bookings.ts
+++ b/src/lib/bookings.ts
@@ -1,12 +1,10 @@
 import { supabase } from "./supabase";
-import type { ServiceId } from "./domain";
-
 export type DbBooking = {
   id: string;
   date: string;
   start: string;
   end: string;
-  service: ServiceId;
+  service: string;
   barber: string;
   customer_id?: string | null;
 };
@@ -52,7 +50,7 @@ export async function createBooking(payload: {
   date: string;
   start: string;
   end: string;
-  service: ServiceId;
+  service: string;
   barber: string;
   customer_id?: string | null;
 }) {

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,11 +1,13 @@
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
-export type ServiceId = "cut" | "cutshave";
+export type ServiceId = string;
 export type Service = {
   id: ServiceId;
   name: string;
-  minutes: number;
+  estimated_minutes: number;
+  price_cents: number;
   icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  created_at?: string | null;
 };
 
 export type BarberId = "joao" | "maria" | "carlos";
@@ -14,11 +16,6 @@ export type Barber = {
   name: string;
   icon: keyof typeof MaterialCommunityIcons.glyphMap;
 };
-
-export const SERVICES: Service[] = [
-  { id: "cut", name: "Cut", minutes: 30, icon: "content-cut" },
-  { id: "cutshave", name: "Cut & Shave", minutes: 60, icon: "razor-double-edge" },
-];
 
 export const BARBERS: Barber[] = [
   { id: "joao", name: "João", icon: "account" },
@@ -32,6 +29,16 @@ export const openingHour = 9;
 export const closingHour = 18;
 
 export const pad = (n: number) => n.toString().padStart(2, "0");
+
+export function formatPrice(cents: number) {
+  if (Number.isNaN(cents)) return "—";
+  const value = cents / 100;
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  });
+}
 
 export function toDateKey(d: Date) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,0 +1,65 @@
+import { supabase } from "./supabase";
+import type { Service } from "./domain";
+
+export type DbService = {
+  id: string;
+  name: string;
+  estimated_minutes: number;
+  price_cents: number;
+  icon: string;
+  created_at: string | null;
+};
+
+export async function listServices(): Promise<Service[]> {
+  const { data, error } = await supabase
+    .from("services")
+    .select("id,name,estimated_minutes,price_cents,icon,created_at")
+    .order("name");
+  if (error) throw error;
+  const rows = (data ?? []) as DbService[];
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    estimated_minutes: row.estimated_minutes,
+    price_cents: row.price_cents,
+    icon: (row.icon || "content-cut") as Service["icon"],
+    created_at: row.created_at ?? null,
+  }));
+}
+
+export async function createService(payload: {
+  name: string;
+  estimated_minutes: number;
+  price_cents: number;
+  icon: Service["icon"];
+}): Promise<Service> {
+  const cleanName = payload.name?.trim();
+  const minutes = Number(payload.estimated_minutes);
+  const price = Number(payload.price_cents);
+
+  if (!cleanName) throw new Error("Name is required");
+  if (!Number.isFinite(minutes) || minutes <= 0) throw new Error("Estimated minutes must be greater than 0");
+  if (!Number.isFinite(price) || price < 0) throw new Error("Price must be 0 or more");
+
+  const { data, error } = await supabase
+    .from("services")
+    .insert({
+      name: cleanName,
+      estimated_minutes: Math.round(minutes),
+      price_cents: Math.round(price),
+      icon: payload.icon,
+    })
+    .select("id,name,estimated_minutes,price_cents,icon,created_at")
+    .single();
+
+  if (error) throw error;
+
+  return {
+    id: data!.id,
+    name: data!.name,
+    estimated_minutes: data!.estimated_minutes,
+    price_cents: data!.price_cents,
+    icon: (data!.icon || "content-cut") as Service["icon"],
+    created_at: data!.created_at ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- load services from Supabase and drive booking selection with dynamic durations and prices
- add a registration form and overview for services so operators can create offerings from the app
- update the assistant tools and booking APIs to work with the new service schema and expose Supabase helpers

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d81a87c030832796527e6788b2f560