### PR TITLE
Add collapsible sidebar and mobile audio support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@expo/metro-runtime": "~5.0.4",
     "@supabase/supabase-js": "^2.57.2",
     "expo": "~53.0.22",
+    "expo-av": "~15.0.6",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- convert the top navigation buttons into a collapsible sidebar shell with updated styling
- remove detailed booking listings from the assistant context summary shown in chat
- enable native mobile voice capture via expo-av with permission handling and fallbacks

## Testing
- npm install expo-av *(fails with 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ec6be8883278b3df0fd14fc8fb1