### PR TITLE
Add secure Azure Functions wrappers for OpenAI and document secret management

### DIFF
--- a/api/AudioTranscription/function.json
+++ b/api/AudioTranscription/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "audio/transcriptions"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/AudioTranscription/index.js
+++ b/api/AudioTranscription/index.js
@@ -1,0 +1,80 @@
+const { ensureConfigured, ensureAuthorized, createOpenAIClient } = require('../_shared/openaiClient');
+
+function toBuffer(dataUrlOrBase64) {
+  if (typeof dataUrlOrBase64 !== 'string' || !dataUrlOrBase64.trim()) {
+    return null;
+  }
+  const commaIndex = dataUrlOrBase64.indexOf(',');
+  const base64 = commaIndex !== -1 ? dataUrlOrBase64.slice(commaIndex + 1) : dataUrlOrBase64;
+  try {
+    return Buffer.from(base64, 'base64');
+  } catch (error) {
+    return null;
+  }
+}
+
+module.exports = async function (context, req) {
+  context.log('AudioTranscription function processed a request.');
+
+  if (ensureConfigured(context)) {
+    return;
+  }
+  if (ensureAuthorized(context, req)) {
+    return;
+  }
+
+  const {
+    file,
+    fileName = 'voice-message.webm',
+    mimeType = 'audio/webm',
+    model = 'gpt-4o-mini-transcribe',
+    temperature,
+    response_format,
+    language,
+  } = req.body || {};
+
+  const buffer = toBuffer(file);
+  if (!buffer || buffer.length === 0) {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'Request must include a base64-encoded "file" field.',
+      },
+    };
+    return;
+  }
+
+  const client = createOpenAIClient();
+
+  try {
+    const response = await client.audio.transcriptions.create({
+      model,
+      file: {
+        data: buffer,
+        name: fileName,
+      },
+      mimeType,
+      temperature,
+      response_format,
+      language,
+    });
+
+    context.res = {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: response,
+    };
+  } catch (error) {
+    context.log.error('Failed to transcribe audio', error);
+    const status = error.status ?? 500;
+    context.res = {
+      status,
+      body: {
+        error: 'Failed to transcribe audio.',
+        details: error.message,
+      },
+    };
+  }
+};

--- a/api/ChatCompletion/function.json
+++ b/api/ChatCompletion/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "chat/completions"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/ChatCompletion/index.js
+++ b/api/ChatCompletion/index.js
@@ -1,0 +1,59 @@
+const { ensureConfigured, ensureAuthorized, createOpenAIClient } = require('../_shared/openaiClient');
+
+module.exports = async function (context, req) {
+  context.log('ChatCompletion function processed a request.');
+
+  if (ensureConfigured(context)) {
+    return;
+  }
+  if (ensureAuthorized(context, req)) {
+    return;
+  }
+
+  const { messages, model = 'gpt-4o-mini', temperature = 0.7, tools, tool_choice, response_format, max_tokens, frequency_penalty, presence_penalty, top_p } = req.body || {};
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'The request body must include a non-empty "messages" array.',
+      },
+    };
+    return;
+  }
+
+  const client = createOpenAIClient();
+
+  try {
+    const response = await client.chat.completions.create({
+      messages,
+      model,
+      temperature,
+      tools,
+      tool_choice,
+      response_format,
+      max_tokens,
+      frequency_penalty,
+      presence_penalty,
+      top_p,
+    });
+
+    context.res = {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: response,
+    };
+  } catch (error) {
+    context.log.error('Failed to call OpenAI chat completion', error);
+    const status = error.status ?? 500;
+    context.res = {
+      status,
+      body: {
+        error: 'Failed to run chat completion.',
+        details: error.message,
+      },
+    };
+  }
+};

