### PR TITLE
Add secure assistant proxy server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "vitest run"
+    "test": "vitest run",
+    "start:assistant-proxy": "npm --prefix server start"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+# Required OpenAI credentials
+OPENAI_API_KEY=sk-your-openai-key
+
+# Optional settings
+# PORT=3000
+# CORS_ORIGIN=http://localhost:8081

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,46 @@
+# Assistant Proxy Server
+
+This lightweight Express server keeps your OpenAI API key on the backend and exposes two routes that mirror the Expo client helpers:
+
+- `POST /assistant/chat-completions`
+- `POST /assistant/audio-transcriptions`
+
+## Getting started
+
+1. Install client dependencies (from the project root):
+
+   ```bash
+   npm install
+   ```
+
+2. Install the proxy dependencies:
+
+   ```bash
+   npm install --prefix server
+   ```
+
+3. Copy the environment template and populate it with your own keys:
+
+   ```bash
+   cp server/.env.example server/.env
+   ```
+
+4. Start the proxy:
+
+   ```bash
+   npm run start:assistant-proxy
+   ```
+
+   The proxy listens on `http://localhost:3000` by default. Update the `PORT` variable in the environment file to change it.
+
+5. Point the Expo client at the proxy by setting `EXPO_PUBLIC_ASSISTANT_API_URL` in your Expo environment (for example in `.env` or your CI secrets) to the proxy's base URL. The mobile app will refuse to call OpenAI directly and will rely on this proxy instead.
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | ✅ | Secret key obtained from the OpenAI dashboard. |
+| `PORT` |  | Port to bind the proxy to (defaults to `3000`). |
+| `CORS_ORIGIN` |  | Comma-separated list of allowed origins. Leave unset to allow all origins during development. |
+
+The server uses [`dotenv`](https://github.com/motdotla/dotenv) to load environment variables from `server/.env` when running locally. In production, supply the variables through your hosting provider instead.

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,0 +1,194 @@
+import 'dotenv/config';
+import cors from 'cors';
+import express from 'express';
+import multer from 'multer';
+import { File } from 'node:buffer';
+import OpenAI from 'openai';
+
+const PORT = Number.parseInt(process.env.PORT || '', 10) || 3000;
+const CORS_ORIGIN = process.env.CORS_ORIGIN;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!OPENAI_API_KEY) {
+  console.error('Missing OPENAI_API_KEY environment variable.');
+  process.exit(1);
+}
+
+const app = express();
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 25 * 1024 * 1024 },
+});
+
+const corsOrigins = (() => {
+  if (!CORS_ORIGIN) return undefined;
+  if (CORS_ORIGIN.trim() === '*') return '*';
+  const origins = CORS_ORIGIN.split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return origins.length > 0 ? origins : undefined;
+})();
+
+app.use(cors(corsOrigins ? { origin: corsOrigins } : undefined));
+app.use(express.json({ limit: '1mb' }));
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+function normalizeError(error) {
+  if (error instanceof OpenAI.APIError) {
+    return {
+      status: error.status ?? 500,
+      message: error.error?.message || error.message || 'OpenAI request failed.',
+    };
+  }
+  if (error instanceof Error) {
+    return { status: 500, message: error.message };
+  }
+  return { status: 500, message: 'Unexpected assistant backend error.' };
+}
+
+const CHAT_COMPLETION_OPTION_KEYS = new Set([
+  'frequency_penalty',
+  'max_tokens',
+  'presence_penalty',
+  'response_format',
+  'stop',
+  'top_p',
+]);
+const CHAT_COMPLETION_NUMERIC_KEYS = new Set([
+  'frequency_penalty',
+  'max_tokens',
+  'presence_penalty',
+  'top_p',
+]);
+
+function coerceNumber(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+app.post('/assistant/chat-completions', async (req, res) => {
+  try {
+    const { messages, model, temperature, ...rest } = req.body ?? {};
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return res.status(400).json({
+        error: { message: 'Request body must include a non-empty messages array.' },
+      });
+    }
+
+    const extraOptions = {};
+    for (const [key, value] of Object.entries(rest ?? {})) {
+      if (!CHAT_COMPLETION_OPTION_KEYS.has(key)) {
+        continue;
+      }
+
+      if (CHAT_COMPLETION_NUMERIC_KEYS.has(key)) {
+        const numeric = coerceNumber(value);
+        if (typeof numeric === 'number') {
+          extraOptions[key] = numeric;
+        }
+        continue;
+      }
+
+      if (key === 'stop') {
+        if (typeof value === 'string') {
+          extraOptions[key] = value;
+        } else if (Array.isArray(value)) {
+          extraOptions[key] = value.filter((entry) => typeof entry === 'string');
+        }
+        continue;
+      }
+
+      extraOptions[key] = value;
+    }
+
+    const payload = {
+      model: typeof model === 'string' && model.trim() ? model : 'gpt-4o-mini',
+      temperature: coerceNumber(temperature),
+      messages,
+      ...extraOptions,
+    };
+
+    if (typeof payload.temperature !== 'number') {
+      delete payload.temperature;
+    }
+    for (const key of Object.keys(payload)) {
+      if (payload[key] === undefined) {
+        delete payload[key];
+      }
+    }
+
+    const completion = await openai.chat.completions.create(payload);
+    res.json(completion);
+  } catch (error) {
+    console.error('Chat completion error:', error);
+    const { status, message } = normalizeError(error);
+    res.status(status).json({ error: { message } });
+  }
+});
+
+const AUDIO_TRANSCRIPTION_OPTION_KEYS = new Set(['language', 'prompt', 'response_format', 'temperature']);
+
+app.post('/assistant/audio-transcriptions', upload.single('file'), async (req, res) => {
+  try {
+    const { file } = req;
+
+    if (!file) {
+      return res.status(400).json({
+        error: { message: 'An audio file must be provided using the "file" field.' },
+      });
+    }
+
+    const model = req.body?.model && typeof req.body.model === 'string' && req.body.model.trim()
+      ? req.body.model
+      : 'gpt-4o-mini-transcribe';
+
+    const fileName = file.originalname || 'audio.webm';
+    const mimeType = file.mimetype || 'audio/webm';
+
+    const fileForOpenAI = new File([file.buffer], fileName, { type: mimeType });
+
+    const transcriptionOptions = {};
+    for (const key of AUDIO_TRANSCRIPTION_OPTION_KEYS) {
+      if (key in (req.body ?? {})) {
+        const value = req.body[key];
+        transcriptionOptions[key] = key === 'temperature' ? coerceNumber(value) ?? undefined : value;
+      }
+    }
+    if (typeof transcriptionOptions.temperature !== 'number') {
+      delete transcriptionOptions.temperature;
+    }
+    for (const key of Object.keys(transcriptionOptions)) {
+      if (transcriptionOptions[key] === undefined) {
+        delete transcriptionOptions[key];
+      }
+    }
+
+    const transcription = await openai.audio.transcriptions.create({
+      model,
+      file: fileForOpenAI,
+      ...transcriptionOptions,
+    });
+
+    res.json(transcription);
+  } catch (error) {
+    console.error('Audio transcription error:', error);
+    const { status, message } = normalizeError(error);
+    res.status(status).json({ error: { message } });
+  }
+});
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Assistant proxy listening on http://localhost:${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "assistant-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.mjs",
+  "scripts": {
+    "start": "node index.mjs"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.77.3"
+  }
+}

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -40,7 +40,8 @@ type AssistantChatProps = {
 
 const INITIAL_ASSISTANT_MESSAGE =
   "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.";
-const API_KEY_WARNING_MESSAGE = "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.";
+const BACKEND_WARNING_MESSAGE =
+  "Set EXPO_PUBLIC_ASSISTANT_API_URL to enable the assistant.";
 
 export default function AssistantChat({ colors, systemPrompt, contextSummary, onBookingsMutated, services }: AssistantChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([
@@ -113,7 +114,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
     if (isOpenAiConfigured) {
       setMessages((prev) => {
         const index = prev.findIndex(
-          (msg) => msg.role === "assistant" && msg.content === API_KEY_WARNING_MESSAGE,
+          (msg) => msg.role === "assistant" && msg.content === BACKEND_WARNING_MESSAGE,
         );
         if (index === -1) return prev;
         const next = [...prev];
@@ -124,10 +125,10 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
     }
 
     setMessages((prev) => {
-      if (prev.some((msg) => msg.role === "assistant" && msg.content === API_KEY_WARNING_MESSAGE)) {
+      if (prev.some((msg) => msg.role === "assistant" && msg.content === BACKEND_WARNING_MESSAGE)) {
         return prev;
       }
-      return [...prev, { role: "assistant", content: API_KEY_WARNING_MESSAGE }];
+      return [...prev, { role: "assistant", content: BACKEND_WARNING_MESSAGE }];
     });
   }, [isOpenAiConfigured]);
   useEffect(() => {
@@ -154,7 +155,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
 
   const startVoiceRecording = useCallback(async () => {
     if (!isOpenAiConfigured) {
-      setError("Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.");
+      setError("Set EXPO_PUBLIC_ASSISTANT_API_URL to enable voice input.");
       return;
     }
     const globalNavigator: any = Platform.OS === "web" ? (globalThis as any).navigator : null;

--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -385,7 +385,9 @@ async function cancelService(
 
 export async function runBookingAgent(options: AgentRunOptions): Promise<string> {
   if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    throw new Error(
+      "Assistant backend is not configured. Set EXPO_PUBLIC_ASSISTANT_API_URL in your environment.",
+    );
   }
 
   const { systemPrompt, contextSummary, conversation, onBookingsMutated, services } = options;


### PR DESCRIPTION
## Summary
- add an Express-based assistant proxy that fronts chat and transcription requests with server-side OpenAI credentials
- document environment setup, example env vars, and npm scripts for running the proxy from the Expo workspace

## Testing
- npm install *(fails: 403 Forbidden fetching cors package)*
- npm install --prefix server *(fails: 403 Forbidden fetching cors package)*

------
https://chatgpt.com/codex/tasks/task_e_68da6dd39f348327a4e918f143c2c39e