### PR TITLE
Fix locale initialization and localization typings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -836,6 +836,7 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [language, setLanguage] = useState<SupportedLanguage>(() => getInitialLanguage());
   const copy = useMemo(() => LANGUAGE_COPY[language], [language]);
+  const locale = language === "pt" ? "pt-BR" : "en-US";
   const bookServiceCopy = copy.bookService;
   const bookingsCopy = copy.bookings;
   const assistantCopy = copy.assistant;
@@ -1459,8 +1460,6 @@ export default function App() {
     () => weekDays.map((dayInfo) => ({ ...dayInfo, bookings: weekDayMap.get(dayInfo.key) ?? [] })),
     [weekDayMap, weekDays],
   );
-
-  const locale = language === "pt" ? "pt-BR" : "en-US";
 
   const weekRangeLabel = useMemo(() => {
     if (!weekDays.length) return "";
@@ -2551,7 +2550,7 @@ function ClientModal({
   onRefreshQuery: (q: string) => void;
   onPick: (c: Customer) => void;
   onSaved: (c: Customer) => void;
-  copy: typeof LANGUAGE_COPY.en.bookService.clientModal;
+  copy: (typeof LANGUAGE_COPY)[SupportedLanguage]["bookService"]["clientModal"];
   colors: ThemeColors;
   styles: ReturnType<typeof createStyles>;
 }) {

--- a/src/components/ImageAssistant.tsx
+++ b/src/components/ImageAssistant.tsx
@@ -23,9 +23,9 @@ type ImageAssistantCopy = {
   promptLabel: string;
   promptPlaceholder: string;
   sizeLabel: string;
-  sizeOptions: Array<{ label: string; value: "256x256" | "512x512" | "1024x1024" }>;
+  sizeOptions: ReadonlyArray<{ label: string; value: "256x256" | "512x512" | "1024x1024" }>;
   qualityLabel: string;
-  qualityOptions: Array<{ label: string; value: "standard" | "hd"; helper: string }>;
+  qualityOptions: ReadonlyArray<{ label: string; value: "standard" | "hd"; helper: string }>;
   optionAccessibility: {
     size: (label: string) => string;
     quality: (label: string) => string;


### PR DESCRIPTION
## Summary
- compute the user locale immediately after resolving the selected language to avoid pre-declaration usage
- generalize the client modal copy typing so both English and Portuguese translations are accepted
- update the image assistant copy interface to accept readonly option arrays used by localized copy data

## Testing
- npx tsc --noEmit *(fails: project tsconfig extends expo/tsconfig.base which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b5d499788327b81c46331895a0f2