--- a/api/_shared/openaiClient.js
+++ b/api/_shared/openaiClient.js
@@ -1,0 +1,50 @@
+const OpenAI = require('openai');
+
+function getProvidedToken(req) {
+  if (!req?.headers) return null;
+  const headers = req.headers;
+  return headers['x-api-key'] || headers['x-functions-key'] || headers['x-functions-clientid'] || null;
+}
+
+function ensureConfigured(context) {
+  if (process.env.OPENAI_API_KEY) {
+    return null;
+  }
+  context.log.error('Missing OPENAI_API_KEY configuration.');
+  context.res = {
+    status: 500,
+    body: {
+      error: 'Server misconfiguration: missing OpenAI credentials.',
+    },
+  };
+  return context.res;
+}
+
+function ensureAuthorized(context, req) {
+  const configuredToken = process.env.IMAGE_API_TOKEN;
+  if (!configuredToken) return null;
+  const providedToken = getProvidedToken(req);
+  if (configuredToken === providedToken) {
+    return null;
+  }
+
+  context.res = {
+    status: 401,
+    body: {
+      error: 'Unauthorized request.',
+    },
+  };
+  return context.res;
+}
+
+function createOpenAIClient() {
+  return new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+}
+
+module.exports = {
+  ensureConfigured,
+  ensureAuthorized,
+  createOpenAIClient,
+};

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,122 +1,123 @@
-# AiBarber Backend Deployment Guide
+# AiBarber Deployment & Secret Management Guide
 
-This guide walks through configuring the new Azure Functions backend under the `api/` folder and wiring it up to your Azure Static Web Apps (SWA) deployment pipeline.
+This guide explains how to run the AiBarber front-end and Azure Functions backend securely on the Azure Static Web Apps (SWA) Free plan. It covers secret storage, GitHub Actions configuration, and how to develop locally with the front-end and backend served from the same port.
 
 ## 1. Repository Structure
 
 ```
 /
-├─ api/                # Azure Functions app (Node.js)
-│  ├─ GenerateImage/   # HTTP trigger for OpenAI image generation
+├─ api/                    # Azure Functions app (Node.js)
+│  ├─ _shared/             # Shared helpers (OpenAI auth, etc.)
+│  ├─ AudioTranscription/  # POST /api/audio/transcriptions
+│  ├─ ChatCompletion/      # POST /api/chat/completions
+│  ├─ GenerateImage/       # POST /api/images/generate
 │  ├─ host.json
-│  ├─ package.json
-│  └─ .gitignore
-├─ src/                # SWA front-end
+│  └─ package.json
+├─ src/                    # Expo / React front-end
+├─ swa-cli.config.json     # Local dev profile for SWA CLI (single-port proxy)
 └─ ...
 ```
 
-Azure Static Web Apps automatically discovers the Azure Functions application because it resides in the `api/` folder.
+Azure Static Web Apps automatically detects the Azure Functions project because it lives in the `api/` folder.
 
-## 2. Local Development
+## 2. Secure Secret Storage
 
-1. Install the Azure Functions Core Tools and Node.js 18 or later.
-2. From the repository root install dependencies:
-   ```bash
-   npm install
-   (cd api && npm install)
-   ```
-3. Add a `api/local.settings.json` file (excluded from git) with your secrets:
-   ```json
-   {
-     "IsEncrypted": false,
-     "Values": {
-       "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-       "FUNCTIONS_WORKER_RUNTIME": "node",
-       "OPENAI_API_KEY": "sk-your-key",
-       "IMAGE_API_TOKEN": "local-dev-token"
-     }
-   }
-   ```
-4. Run both the SWA front-end and the Azure Functions backend locally using the SWA CLI or separate terminals:
-   ```bash
-   npm run dev          # front-end
-   npm run start --prefix api   # backend (func start)
-   ```
+### Azure Static Web Apps configuration (runtime secrets)
 
-## 3. Secure Configuration
+Create the following application settings under **Settings → Configuration** in your SWA resource. These values are encrypted at rest and injected into the Azure Functions runtime.
 
-- `OPENAI_API_KEY` **must never be committed to the repository.** Store it as an application setting in Azure.
-- The function expects requests to include an `x-api-key` header that matches `IMAGE_API_TOKEN`. This allows you to control who can call the API while keeping the function itself anonymous for SWA routing.
-- Rotate keys regularly and remove unused secrets from Azure.
+| Setting name        | Purpose                                                                 |
+| ------------------- | ----------------------------------------------------------------------- |
+| `OPENAI_API_KEY`    | Used by all Azure Functions to authenticate with OpenAI.                |
+| `IMAGE_API_TOKEN`   | Shared secret that incoming requests must provide via the `x-api-key` header. |
 
-## 4. Azure Resources
+### Front-end build variables
 
