### PR TITLE
Revamp services management flow

### DIFF
--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -78,3 +78,57 @@ export async function createService(payload: {
     created_at: data!.created_at ?? null,
   };
 }
+
+export async function updateService(
+  id: string,
+  payload: {
+    name: string;
+    estimated_minutes: number;
+    price_cents: number;
+    icon: Service["icon"];
+  },
+): Promise<Service> {
+  const cleanName = payload.name?.trim();
+  const minutesInput = Number(payload.estimated_minutes);
+  const priceInput = Number(payload.price_cents);
+
+  if (!id) throw new Error("Service ID is required");
+  if (!cleanName) throw new Error("Name is required");
+  if (!Number.isFinite(minutesInput) || minutesInput <= 0) {
+    throw new Error("Estimated minutes must be greater than 0");
+  }
+  if (!Number.isFinite(priceInput) || priceInput < 0) {
+    throw new Error("Price must be 0 or more");
+  }
+
+  const { data, error } = await supabase
+    .from("services")
+    .update({
+      name: cleanName,
+      estimated_minutes: Math.round(minutesInput),
+      price_cents: Math.round(priceInput),
+      icon: payload.icon,
+    })
+    .eq("id", id)
+    .select("id,name,estimated_minutes,price_cents,icon,created_at")
+    .single();
+
+  if (error) throw error;
+  if (!data) throw new Error("Service not found");
+
+  const minutes = Number(data.estimated_minutes);
+  const price = Number(data.price_cents);
+
+  return {
+    id: data.id,
+    name: data.name,
+    estimated_minutes: Number.isFinite(minutes)
+      ? minutes
+      : Number.parseInt(String(data.estimated_minutes ?? 0), 10) || 0,
+    price_cents: Number.isFinite(price)
+      ? price
+      : Number.parseInt(String(data.price_cents ?? 0), 10) || 0,
+    icon: (data.icon || "content-cut") as Service["icon"],
+    created_at: data.created_at ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- update the services screen to mirror the bookings layout with a list-first experience and explicit create button
- reuse the service form for both creation and editing, including cancel handling and UI tweaks
- add a Supabase helper to update services so existing entries can be edited in place

## Testing
- npm test *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d4187788832780f9c63b1c74b405