### PR TITLE
Localize settings and service labels

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -103,6 +103,10 @@ const LANGUAGE_COPY = {
       imageAssistant: "Image lab",
       settings: "Settings",
     },
+    settingsPage: {
+      title: "Settings",
+      subtitle: "Manage your preferences for the AIBarber dashboard.",
+    },
     servicesPage: {
       title: "Services",
       subtitle: "Manage what clients can book and adjust existing options as needed.",
@@ -416,6 +420,10 @@ const LANGUAGE_COPY = {
       assistant: "Assistente",
       imageAssistant: "Laboratório de imagens",
       settings: "Configurações",
+    },
+    settingsPage: {
+      title: "Configurações",
+      subtitle: "Gerencie suas preferências no painel do AIBarber.",
     },
     servicesPage: {
       title: "Serviços",
@@ -1058,7 +1066,7 @@ export default function App() {
       const displayServiceName = selectedLocalizedService?.name ?? selectedService.name;
       Alert.alert(
         bookServiceCopy.alerts.bookingSuccessTitle,
-        `${displayServiceName} • ${selectedCustomer.first_name} • ${barberName} • ${start} • ${humanDate(dateKey)}`,
+        `${displayServiceName} • ${selectedCustomer.first_name} • ${barberName} • ${start} • ${humanDate(dateKey, locale)}`,
       );
     } catch (e: any) {
       console.error(e);
@@ -1255,7 +1263,7 @@ export default function App() {
           ? `${b._customer.first_name}${b._customer.last_name ? ` ${b._customer.last_name}` : ""}`
           : null;
         return assistantCopy.systemPrompt.bookingLine({
-          date: humanDate(b.date),
+          date: humanDate(b.date, locale),
           start: b.start,
           end: b.end,
           serviceName,
@@ -1279,7 +1287,7 @@ export default function App() {
       existingBookings,
       ...assistantCopy.systemPrompt.instructions,
     ].join("\n");
-  }, [assistantCopy.systemPrompt, bookings, localizedServiceMap, localizedServices]);
+  }, [assistantCopy.systemPrompt, bookings, locale, localizedServiceMap, localizedServices]);
 
   const filteredBookingsList = useMemo(() => {
     const barber = bookingFilterBarber?.trim();
@@ -1714,10 +1722,11 @@ export default function App() {
                   border: COLORS.border,
                   accent: COLORS.accent,
                 }}
+                locale={locale}
               />
 
               {/* Slots */}
-              <Text style={styles.sectionLabel}>{bookServiceCopy.slots.title(humanDate(dateKey))}</Text>
+              <Text style={styles.sectionLabel}>{bookServiceCopy.slots.title(humanDate(dateKey, locale))}</Text>
           <View style={styles.card}>
             {selectedService ? (
               <View style={styles.grid}>
@@ -1781,7 +1790,7 @@ export default function App() {
             {/* Resumo fixo */}
             {selectedSlot && selectedService && (
               <Text style={styles.summaryText}>
-                {(selectedLocalizedService?.name ?? selectedService.name)} • {BARBER_MAP[selectedBarber.id]?.name} • {selectedSlot} • {humanDate(dateKey)}
+                {(selectedLocalizedService?.name ?? selectedService.name)} • {BARBER_MAP[selectedBarber.id]?.name} • {selectedSlot} • {humanDate(dateKey, locale)}
                 {selectedCustomer ? ` • ${selectedCustomer.first_name}` : ""}
               </Text>
             )}
@@ -2105,7 +2114,7 @@ export default function App() {
                   style={[styles.bookingListRow, isUltraCompactLayout && styles.bookingListRowCompact]}
                 >
                   <View style={[styles.bookingListTime, isUltraCompactLayout && styles.bookingListTimeCompact]}>
-                    <Text style={styles.bookingListDate}>{humanDate(booking.date)}</Text>
+                    <Text style={styles.bookingListDate}>{humanDate(booking.date, locale)}</Text>
                     <Text style={styles.bookingListClock}>
                       {booking.start} – {booking.end}
                     </Text>
@@ -2258,10 +2267,10 @@ export default function App() {
         <View style={[styles.card, { borderColor: COLORS.border, backgroundColor: COLORS.surface, gap: 12 }]}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
             <Ionicons name="settings-outline" size={22} color={COLORS.accent} />
-            <Text style={[styles.title, { color: COLORS.text }]}>Settings</Text>
+            <Text style={[styles.title, { color: COLORS.text }]}>{copy.settingsPage.title}</Text>
           </View>
           <Text style={{ color: COLORS.subtext, fontSize: 13, fontWeight: "600" }}>
-            Manage your preferences for the AIBarber dashboard.
+            {copy.settingsPage.subtitle}
           </Text>
         </View>
 

--- a/src/components/DateSelector.tsx
+++ b/src/components/DateSelector.tsx
@@ -12,14 +12,15 @@ type Props = {
     border: string;
     accent: string;
   };
+  locale?: string;
 };
 
 const pad = (n: number) => n.toString().padStart(2, "0");
 const toDateKey = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-const humanDow = (d: Date) => d.toLocaleDateString(undefined, { weekday: "short" });
-const humanDateKey = (dk: string) => {
+const humanDow = (d: Date, locale?: string) => d.toLocaleDateString(locale ?? undefined, { weekday: "short" });
+const humanDateKey = (dk: string, locale?: string) => {
   const d = new Date(`${dk}T00:00:00`);
-  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  return d.toLocaleDateString(locale ?? undefined, { weekday: "short", month: "short", day: "numeric" });
 };
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -47,6 +48,7 @@ export default function DateSelector({
     border: "rgba(255,255,255,0.07)",
     accent: "#60a5fa",
   },
+  locale,
 }: Props) {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(value));
@@ -143,7 +145,9 @@ export default function DateSelector({
               accessibilityRole="button"
               accessibilityLabel={`Select ${d.toDateString()}`}
             >
-              <Text style={[styles.dayDow, { color: colors.subtext }, active && { color: colors.text }]}>{humanDow(d)}</Text>
+              <Text style={[styles.dayDow, { color: colors.subtext }, active && { color: colors.text }]}>
+                {humanDow(d, locale)}
+              </Text>
               <Text style={[styles.dayNum, { color: colors.text }]}>{d.getDate()}</Text>
             </Pressable>
           );
@@ -163,7 +167,7 @@ export default function DateSelector({
       />
 
       {/* Rótulo com resumo da data atual */}
-      <Text style={[styles.currentLabel, { color: colors.subtext }]}>{humanDateKey(dateKey)}</Text>
+      <Text style={[styles.currentLabel, { color: colors.subtext }]}>{humanDateKey(dateKey, locale)}</Text>
     </View>
   );
 }

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -67,9 +67,9 @@ export function overlap(aS: string, aE: string, bS: string, bE: string) {
   return Math.max(as, bs) < Math.min(ae, be);
 }
 
-export function humanDate(dk: string) {
+export function humanDate(dk: string, locale?: string) {
   const d = new Date(`${dk}T00:00:00`);
-  return d.toLocaleDateString(undefined, {
+  return d.toLocaleDateString(locale ?? undefined, {
     weekday: "short",
     month: "short",
     day: "numeric",

--- a/src/lib/polyglot.ts
+++ b/src/lib/polyglot.ts
@@ -3,7 +3,7 @@ import type { Service } from "./domain";
 export type LanguageCode = "en" | "pt";
 
 const RAW_SERVICE_TRANSLATIONS: Record<string, Partial<Record<LanguageCode, string>>> = {
-  cut: { pt: "Corte clássico" },
+  cut: { pt: "Corte" },
   "classic cut": { pt: "Corte clássico" },
   "classic haircut": { pt: "Corte clássico" },
   fade: { pt: "Degradê" },
@@ -11,8 +11,10 @@ const RAW_SERVICE_TRANSLATIONS: Record<string, Partial<Record<LanguageCode, stri
   colors: { pt: "Coloração" },
   "hair color": { pt: "Coloração" },
   beard: { pt: "Barba" },
-  shave: { pt: "Barbear" },
-  "beard shave": { pt: "Barbear" },
+  shave: { pt: "Barba" },
+  "beard shave": { pt: "Barba" },
+  "cut shave": { pt: "Corte & Barba" },
+  "cut and shave": { pt: "Corte & Barba" },
   trim: { pt: "Aparar" },
   "buzz cut": { pt: "Corte militar" },
   "cut style": { pt: "Corte e estilo" },


### PR DESCRIPTION
## Summary
- update polyglot service translations so Cut, Shave, and Cut & Shave render in Portuguese as requested
- expose localized settings page copy and render it through the existing language switcher
- respect the selected locale when formatting dates in the booking flow

## Testing
- npm run test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5aebf08f4832792d18132c437e3a3