### PR TITLE
Add booking service test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "web-build": "expo export -p web",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "vitest run"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
@@ -23,7 +24,8 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "vitest": "^2.0.5"
   },
   "private": true
 }

--- a/tests/bookingService/functional/bookingLifecycle.functional.test.ts
+++ b/tests/bookingService/functional/bookingLifecycle.functional.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from "vitest";
+import {
+  createBooking,
+  createCustomer,
+  findCustomerByPhone,
+  listRecentBookings,
+} from "../../../src/lib/bookings";
+import { supabaseMock } from "../testUtils/supabaseMock";
+
+describe("booking service functional flow", () => {
+  it("supports creating a customer, finding them, and retrieving their booking", async () => {
+    const customerRecord = {
+      id: "cust-1",
+      first_name: "Zoe",
+      last_name: "Ray",
+      phone: "12345678",
+      email: null,
+      date_of_birth: null,
+    };
+    const bookingRecord = {
+      id: "book-1",
+      date: "2024-05-01",
+      start: "09:00",
+      end: "09:30",
+      service: "cut",
+      barber: "Mina",
+      customer_id: customerRecord.id,
+    };
+
+    const customersTable = supabaseMock.useTable("customers");
+    customersTable.insert.mockImplementation((payload) => {
+      expect(payload).toEqual({
+        first_name: "Zoe",
+        last_name: "Ray",
+        phone: "12345678",
+      });
+      customersTable.returns({ data: customerRecord, error: null, status: 201 });
+      return customersTable;
+    });
+    customersTable.single.mockResolvedValue({ data: customerRecord, error: null, status: 201 });
+    customersTable.maybeSingle.mockResolvedValue({ data: customerRecord, error: null, status: 200 });
+    customersTable.select.mockImplementation(() => customersTable);
+    customersTable.eq.mockImplementation(() => customersTable);
+    customersTable.in.mockImplementation(() => customersTable);
+    customersTable.or.mockImplementation(() => customersTable);
+    customersTable.order.mockImplementation(() => customersTable);
+    customersTable.limit.mockImplementation(() => customersTable);
+
+    const bookingsTable = supabaseMock.useTable("bookings");
+    bookingsTable.insert.mockImplementation((payload) => {
+      expect(payload).toEqual({
+        date: bookingRecord.date,
+        start: bookingRecord.start,
+        end: bookingRecord.end,
+        service: bookingRecord.service,
+        barber: bookingRecord.barber,
+        customer_id: bookingRecord.customer_id,
+      });
+      bookingsTable.returns({ data: { id: bookingRecord.id }, error: null, status: 201 });
+      return bookingsTable;
+    });
+    bookingsTable.single.mockResolvedValue({ data: { id: bookingRecord.id }, error: null, status: 201 });
+    bookingsTable.select.mockImplementation(() => bookingsTable);
+    bookingsTable.order.mockImplementation(() => bookingsTable);
+    bookingsTable.limit.mockImplementation(() => bookingsTable);
+    bookingsTable.eq.mockImplementation(() => bookingsTable);
+    bookingsTable.in.mockImplementation(() => bookingsTable);
+
+    const createdCustomer = await createCustomer({
+      first_name: " Zoe",
+      last_name: " Ray ",
+      phone: " (123) 456-78 ",
+    });
+    expect(createdCustomer).toEqual(customerRecord);
+
+    customersTable.returns({ data: customerRecord, error: null, status: 200 });
+    const foundCustomer = await findCustomerByPhone("123-456-78");
+    expect(foundCustomer).toEqual(customerRecord);
+    expect(customersTable.eq).toHaveBeenLastCalledWith("phone", "12345678");
+
+    const bookingId = await createBooking({
+      date: bookingRecord.date,
+      start: bookingRecord.start,
+      end: bookingRecord.end,
+      service: bookingRecord.service,
+      barber: bookingRecord.barber,
+      customer_id: bookingRecord.customer_id,
+    });
+    expect(bookingId).toBe(bookingRecord.id);
+
+    bookingsTable.returns({ data: [bookingRecord], error: null, status: 200 });
+    customersTable.returns({ data: [customerRecord], error: null, status: 200 });
+
+    const bookings = await listRecentBookings(5);
+
+    expect(bookingsTable.order).toHaveBeenCalledWith("date", { ascending: true });
+    expect(bookingsTable.limit).toHaveBeenCalledWith(5);
+    expect(customersTable.in).toHaveBeenCalledWith("id", [customerRecord.id]);
+    expect(bookings).toEqual([
+      {
+        ...bookingRecord,
+        _customer: customerRecord,
+      },
+    ]);
+  });
+});

