### PR TITLE
Add image assistant powered by GenerateImage API

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ import RecurrenceModal from "./src/components/RecurrenceModal"; // recebe fixedD
 import OccurrencePreviewModal, { PreviewItem } from "./src/components/OccurrencePreviewModal";
 import BarberSelector, { Barber } from "./src/components/BarberSelector";
 import AssistantChat from "./src/components/AssistantChat";
+import ImageAssistant from "./src/components/ImageAssistant";
 import ServiceForm from "./src/components/ServiceForm";
 
 /* Novo: formulário de usuário (com date_of_birth e salvando no Supabase) */
@@ -62,7 +63,7 @@ export default function App() {
   const [serviceFormMode, setServiceFormMode] = useState<"create" | "edit">("create");
   const [serviceBeingEdited, setServiceBeingEdited] = useState<Service | null>(null);
   const [activeScreen, setActiveScreen] = useState<
-    "home" | "bookings" | "bookService" | "services" | "assistant"
+    "home" | "bookings" | "bookService" | "services" | "assistant" | "imageAssistant"
   >("home");
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -637,7 +638,15 @@ export default function App() {
   const bookingsNavActive = activeScreen === "bookings" || activeScreen === "bookService";
 
   const handleNavigate = useCallback(
-    (screen: "home" | "bookings" | "bookService" | "services" | "assistant") => {
+    (
+      screen:
+        | "home"
+        | "bookings"
+        | "bookService"
+        | "services"
+        | "assistant"
+        | "imageAssistant",
+    ) => {
       setActiveScreen(screen);
       setSidebarOpen(false);
     },
@@ -783,6 +792,23 @@ export default function App() {
               color={activeScreen === "assistant" ? COLORS.accentFgOn : COLORS.subtext}
             />
             <Text style={[styles.sidebarItemText, activeScreen === "assistant" && styles.sidebarItemTextActive]}>Assistant</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => handleNavigate("imageAssistant")}
+            style={[styles.sidebarItem, activeScreen === "imageAssistant" && styles.sidebarItemActive]}
+            accessibilityRole="button"
+            accessibilityLabel="Open the image assistant"
+          >
+            <Ionicons
+              name="image-outline"
+              size={20}
+              color={activeScreen === "imageAssistant" ? COLORS.accentFgOn : COLORS.subtext}
+            />
+            <Text
+              style={[styles.sidebarItemText, activeScreen === "imageAssistant" && styles.sidebarItemTextActive]}
+            >
+              Image lab
+            </Text>
           </Pressable>
         </View>
       </View>
@@ -1326,6 +1352,19 @@ export default function App() {
         contextSummary={assistantContextSummary}
         onBookingsMutated={handleBookingsMutated}
         services={services}
+      />
+    ) : activeScreen === "imageAssistant" ? (
+      <ImageAssistant
+        colors={{
+          text: COLORS.text,
+          subtext: COLORS.subtext,
+          surface: COLORS.surface,
+          border: COLORS.border,
+          accent: COLORS.accent,
+          accentFgOn: COLORS.accentFgOn,
+          danger: COLORS.danger,
+          bg: COLORS.bg,
+        }}
       />
     ) : (
       <ScrollView

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -109,7 +109,7 @@ if (!response.ok) {
 const data = await response.json();
 ```
 
-Define `VITE_IMAGE_API_TOKEN` as a build-time environment variable for the front-end using the SWA configuration or GitHub Actions if necessary.
+Define `VITE_IMAGE_API_TOKEN` (Vite build) or `EXPO_PUBLIC_IMAGE_API_TOKEN` (Expo dev server) as a build-time environment variable for the front-end using the SWA configuration or GitHub Actions if necessary.
 
 ## 8. Verification Checklist
 

--- a/docs/IMAGE_ASSISTANT_SETUP.md
+++ b/docs/IMAGE_ASSISTANT_SETUP.md
@@ -1,0 +1,75 @@
+# Image Assistant Local Setup
+
+The image assistant screen consumes the Azure Functions endpoint under `api/GenerateImage`. Follow the steps below to configure everything locally.
+
+## 1. Install prerequisites
+
+- **Node.js 18+**
+- **npm** (bundled with Node.js)
+- **Azure Functions Core Tools** (for running the API locally)
+
+## 2. Install dependencies
+
+From the repository root install both the Expo app and the Azure Functions packages:
+
+```bash
+npm install
+(cd api && npm install)
+```
+
+## 3. Configure environment variables
+
+### 3.1 Front-end (Expo)
+
+Create a file named `.env.local` in the project root and add the following values:
+
+```bash
+EXPO_PUBLIC_OPENAI_API_KEY=sk-your-openai-api-key
+EXPO_PUBLIC_IMAGE_API_TOKEN=local-dev-token
+```
+
+Expo automatically exposes variables prefixed with `EXPO_PUBLIC_` to the client at runtime. Restart the dev server whenever these values change.
+
+### 3.2 Azure Function
+
+Create `api/local.settings.json` (excluded from git) with matching secrets:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "OPENAI_API_KEY": "sk-your-openai-api-key",
+    "IMAGE_API_TOKEN": "local-dev-token"
+  }
+}
+```
+
+Make sure `IMAGE_API_TOKEN` matches the value used in `.env.local`. The function checks the `x-api-key` header and rejects requests that do not match.
+
+## 4. Start the services
+
+Use two terminals (or run the commands in the background):
+
+```bash
+npm run dev            # starts Expo for the front-end (web, iOS, or Android)
+npm run start --prefix api   # starts the Azure Functions app (func start)
+```
+
+> If you prefer the Static Web Apps CLI, you can alternatively run `npx swa start http://localhost:8081 --run "npm run dev"`.
+
+## 5. Generate images
+
+1. Open the Expo web experience (default at http://localhost:8081 for Expo web).
+2. Navigate to **Image lab** from the sidebar.
+3. Enter a prompt, choose a size/quality combination, and press **Generate image**.
+4. The assistant stores recent results locally so you can compare variations or clear the history with the **Clear** button.
+
+If requests fail with **Unauthorized request**, double-check that:
+
+- `EXPO_PUBLIC_IMAGE_API_TOKEN` is defined in `.env.local`.
+- `IMAGE_API_TOKEN` in `api/local.settings.json` matches the same string.
+- The Azure Functions server has been restarted after editing `local.settings.json`.
+
+With these steps you can iterate on prompts locally while keeping API keys out of source control.

--- a/src/components/ImageAssistant.tsx
+++ b/src/components/ImageAssistant.tsx
@@ -1,0 +1,362 @@
+import React, { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import {
+  generateImage,
+  isImageApiConfigured,
+  type GenerateImageResponse,
+} from "../lib/imageApi";
+
+const SIZE_OPTIONS: Array<{ label: string; value: "256x256" | "512x512" | "1024x1024" }> = [
+  { label: "Square • 256px", value: "256x256" },
+  { label: "Detailed • 512px", value: "512x512" },
+  { label: "Showcase • 1024px", value: "1024x1024" },
+];
+
+const QUALITY_OPTIONS: Array<{ label: string; value: "standard" | "hd"; helper: string }> = [
+  { label: "Standard", value: "standard", helper: "Fastest option for quick previews." },
+  { label: "HD", value: "hd", helper: "Sharper output, slightly slower." },
+];
+
+const API_WARNING_MESSAGE =
+  "Set EXPO_PUBLIC_IMAGE_API_TOKEN to authenticate requests to the GenerateImage function.";
+
+const PLACEHOLDER_PROMPT =
+  "Create a premium hero image for a barber shop website featuring a modern haircut session.";
+
+type ImageAssistantProps = {
+  colors: {
+    text: string;
+    subtext: string;
+    surface: string;
+    border: string;
+    accent: string;
+    accentFgOn: string;
+    danger: string;
+    bg: string;
+  };
+};
+
+type HistoryEntry = {
+  id: string;
+  response: GenerateImageResponse;
+  imageUri: string;
+  createdAt: number;
+};
+
+function toDataUri(image: GenerateImageResponse["data"]): string {
+  if (image.b64_json) {
+    return `data:image/png;base64,${image.b64_json}`;
+  }
+  if (image.url) return image.url;
+  throw new Error("The image response did not include any renderable data.");
+}
+
+export default function ImageAssistant({ colors }: ImageAssistantProps) {
+  const [prompt, setPrompt] = useState("");
+  const [size, setSize] = useState<"256x256" | "512x512" | "1024x1024">("1024x1024");
+  const [quality, setQuality] = useState<"standard" | "hd">("standard");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  const canGenerate = useMemo(() => {
+    return Boolean(prompt.trim()) && !pending && isImageApiConfigured;
+  }, [prompt, pending]);
+
+  const helperMessage = isImageApiConfigured ? null : API_WARNING_MESSAGE;
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || pending) return;
+
+    setPending(true);
+    setError(null);
+
+    try {
+      const response = await generateImage({ prompt, size, quality });
+      const uri = toDataUri(response.data);
+      setHistory((prev) => [
+        { id: `${Date.now()}-${Math.random()}`, response, imageUri: uri, createdAt: Date.now() },
+        ...prev,
+      ]);
+    } catch (e: any) {
+      setError(e?.message ?? "Unable to generate image.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const clearHistory = () => {
+    setHistory([]);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        <Text style={[styles.title, { color: colors.text }]}>Image assistant</Text>
+        <Text style={[styles.subtitle, { color: colors.subtext }]}>Generate marketing visuals for your shop using the OpenAI image API deployed under <Text style={{ fontWeight: "700", color: colors.text }}>/api/GenerateImage</Text>.</Text>
+
+        {helperMessage ? (
+          <View style={[styles.banner, { borderColor: colors.danger, backgroundColor: "rgba(239,68,68,0.12)" }]}>
+            <Text style={[styles.bannerText, { color: colors.danger }]}>{helperMessage}</Text>
+          </View>
+        ) : null}
+
+        <View style={{ gap: 12 }}>
+          <View>
+            <Text style={[styles.label, { color: colors.subtext }]}>Prompt</Text>
+            <TextInput
+              multiline
+              value={prompt}
+              onChangeText={setPrompt}
+              placeholder={PLACEHOLDER_PROMPT}
+              placeholderTextColor={"rgba(255,255,255,0.4)"}
+              style={[styles.promptInput, { color: colors.text, borderColor: colors.border, backgroundColor: colors.bg }]}
+            />
+          </View>
+
+          <View>
+            <Text style={[styles.label, { color: colors.subtext }]}>Size</Text>
+            <View style={styles.optionRow}>
+              {SIZE_OPTIONS.map((option) => {
+                const active = option.value === size;
+                return (
+                  <Pressable
+                    key={option.value}
+                    onPress={() => setSize(option.value)}
+                    style={[
+                      styles.optionChip,
+                      { borderColor: colors.border },
+                      active && { backgroundColor: colors.accent, borderColor: colors.accent },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Select ${option.label}`}
+                  >
+                    <Text style={[styles.optionText, { color: active ? colors.accentFgOn : colors.subtext }]}>
+                      {option.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          <View>
+            <Text style={[styles.label, { color: colors.subtext }]}>Quality</Text>
+            <View style={styles.optionRow}>
+              {QUALITY_OPTIONS.map((option) => {
+                const active = option.value === quality;
+                return (
+                  <Pressable
+                    key={option.value}
+                    onPress={() => setQuality(option.value)}
+                    style={[
+                      styles.optionChip,
+                      { borderColor: colors.border },
+                      active && { backgroundColor: colors.accent, borderColor: colors.accent },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Use ${option.label} quality`}
+                  >
+                    <View style={{ alignItems: "center" }}>
+                      <Text style={[styles.optionText, { color: active ? colors.accentFgOn : colors.subtext }]}>
+                        {option.label}
+                      </Text>
+                      <Text style={[styles.optionHelper, { color: active ? colors.accentFgOn : colors.subtext }]}>
+                        {option.helper}
+                      </Text>
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          <Pressable
+            onPress={handleGenerate}
+            style={[styles.generateButton, { backgroundColor: canGenerate ? colors.accent : colors.border }]}
+            disabled={!canGenerate}
+            accessibilityRole="button"
+            accessibilityLabel="Generate marketing image"
+          >
+            {pending ? (
+              <ActivityIndicator color={colors.accentFgOn} />
+            ) : (
+              <Text style={[styles.generateButtonText, { color: colors.accentFgOn }]}>Generate image</Text>
+            )}
+          </Pressable>
+
+          {error ? <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text> : null}
+        </View>
+      </View>
+
+      {history.length > 0 ? (
+        <View style={{ gap: 16 }}>
+          <View style={[styles.historyHeader, { borderColor: colors.border }]}> 
+            <Text style={[styles.title, { color: colors.text, flex: 1 }]}>Recent results</Text>
+            <Pressable
+              onPress={clearHistory}
+              style={[styles.clearHistoryButton, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel="Clear generated images"
+            >
+              <Text style={[styles.clearHistoryText, { color: colors.subtext }]}>Clear</Text>
+            </Pressable>
+          </View>
+
+          {history.map((entry) => {
+            const { response } = entry;
+            return (
+              <View
+                key={entry.id}
+                style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border, gap: 12 }]}
+              >
+                <Text style={[styles.historyMeta, { color: colors.subtext }]}>Prompt:</Text>
+                <Text style={[styles.historyPrompt, { color: colors.text }]}>{response.prompt}</Text>
+                {response.data.revised_prompt ? (
+                  <Text style={[styles.historyRevised, { color: colors.subtext }]}>Revised prompt: {response.data.revised_prompt}</Text>
+                ) : null}
+                <Image source={{ uri: entry.imageUri }} style={styles.previewImage} resizeMode="contain" />
+                <Text style={[styles.historyMeta, { color: colors.subtext }]}>Size: {response.size} • Quality: {response.quality}</Text>
+                <Text style={[styles.historyTimestamp, { color: colors.subtext }]}>
+                  Generated {new Date(entry.createdAt).toLocaleString()}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 20,
+    gap: 20,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: 18,
+    padding: 20,
+    gap: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "800",
+  },
+  subtitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  banner: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+  },
+  bannerText: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: "800",
+    textTransform: "uppercase",
+    marginBottom: 6,
+  },
+  promptInput: {
+    minHeight: 120,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  optionRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  optionChip: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  optionText: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  optionHelper: {
+    fontSize: 11,
+    fontWeight: "600",
+    marginTop: 2,
+  },
+  generateButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  generateButtonText: {
+    fontSize: 15,
+    fontWeight: "900",
+    textTransform: "uppercase",
+  },
+  errorText: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  historyHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  clearHistoryButton: {
+    borderWidth: 1,
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+  },
+  clearHistoryText: {
+    fontSize: 12,
+    fontWeight: "800",
+    textTransform: "uppercase",
+  },
+  historyMeta: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  historyPrompt: {
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  historyRevised: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  previewImage: {
+    width: "100%",
+    aspectRatio: 1,
+    borderRadius: 12,
+    backgroundColor: "rgba(0,0,0,0.06)",
+  },
+  historyTimestamp: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+});

--- a/src/lib/imageApi.ts
+++ b/src/lib/imageApi.ts
@@ -1,0 +1,96 @@
+const API_ROUTE = "/api/images/generate";
+const IMAGE_API_TOKEN = process.env.EXPO_PUBLIC_IMAGE_API_TOKEN;
+
+export type GenerateImageOptions = {
+  prompt: string;
+  size?: "256x256" | "512x512" | "1024x1024";
+  quality?: "standard" | "hd";
+  responseFormat?: "b64_json" | "url";
+  signal?: AbortSignal;
+};
+
+export type GeneratedImagePayload = {
+  b64_json?: string;
+  url?: string;
+  revised_prompt?: string;
+};
+
+export type GenerateImageResponse = {
+  prompt: string;
+  size: string;
+  quality: string;
+  response_format: string;
+  data: GeneratedImagePayload;
+};
+
+export const isImageApiConfigured = typeof IMAGE_API_TOKEN === "string" && IMAGE_API_TOKEN.length > 0;
+
+function buildErrorMessage(status: number, body: any) {
+  if (body && typeof body === "object") {
+    if ("error" in body && typeof (body as any).error === "string") {
+      return String((body as any).error);
+    }
+    if ("details" in body) {
+      const details = (body as any).details;
+      if (typeof details === "string") return details;
+    }
+  }
+
+  if (status === 401) return "Unauthorized request to the image generator.";
+  if (status >= 400 && status < 500) return `Request failed with status ${status}.`;
+  if (status >= 500) return "Image service is currently unavailable.";
+  return "Unexpected error contacting the image API.";
+}
+
+export async function generateImage(options: GenerateImageOptions): Promise<GenerateImageResponse> {
+  const { prompt, size = "1024x1024", quality = "standard", responseFormat = "b64_json", signal } = options;
+
+  if (!prompt || !prompt.trim()) {
+    throw new Error("A prompt is required to generate an image.");
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (IMAGE_API_TOKEN) {
+    headers["x-api-key"] = IMAGE_API_TOKEN;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(API_ROUTE, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        prompt: prompt.trim(),
+        size,
+        quality,
+        response_format: responseFormat,
+      }),
+      signal,
+    });
+  } catch (error: any) {
+    throw new Error(error?.message ?? "Unable to reach the image API.");
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}.`);
+    }
+    throw new Error("Image API did not return a JSON payload.");
+  }
+
+  if (!response.ok) {
+    throw new Error(buildErrorMessage(response.status, body));
+  }
+
+  if (!body || typeof body !== "object" || !body.data) {
+    throw new Error("Image API response was missing the generated image.");
+  }
+
+  return body as GenerateImageResponse;
+}


### PR DESCRIPTION
## Summary
- add a dedicated Image Lab screen that calls the GenerateImage Azure Function and shows recent renders
- introduce a shared image API client with helpful error messages and configuration checks
- document the local setup steps for wiring the Expo app to the GenerateImage function and update deployment guidance

## Testing
- npm test *(fails: dependencies could not be installed because the registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e0651429308327b16b8cb0ec166197