-1. **Azure Static Web App** – Hosts the front-end and orchestrates the Functions backend.
-2. **Functions Environment** – Automatically provisioned by SWA when the `api/` folder exists.
-3. **Application Insights (optional)** – Enable for observability.
+The React front-end never sees the raw OpenAI key. Instead it sends the lightweight `IMAGE_API_TOKEN` so the Functions app can authenticate the request. Expose the token at build time with an Expo/Metro environment variable:
 
-## 5. GitHub Actions Workflow
-
-When you create the SWA resource, Azure provisions a GitHub Actions workflow in `.github/workflows/`. Make sure the workflow defines the `app_location`, `api_location`, and `output_location` keys, for example:
-
-```yaml
-app_location: "/"           # or "src" depending on your build
-api_location: "api"
-output_location: "dist"      # Vite build output
+```
+EXPO_PUBLIC_API_TOKEN=<same value as IMAGE_API_TOKEN>
 ```
 
-### Required Secrets in GitHub
+You can define this variable in:
 
-| Secret Name                   | Where to define                          | Purpose                                     |
-| ----------------------------- | ---------------------------------------- | ------------------------------------------- |
-| `AZURE_STATIC_WEB_APPS_API_TOKEN` | GitHub repository → Settings → Secrets    | Authentication for the SWA deployment task. |
-| `OPENAI_API_KEY`              | Azure Portal → Static Web App → Configuration | Used by the Azure Function at runtime.      |
-| `IMAGE_API_TOKEN`             | Azure Portal → Static Web App → Configuration | Shared secret between the client and API.   |
+- **Azure Portal → Static Web App → Configuration → App settings** (prefix with `EXPO_PUBLIC_` so Expo injects it), or
+- **GitHub Actions → `env:` block** when building for production (no need to store the OpenAI key in GitHub).
 
-> Do **not** store `OPENAI_API_KEY` or `IMAGE_API_TOKEN` as GitHub secrets unless you specifically need them for unit tests. They should stay in the Azure environment.
+> ❗️Never commit secrets to the repository. Keep the OpenAI key only in Azure.
 
-## 6. Configure Azure Static Web App
+### GitHub Actions secrets
 
-1. In the Azure Portal, open your Static Web App resource.
-2. Go to **Configuration** and add the following application settings:
-   - `OPENAI_API_KEY` = `sk-...`
-   - `IMAGE_API_TOKEN` = a random string that your assistant will send in the `x-api-key` header.
-3. Trigger a redeploy from GitHub Actions or manually restart the Functions API to apply the new settings.
+The auto-generated SWA workflow requires just one GitHub secret:
 
-## 7. Consuming the API from the Assistant
+| Secret name                       | Where to add it                                      | Notes                                                         |
+| --------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------- |
+| `AZURE_STATIC_WEB_APPS_API_TOKEN` | GitHub → Settings → Secrets and variables → Actions  | Provided when you create the SWA resource in the Azure Portal |
 
-Example `fetch` call from the SWA front-end:
+Because the OpenAI key is stored in Azure, you do **not** need to add it to GitHub Actions unless you run server-side tests that require it.
+
+## 3. Local Development on a Single Port
+
+The included `swa-cli.config.json` lets you use the SWA CLI to proxy both the Expo web dev server and the Azure Functions runtime through `http://localhost:4280`.
+
+```bash
+npm install
+(cd api && npm install)
+
+# Terminal 1 - start the SWA proxy (front-end + functions on :4280)
+npx @azure/static-web-apps-cli start --config swa-cli.config.json --app-name dev
+```
+
+The CLI launches `npm run web` (Expo dev server on port 19006) and `npm run start --prefix api` (Azure Functions on port 7071), then exposes them together at `http://localhost:4280`. This satisfies the “single port” requirement without needing a custom Vite setup.
+
+If you prefer to use Vite for web builds, the following proxy snippet mirrors the same behaviour:
 
 ```ts
-const response = await fetch('/api/images/generate', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'x-api-key': import.meta.env.VITE_IMAGE_API_TOKEN,
+// vite.config.ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:7071',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
   },
-  body: JSON.stringify({
-    prompt: 'High-resolution haircut design for a modern barber shop',
-    size: '1024x1024',
-    quality: 'high',
-    response_format: 'b64_json',
-  }),
 });
-
-if (!response.ok) {
-  throw new Error('Failed to generate image');
-}
-
-const data = await response.json();
 ```
 