--- a/tests/bookingService/integration/getBookings.integration.test.ts
+++ b/tests/bookingService/integration/getBookings.integration.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from "vitest";
+import { getBookings } from "../../../src/lib/bookings";
+import { supabaseMock } from "../testUtils/supabaseMock";
+
+describe("booking service integration", () => {
+  it("joins bookings with their customers", async () => {
+    const bookingRows = [
+      {
+        id: "b-1",
+        date: "2024-05-01",
+        start: "09:00",
+        end: "09:30",
+        service: "cut",
+        barber: "Maya",
+        customer_id: "c-1",
+      },
+      {
+        id: "b-2",
+        date: "2024-05-01",
+        start: "10:00",
+        end: "10:45",
+        service: "fade",
+        barber: "Luca",
+        customer_id: null,
+      },
+    ];
+    const customerRows = [
+      {
+        id: "c-1",
+        first_name: "Kira",
+        last_name: "Torres",
+        phone: "5552222",
+        email: null,
+        date_of_birth: null,
+      },
+    ];
+
+    const bookingsTable = supabaseMock.useTable("bookings", {
+      data: bookingRows,
+      error: null,
+      status: 200,
+    });
+    const customersTable = supabaseMock.useTable("customers", {
+      data: customerRows,
+      error: null,
+      status: 200,
+    });
+
+    const result = await getBookings("2024-05-01");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("bookings");
+    expect(bookingsTable.eq).toHaveBeenCalledWith("date", "2024-05-01");
+    expect(bookingsTable.order).toHaveBeenCalledWith("start");
+    expect(customersTable.select).toHaveBeenCalledWith("id,first_name,last_name,phone,email,date_of_birth");
+    expect(customersTable.in).toHaveBeenCalledWith("id", ["c-1"]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]._customer).toEqual(customerRows[0]);
+    expect(result[1]._customer).toBeUndefined();
+  });
+
+  it("propagates errors from the bookings query", async () => {
+    supabaseMock.useTable("bookings", {
+      data: null,
+      error: new Error("boom"),
+      status: 500,
+    });
+
+    await expect(getBookings("2024-05-01")).rejects.toThrow("boom");
+  });
+});

--- a/tests/bookingService/setup.ts
+++ b/tests/bookingService/setup.ts
@@ -1,0 +1,10 @@
+import { beforeEach, vi } from "vitest";
+import { supabaseMock } from "./testUtils/supabaseMock";
+
+vi.mock("../../src/lib/supabase", () => ({
+  supabase: supabaseMock.client,
+}));
+
+beforeEach(() => {
+  supabaseMock.reset();
+});

