### PR TITLE
Add Azure Functions OpenAI proxy and update frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# AIBarber
+
+This project now ships with an Azure Static Web Apps friendly Functions backend that can securely call
+third-party AI providers (such as OpenAI) without exposing keys in the client bundle. The frontend
+continues to run as a Static Web Apps site, while the API is executed in the free tier of Azure
+Functions.
+
+## Repository layout
+
+```
+/
+├── App.tsx                # Expo/React Native application entry point
+├── src/                   # Frontend code
+└── api/                   # Azure Functions project used by Static Web Apps
+    ├── openai-chat/       # HTTP POST proxy for chat completions
+    └── openai-transcribe/ # HTTP POST proxy for audio transcription
+```
+
+## Frontend configuration
+
+The frontend expects an API origin to be exposed under the same Static Web Apps domain. For local
+workflows (or native testing where relative URLs are not supported) set an Expo environment variable
+before starting the dev server:
+
+```bash
+# Point the app at the local Azure Functions host
+export EXPO_PUBLIC_API_BASE_URL="http://localhost:7071"
+
+# Optional: disable assistant features without touching the backend
+export EXPO_PUBLIC_DISABLE_OPENAI="true" # omit or set to false to keep it enabled
+```
+
+The `EXPO_PUBLIC_API_BASE_URL` value is optional in hosted environments because the proxy is exposed
+under `/api` by Static Web Apps.
+
+## Azure Functions configuration
+
+The `api` folder contains a minimal JavaScript Functions project with two HTTP-triggered endpoints:
+
+- `POST /api/openai-chat` forwards chat-completion payloads to OpenAI (or Azure OpenAI if you point
+  `OPENAI_API_BASE_URL` at that endpoint).
+- `POST /api/openai-transcribe` forwards multipart audio uploads to the OpenAI transcription route.
+
+Both functions require an `OPENAI_API_KEY` application setting. Optionally override the default
+OpenAI REST base with `OPENAI_API_BASE_URL` or set `OPENAI_DEFAULT_CHAT_MODEL` to adjust the default
+chat model used by the proxy.
+
+### Local development
+
+1. Install the [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#v4) (free).
+2. Copy `api/local.settings.sample.json` to `api/local.settings.json` and fill in your OpenAI (or Azure OpenAI) key.
+3. From the `api` directory, start the Functions host:
+   ```bash
+   cd api
+   func start
+   ```
+4. In a separate terminal start the Expo dev server (web or native). With
+   `EXPO_PUBLIC_API_BASE_URL=http://localhost:7071` the app will talk to the local Functions host.
+
+### Deploying with Azure Static Web Apps
+
+1. Configure your Static Web App build pipeline so that the `api` directory is deployed as the
+   Functions app (this is the default when a folder named `api` is present).
+2. In the Static Web Apps portal, add the following application settings under **Environment >
+   Configuration**:
+   - `OPENAI_API_KEY`: the secret key used by the Functions backend to call OpenAI securely.
+   - `OPENAI_API_BASE_URL` (optional): set this if you are using Azure OpenAI or another compatible endpoint.
+   - `OPENAI_DEFAULT_CHAT_MODEL` (optional): override the chat model without touching the code.
+3. Redeploy the Static Web App. The frontend will call `/api/openai-chat` and `/api/openai-transcribe`
+   without ever shipping the secret to the browser.
+
+Because both Static Web Apps and Azure Functions offer always-free tiers, this setup keeps the
+entire stack free while ensuring sensitive keys remain on the server.
+
+## Security considerations
+
+- The Functions endpoints accept anonymous requests but the key is never sent to the client.
+- Rate limiting, additional validation, or authentication can be layered on later using Static Web
+  Apps authentication or API Management without changing the frontend contract.
+
+## Further reading
+
+- [Azure Static Web Apps documentation](https://learn.microsoft.com/azure/static-web-apps/)
+- [Azure Functions documentation](https://learn.microsoft.com/azure/azure-functions/)
+- [OpenAI REST API reference](https://platform.openai.com/docs/api-reference)

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,2 @@
+local.settings.json
+node_modules/

--- a/api/host.json
+++ b/api/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/api/local.settings.sample.json
+++ b/api/local.settings.sample.json
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "OPENAI_API_KEY": "sk-your-openai-key",
+    "OPENAI_API_BASE_URL": "https://api.openai.com/v1"
+  }
+}

--- a/api/openai-chat/function.json
+++ b/api/openai-chat/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "openai-chat"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/api/openai-chat/index.js
+++ b/api/openai-chat/index.js
@@ -1,0 +1,80 @@
+const DEFAULT_CHAT_MODEL = process.env.OPENAI_DEFAULT_CHAT_MODEL || "gpt-4o-mini";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_API_BASE_URL = (process.env.OPENAI_API_BASE_URL || "https://api.openai.com/v1").replace(/\/$/, "");
+
+function pickErrorMessage(payload) {
+  if (!payload) return null;
+  if (typeof payload === "string") return payload;
+  if (typeof payload === "object") {
+    if (typeof payload.error === "string") return payload.error;
+    if (payload.error && typeof payload.error.message === "string") return payload.error.message;
+    if (typeof payload.message === "string") return payload.message;
+  }
+  return null;
+}
+
+module.exports = async function (context, req) {
+  if (req.method !== "POST") {
+    return {
+      status: 405,
+      headers: { "Allow": "POST" },
+      body: { error: "Method not allowed" },
+    };
+  }
+
+  if (!OPENAI_API_KEY) {
+    return {
+      status: 500,
+      body: { error: "OPENAI_API_KEY is not configured on the server." },
+    };
+  }
+
+  const body = req.body || {};
+  const payload = {
+    model: DEFAULT_CHAT_MODEL,
+    temperature: 0.7,
+    ...body,
+  };
+
+  try {
+    const response = await fetch(`${OPENAI_API_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const text = await response.text();
+    let data = null;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    if (!response.ok) {
+      const message = pickErrorMessage(data) || `OpenAI request failed with status ${response.status}.`;
+      context.log.error("OpenAI chat completion failed", message);
+      return {
+        status: response.status,
+        body: { error: message },
+      };
+    }
+
+    return {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: data,
+    };
+  } catch (error) {
+    context.log.error("Unexpected error calling OpenAI chat completion", error);
+    return {
+      status: 500,
+      body: { error: "Unexpected error calling OpenAI chat completion." },
+    };
+  }
+};

--- a/api/openai-transcribe/function.json
+++ b/api/openai-transcribe/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "openai-transcribe"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/api/openai-transcribe/index.js
+++ b/api/openai-transcribe/index.js
@@ -1,0 +1,96 @@
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_API_BASE_URL = (process.env.OPENAI_API_BASE_URL || "https://api.openai.com/v1").replace(/\/$/, "");
+
+function toBuffer(value) {
+  if (!value) {
+    return null;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return Buffer.from(value);
+  }
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value);
+  }
+  return null;
+}
+
+module.exports = async function (context, req) {
+  if (req.method !== "POST") {
+    return {
+      status: 405,
+      headers: { "Allow": "POST" },
+      body: { error: "Method not allowed" },
+    };
+  }
+
+  if (!OPENAI_API_KEY) {
+    return {
+      status: 500,
+      body: { error: "OPENAI_API_KEY is not configured on the server." },
+    };
+  }
+
+  const contentType = req.headers["content-type"] || req.headers["Content-Type"];
+  if (!contentType || !contentType.toLowerCase().includes("multipart/form-data")) {
+    return {
+      status: 400,
+      body: { error: "Requests must use multipart/form-data." },
+    };
+  }
+
+  const bodyBuffer = toBuffer(req.rawBody) || toBuffer(req.body);
+  if (!bodyBuffer || bodyBuffer.length === 0) {
+    return {
+      status: 400,
+      body: { error: "Request body is empty." },
+    };
+  }
+
+  try {
+    const response = await fetch(`${OPENAI_API_BASE_URL}/audio/transcriptions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": contentType,
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: bodyBuffer,
+    });
+
+    const text = await response.text();
+    let data = null;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    if (!response.ok) {
+      const message =
+        (data && typeof data === "object" && data.error && data.error.message) ||
+        (typeof data === "string" ? data : null) ||
+        `OpenAI request failed with status ${response.status}.`;
+      context.log.error("OpenAI transcription failed", message);
+      return {
+        status: response.status,
+        body: { error: message },
+      };
+    }
+
+    return {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: data,
+    };
+  } catch (error) {
+    context.log.error("Unexpected error calling OpenAI transcription", error);
+    return {
+      status: 500,
+      body: { error: "Unexpected error calling OpenAI transcription." },
+    };
+  }
+};

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -40,7 +40,8 @@ type AssistantChatProps = {
 
 const INITIAL_ASSISTANT_MESSAGE =
   "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.";
-const API_KEY_WARNING_MESSAGE = "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.";
+const API_BACKEND_WARNING_MESSAGE =
+  "Connect the Azure Functions OpenAI proxy to enable the assistant features.";
 
 export default function AssistantChat({ colors, systemPrompt, contextSummary, onBookingsMutated, services }: AssistantChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([
@@ -113,7 +114,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
     if (isOpenAiConfigured) {
       setMessages((prev) => {
         const index = prev.findIndex(
-          (msg) => msg.role === "assistant" && msg.content === API_KEY_WARNING_MESSAGE,
+          (msg) => msg.role === "assistant" && msg.content === API_BACKEND_WARNING_MESSAGE,
         );
         if (index === -1) return prev;
         const next = [...prev];
@@ -124,10 +125,10 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
     }
 
     setMessages((prev) => {
-      if (prev.some((msg) => msg.role === "assistant" && msg.content === API_KEY_WARNING_MESSAGE)) {
+      if (prev.some((msg) => msg.role === "assistant" && msg.content === API_BACKEND_WARNING_MESSAGE)) {
         return prev;
       }
-      return [...prev, { role: "assistant", content: API_KEY_WARNING_MESSAGE }];
+      return [...prev, { role: "assistant", content: API_BACKEND_WARNING_MESSAGE }];
     });
   }, [isOpenAiConfigured]);
   useEffect(() => {
@@ -154,7 +155,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
 
   const startVoiceRecording = useCallback(async () => {
     if (!isOpenAiConfigured) {
-      setError("Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.");
+      setError("Configure the OpenAI Azure Functions proxy to enable voice input.");
       return;
     }
     const globalNavigator: any = Platform.OS === "web" ? (globalThis as any).navigator : null;

--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -385,7 +385,9 @@ async function cancelService(
 
 export async function runBookingAgent(options: AgentRunOptions): Promise<string> {
   if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    throw new Error(
+      "The OpenAI assistant backend is disabled. Deploy the Azure Functions API and make sure EXPO_PUBLIC_DISABLE_OPENAI is not set to 'true'.",
+    );
   }
 
   const { systemPrompt, contextSummary, conversation, onBookingsMutated, services } = options;


### PR DESCRIPTION
## Summary
- add JavaScript Azure Functions to proxy OpenAI chat and transcription requests for Static Web Apps
- refactor the Expo frontend to call the secure backend and update assistant messaging
- document configuration for the free Static Web Apps + Functions stack and provide sample settings

## Testing
- npm test *(fails: vitest is unavailable because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcf7c08648327830f84eb288e10df