-Define `VITE_IMAGE_API_TOKEN` as a build-time environment variable for the front-end using the SWA configuration or GitHub Actions if necessary.
+With this configuration `npm run dev` (or `vite`) serves both the React router pages and the Azure Functions API through the same origin.
 
-## 8. Verification Checklist
+## 4. Running on the SWA Free Plan
 
-- [ ] GitHub Actions workflow references `api_location: "api"`.
-- [ ] Azure Static Web App configuration includes `OPENAI_API_KEY` and `IMAGE_API_TOKEN`.
+1. In the Azure Portal create a **Static Web App** using the Free plan.
+2. Point it to your GitHub repository and select the default workflow template.
+3. When prompted, set:
+   - **App location**: `./` (Expo app at the repository root)
+   - **API location**: `api`
+   - **Output location**: leave blank (Expo handles bundling).
+4. After the resource is created, copy the deployment token and add it to `AZURE_STATIC_WEB_APPS_API_TOKEN` in GitHub secrets.
+5. Under **Configuration**, add the `OPENAI_API_KEY`, `IMAGE_API_TOKEN`, and `EXPO_PUBLIC_API_TOKEN` settings.
+6. Commit your changes; the GitHub Actions workflow builds the Expo web bundle and deploys the Functions API together.
+
+## 5. End-to-end Request Flow
+
+1. The front-end calls the helper in `src/lib/openai.ts`, which sends a POST request to `/api/chat/completions`, `/api/audio/transcriptions`, or `/api/images/generate`.
+2. The request includes the `x-api-key` header whose value is injected at build time from `EXPO_PUBLIC_API_TOKEN`.
+3. Azure Functions verifies the token against `IMAGE_API_TOKEN`, uses `OPENAI_API_KEY` to talk to OpenAI, and returns the result to the client.
+
+This design keeps the OpenAI key entirely on the server while still allowing the Expo app (or any other client) to authenticate through a lightweight shared secret.
+
+## 6. Verification Checklist
+
+- [ ] `.github/workflows/*` workflow uses `app_location: "."` and `api_location: "api"`.
+- [ ] Azure Static Web App configuration contains `OPENAI_API_KEY`, `IMAGE_API_TOKEN`, and `EXPO_PUBLIC_API_TOKEN`.
+- [ ] No OpenAI credentials live in source control or GitHub Secrets.
 - [ ] Front-end requests include the `x-api-key` header.
-- [ ] Secrets are never committed to the repository.
-- [ ] `api/` folder is checked in so that SWA deploys the Functions app.
+- [ ] Local development uses the SWA CLI (or Vite proxy) so the app and API share a port.
 
