### PR TITLE
Fix audio transcription file extension for mobile recordings

### DIFF
--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -268,10 +268,30 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
           setError("No audio captured. Try again.");
           return;
         }
+        const mimeType = blob.type || "audio/webm";
+        const extension = (() => {
+          if (!mimeType) return "webm";
+          if (mimeType.includes("mp4") || mimeType.includes("m4a")) {
+            return "m4a";
+          }
+          if (mimeType.includes("ogg")) {
+            return "ogg";
+          }
+          if (mimeType.includes("wav")) {
+            return "wav";
+          }
+          if (mimeType.includes("mp3")) {
+            return "mp3";
+          }
+          if (mimeType.includes("webm")) {
+            return "webm";
+          }
+          return "webm";
+        })();
         const transcript = await transcribeAudio({
           blob,
-          fileName: "voice-message.webm",
-          mimeType: blob.type || "audio/webm",
+          fileName: `voice-message.${extension}`,
+          mimeType,
         });
         await sendMessage(transcript);
       } catch (e: any) {


### PR DESCRIPTION
## Summary
- derive the audio file extension from the captured blob MIME type before transcription
- ensure Safari/iOS recordings upload with a supported filename for OpenAI

## Testing
- npm test *(fails: vitest not found in PATH prior to installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d94a245f6c832797e2c0cad2503eaa