### PR TITLE
Add web voice input support to assistant chat

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,4 +1,5 @@
 const API_URL = "https://api.openai.com/v1/chat/completions";
+const AUDIO_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions";
 const API_KEY = process.env.EXPO_PUBLIC_OPENAI_API_KEY;
 
 export type ChatMessage = {
@@ -56,4 +57,58 @@ export async function fetchAssistantReply(messages: ChatMessage[]): Promise<stri
   }
 
   return content.trim();
+}
+
+type BlobLike = any;
+
+type TranscribeAudioInput =
+  | { uri: string; fileName?: string; mimeType?: string }
+  | { blob: BlobLike; fileName?: string; mimeType?: string };
+
+export async function transcribeAudio(input: TranscribeAudioInput) {
+  if (!isOpenAiConfigured) {
+    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+  }
+
+  const formData = new FormData();
+  formData.append("model", "gpt-4o-mini-transcribe");
+
+  if ("blob" in input) {
+    const { blob, fileName = "voice-message.webm", mimeType } = input;
+    const typedBlob =
+      mimeType && blob && typeof blob.slice === "function"
+        ? blob.slice(0, blob.size ?? undefined, mimeType)
+        : blob;
+    formData.append("file", typedBlob as any, fileName);
+  } else {
+    const { uri, fileName = "voice-message.m4a", mimeType = "audio/m4a" } = input;
+    formData.append(
+      "file",
+      {
+        uri,
+        name: fileName,
+        type: mimeType,
+      } as any,
+    );
+  }
+
+  const response = await fetch(AUDIO_TRANSCRIPTION_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: formData,
+  });
+
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(buildErrorMessage(response.status, body));
+  }
+
+  const text: unknown = body?.text;
+  if (typeof text !== "string" || !text.trim()) {
+    throw new Error("Transcription did not return any text.");
+  }
+
+  return text.trim();
 }


### PR DESCRIPTION
## Summary
- add a microphone control to the assistant chat so users can record voice messages on the web and automatically send the transcribed text to the agent
- extend the OpenAI helper with an audio transcription request that uploads recorded clips

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a87ae0288327b0645137297cfaa1