--- a/tests/bookingService/testUtils/supabaseMock.ts
+++ b/tests/bookingService/testUtils/supabaseMock.ts
@@ -1,0 +1,75 @@
+import { vi } from "vitest";
+
+export type SupabaseResponse<T = unknown> = {
+  data?: T | null;
+  error?: unknown;
+  status?: number;
+};
+
+export class MockQueryBuilder<T = unknown> {
+  private _response: SupabaseResponse<T>;
+
+  readonly select = vi.fn(() => this);
+  readonly eq = vi.fn(() => this);
+  readonly gte = vi.fn(() => this);
+  readonly lte = vi.fn(() => this);
+  readonly in = vi.fn(() => this);
+  readonly order = vi.fn(() => this);
+  readonly limit = vi.fn(() => this);
+  readonly insert = vi.fn(() => this);
+  readonly delete = vi.fn(() => this);
+  readonly or = vi.fn(() => this);
+
+  readonly single = vi.fn(async () => this._response);
+  readonly maybeSingle = vi.fn(async () => this._response);
+
+  constructor(response: SupabaseResponse<T> = { data: null, error: null, status: 200 }) {
+    this._response = response;
+  }
+
+  returns(response: SupabaseResponse<T>) {
+    this._response = response;
+    return this;
+  }
+
+  then<TResult1 = SupabaseResponse<T>, TResult2 = never>(
+    onfulfilled?: ((value: SupabaseResponse<T>) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined | null,
+  ) {
+    return Promise.resolve(this._response).then(onfulfilled, onrejected);
+  }
+}
+
+export function createSupabaseMock() {
+  const tables = new Map<string, MockQueryBuilder<any> | (() => MockQueryBuilder<any>)>();
+  const from = vi.fn((table: string) => {
+    const handler = tables.get(table);
+    if (!handler) {
+      throw new Error(`No mock configured for table: ${table}`);
+    }
+    if (typeof handler === "function") {
+      const instance = handler();
+      return instance;
+    }
+    return handler;
+  });
+
+  return {
+    client: { from },
+    from,
+    useTable<T>(table: string, response: SupabaseResponse<T> = { data: null, error: null, status: 200 }) {
+      const builder = new MockQueryBuilder<T>(response);
+      tables.set(table, builder);
+      return builder;
+    },
+    setTable(table: string, factory: () => MockQueryBuilder<any>) {
+      tables.set(table, factory);
+    },
+    reset() {
+      tables.clear();
+      from.mockReset();
+    },
+  };
+}
+
+export const supabaseMock = createSupabaseMock();

--- a/tests/bookingService/unit/customers.test.ts
+++ b/tests/bookingService/unit/customers.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from "vitest";
+import {
+  findCustomerByPhone,
+  getCustomerById,
+  listCustomers,
+} from "../../../src/lib/bookings";
+import { supabaseMock } from "../testUtils/supabaseMock";
+
+describe("booking service customers", () => {
+  it("lists customers in alphabetical order when no search query is provided", async () => {
+    const customerRows = [
+      { id: "c-1", first_name: "Ada", last_name: "Lovelace", phone: "1234", email: null, date_of_birth: null },
+      { id: "c-2", first_name: "Grace", last_name: "Hopper", phone: "5678", email: null, date_of_birth: null },
+    ];
+    const customersTable = supabaseMock.useTable("customers", {
+      data: customerRows,
+      error: null,
+      status: 200,
+    });
+
+    const result = await listCustomers("");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("customers");
+    expect(customersTable.select).toHaveBeenCalledWith("id,first_name,last_name,phone,email,date_of_birth");
+    expect(customersTable.order).toHaveBeenCalledWith("first_name");
+    expect(customersTable.limit).toHaveBeenCalledWith(20);
+    expect(result).toEqual(customerRows);
+  });
+
+  it("uses a flexible search when a query is provided", async () => {
+    const match = {
+      id: "c-3",
+      first_name: "Anne",
+      last_name: "Shirley",
+      phone: "9999",
+      email: "anne@example.com",
+      date_of_birth: null,
+    };
+    const customersTable = supabaseMock.useTable("customers", {
+      data: [match],
+      error: null,
+      status: 200,
+    });
+
+    const result = await listCustomers(" anN  ");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("customers");
+    expect(customersTable.or).toHaveBeenCalledWith(
+      expect.stringContaining("%anN%"),
+    );
+    expect(customersTable.limit).toHaveBeenCalledWith(20);
+    expect(result).toEqual([match]);
+  });
+
+  it("finds a customer by normalized phone digits", async () => {
+    const found = {
+      id: "c-4",
+      first_name: "Mara",
+      last_name: "Jade",
+      phone: "5551234",
+      email: null,
+      date_of_birth: null,
+    };
+    const customersTable = supabaseMock.useTable("customers", {
+      data: found,
+      error: null,
+      status: 200,
+    });
+
+    const result = await findCustomerByPhone(" (555) 1234 ");
+
+    expect(customersTable.select).toHaveBeenCalledWith("id,first_name,last_name,phone,email,date_of_birth");
+    expect(customersTable.eq).toHaveBeenCalledWith("phone", "5551234");
+    expect(result).toEqual(found);
+  });
+
+  it("skips the database lookup when the customer id is blank", async () => {
+    const result = await getCustomerById("   ");
+
+    expect(result).toBeNull();
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("retrieves a customer by id when provided", async () => {
+    const entry = {
+      id: "c-5",
+      first_name: "Jon",
+      last_name: "Snow",
+      phone: "1111",
+      email: null,
+      date_of_birth: null,
+    };
+    const customersTable = supabaseMock.useTable("customers", {
+      data: entry,
+      error: null,
+      status: 200,
+    });
+
+    const result = await getCustomerById("  c-5  ");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("customers");
+    expect(customersTable.eq).toHaveBeenCalledWith("id", "c-5");
+    expect(result).toEqual(entry);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["tests/bookingService/**/*.test.ts"],
+    setupFiles: ["tests/bookingService/setup.ts"],
+    environment: "node",
+    reporters: "default",
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vitest configuration and npm test script for the booking service
- provide shared Supabase mocking utilities and setup scaffolding for tests
- implement unit, integration, and functional coverage for the booking service module

## Testing
- npm test *(fails in container: vitest binary not available because package install is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68d8465c78048327b24193471d79536c