-Following this guide ensures your OpenAI-powered image generation endpoint is securely deployed alongside the AiBarber front-end using Azure Static Web Apps and GitHub Actions.
+Following these steps keeps the OpenAI credentials safe, simplifies Azure deployment on the Free plan, and gives you a reliable single-origin development experience.

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -40,7 +40,7 @@ type AssistantChatProps = {
 
 const INITIAL_ASSISTANT_MESSAGE =
   "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.";
-const API_KEY_WARNING_MESSAGE = "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.";
+const API_KEY_WARNING_MESSAGE = "Set EXPO_PUBLIC_API_TOKEN to enable the assistant.";
 
 export default function AssistantChat({ colors, systemPrompt, contextSummary, onBookingsMutated, services }: AssistantChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([
@@ -154,7 +154,7 @@ export default function AssistantChat({ colors, systemPrompt, contextSummary, on
 
   const startVoiceRecording = useCallback(async () => {
     if (!isOpenAiConfigured) {
-      setError("Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.");
+      setError("Set EXPO_PUBLIC_API_TOKEN to enable voice input.");
       return;
     }
     const globalNavigator: any = Platform.OS === "web" ? (globalThis as any).navigator : null;

--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -385,7 +385,7 @@ async function cancelService(
 
 export async function runBookingAgent(options: AgentRunOptions): Promise<string> {
   if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    throw new Error("Assistant service is not configured. Set EXPO_PUBLIC_API_TOKEN in your environment.");
   }
 
   const { systemPrompt, contextSummary, conversation, onBookingsMutated, services } = options;

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,113 +1,185 @@
-const API_URL = "https://api.openai.com/v1/chat/completions";
-const AUDIO_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions";
-const API_KEY = process.env.EXPO_PUBLIC_OPENAI_API_KEY;
+const API_BASE = (process.env.EXPO_PUBLIC_API_BASE_URL ?? '').replace(/\/$/, '');
+const API_TOKEN =
+  process.env.EXPO_PUBLIC_API_TOKEN ?? process.env.EXPO_PUBLIC_IMAGE_API_TOKEN ?? '';
 
-export type ChatMessage = {
-  role: "system" | "user" | "assistant";
-  content: string;
-};
-
-export const isOpenAiConfigured = typeof API_KEY === "string" && API_KEY.length > 0;
+function resolveApiUrl(path: string) {
+  if (/^https?:\/\//i.test(path)) return path;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const base = API_BASE || '';
+  return `${base}${normalizedPath}`;
+}
 
 function buildErrorMessage(status: number, body: any) {
-  if (body && typeof body === "object" && "error" in body) {
-    const err = (body as any).error;
-    if (err && typeof err === "object" && "message" in err) {
-      return String(err.message);
+  if (body && typeof body === 'object') {
+    if ('details' in body && typeof (body as any).details === 'string') {
+      return (body as any).details;
+    }
+    if ('error' in body && typeof (body as any).error === 'string') {
+      return (body as any).error;
     }
   }
   if (status >= 400 && status < 500) return `Request failed with status ${status}.`;
-  if (status >= 500) return "OpenAI service is currently unavailable.";
-  return "Unexpected error calling OpenAI.";
+  if (status >= 500) return 'The assistant service is currently unavailable.';
+  return 'Unexpected error calling the assistant service.';
 }
 
-export async function callOpenAIChatCompletion(payload: Record<string, any>) {
-  if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+async function callApi(path: string, options: RequestInit & { body?: any }) {
+  const url = resolveApiUrl(path);
+  const headers = new Headers(options.headers ?? {});
+  headers.set('Accept', 'application/json');
+  if (API_TOKEN) {
+    headers.set('x-api-key', API_TOKEN);
   }
 
-  const bodyPayload = {
-    model: "gpt-4o-mini",
-    temperature: 0.7,
-    ...payload,
-  };
+  let body = options.body;
+  if (body && typeof body !== 'string' && !(body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+    body = JSON.stringify(body);
+  }
 
-  const response = await fetch(API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${API_KEY}`,
-    },
-    body: JSON.stringify(bodyPayload),
+  const response = await fetch(url, {
+    ...options,
+    headers,
+    body,
   });
 
-  const body = await response.json();
-  if (!response.ok) {
-    throw new Error(buildErrorMessage(response.status, body));
+  const text = await response.text();
+  let parsed: any = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      parsed = text;
+    }
   }
 
+  if (!response.ok) {
+    throw new Error(buildErrorMessage(response.status, parsed));
+  }
+
+  return parsed;
+}
+
+export type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export const isOpenAiConfigured = typeof API_TOKEN === 'string' && API_TOKEN.length > 0;
+
+export async function callOpenAIChatCompletion(payload: Record<string, any>) {
+  const body = await callApi('/api/chat/completions', {
+    method: 'POST',
+    body: payload,
+  });
+  if (!body) {
+    throw new Error('Assistant service returned an empty response.');
+  }
   return body;
 }
 
 export async function fetchAssistantReply(messages: ChatMessage[]): Promise<string> {
   const body = await callOpenAIChatCompletion({ messages });
   const content = body?.choices?.[0]?.message?.content;
-  if (typeof content !== "string" || !content.trim()) {
-    throw new Error("OpenAI assistant did not return any content.");
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('Assistant did not return any content.');
   }
 
   return content.trim();
 }
 
-type BlobLike = any;
+type BlobLike = Blob & { arrayBuffer?: () => Promise<ArrayBuffer> };
 
 type TranscribeAudioInput =
   | { uri: string; fileName?: string; mimeType?: string }
   | { blob: BlobLike; fileName?: string; mimeType?: string };
 
+function bufferToBase64(buffer: ArrayBuffer): string {
+  const globalBuffer: any = (globalThis as any)?.Buffer;
+  if (globalBuffer && typeof globalBuffer.from === 'function') {
+    return globalBuffer.from(buffer).toString('base64');
+  }
+
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  throw new Error('Environment does not support base64 encoding.');
+}
+
+async function blobToBase64(blob: BlobLike): Promise<string> {
+  if (typeof FileReader !== 'undefined') {
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error ?? new Error('Failed to read audio blob.'));
+      reader.onloadend = () => {
+        const result = reader.result;
+        if (typeof result === 'string') {
+          const commaIndex = result.indexOf(',');
+          resolve(commaIndex === -1 ? result : result.slice(commaIndex + 1));
+          return;
+        }
+        reject(new Error('Unexpected FileReader result.'));
+      };
+      reader.readAsDataURL(blob as Blob);
+    });
+  }
+
+  if (typeof blob.arrayBuffer === 'function') {
+    const buffer = await blob.arrayBuffer();
+    return bufferToBase64(buffer);
+  }
+
+  throw new Error('Unsupported blob input.');
+}
+
+async function uriToBase64(uri: string): Promise<{ base64: string; mimeType?: string }> {
+  const response = await fetch(uri);
+  if (!response.ok) {
+    throw new Error('Failed to load audio for transcription.');
+  }
+  const blob = (await response.blob()) as BlobLike;
+  const base64 = await blobToBase64(blob);
+  return { base64, mimeType: blob.type };
+}
+
 export async function transcribeAudio(input: TranscribeAudioInput) {
   if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    throw new Error('Assistant service is not configured. Set EXPO_PUBLIC_API_TOKEN in your environment.');
   }
 
-  const formData = new FormData();
-  formData.append("model", "gpt-4o-mini-transcribe");
+  let base64: string;
+  let mimeType = input.mimeType;
 
-  if ("blob" in input) {
-    const { blob, fileName = "voice-message.webm", mimeType } = input;
-    const typedBlob =
-      mimeType && blob && typeof blob.slice === "function"
-        ? blob.slice(0, blob.size ?? undefined, mimeType)
-        : blob;
-    formData.append("file", typedBlob as any, fileName);
+  if ('blob' in input) {
+    base64 = await blobToBase64(input.blob);
+    mimeType = mimeType ?? (input.blob as any)?.type ?? 'audio/webm';
   } else {
-    const { uri, fileName = "voice-message.m4a", mimeType = "audio/m4a" } = input;
-    formData.append(
-      "file",
-      {
-        uri,
-        name: fileName,
-        type: mimeType,
-      } as any,
-    );
+    const result = await uriToBase64(input.uri);
+    base64 = result.base64;
+    mimeType = mimeType ?? result.mimeType ?? 'audio/webm';
   }
 
-  const response = await fetch(AUDIO_TRANSCRIPTION_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-    },
-    body: formData,
+  const payload = {
+    file: `data:${mimeType};base64,${base64}`,
+    fileName: input.fileName ?? 'voice-message.webm',
+    mimeType,
+  };
+
+  const body = await callApi('/api/audio/transcriptions', {
+    method: 'POST',
+    body: payload,
   });
 
-  const body = await response.json();
-  if (!response.ok) {
-    throw new Error(buildErrorMessage(response.status, body));
-  }
-
-  const text: unknown = body?.text;
-  if (typeof text !== "string" || !text.trim()) {
-    throw new Error("Transcription did not return any text.");
+  const text: unknown = body?.text ?? body?.transcript ?? null;
+  if (typeof text !== 'string' || !text.trim()) {
+    throw new Error('Transcription did not return any text.');
   }
 
   return text.trim();

--- a/swa-cli.config.json
+++ b/swa-cli.config.json
@@ -1,0 +1,13 @@
+{
+  "configurations": {
+    "dev": {
+      "appLocation": ".",
+      "apiLocation": "api",
+      "run": "npm run web",
+      "runApi": "npm run start --prefix api",
+      "devServerUrl": "http://localhost:19006",
+      "apiPort": 7071,
+      "port": 4280
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared OpenAI client helper plus chat and transcription Azure Functions secured with the deployment token
- update the Expo front-end to call the Azure Functions API instead of OpenAI directly and refresh assistant messaging
- expand the deployment guide with Azure/GitHub secret guidance and add an SWA CLI config for single-port local development

## Testing
- npx tsc --noEmit *(fails: expo/tsconfig.base and React Native typings are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dddb4679f483279a624ccfa640d71a