### PR TITLE
Fix client modal scrolling and zoom issues

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2611,89 +2611,96 @@ function ClientModal({
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.backdrop}>
         <View style={[styles.sheet, { backgroundColor: colors.sidebarBg, borderColor: colors.border }]}>
-          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+          <View style={styles.sheetHeader}>
             <Text style={{ color: colors.text, fontWeight: "900", fontSize: 16 }}>{copy.title}</Text>
             <Pressable onPress={onClose}><Ionicons name="close" size={22} color={colors.subtext} /></Pressable>
           </View>
 
-          {/* Tabs */}
-          <View style={{ flexDirection: "row", gap: 8 }}>
-            <Pressable onPress={() => setTab("list")}
-              style={[styles.tab, tab === "list" && { backgroundColor: colors.accent, borderColor: colors.accent }]}>
-              <Text style={[styles.tabText, tab === "list" && { color: colors.accentFgOn }]}>{copy.tabs.list}</Text>
-            </Pressable>
-            <Pressable onPress={() => setTab("create")}
-              style={[styles.tab, tab === "create" && { backgroundColor: colors.accent, borderColor: colors.accent }]}>
-              <Text style={[styles.tabText, tab === "create" && { color: colors.accentFgOn }]}>{copy.tabs.create}</Text>
-            </Pressable>
-          </View>
+          <ScrollView
+            style={styles.sheetScroll}
+            contentContainerStyle={{ gap: 12, paddingBottom: 4 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* Tabs */}
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              <Pressable onPress={() => setTab("list")}
+                style={[styles.tab, tab === "list" && { backgroundColor: colors.accent, borderColor: colors.accent }]}>
+                <Text style={[styles.tabText, tab === "list" && { color: colors.accentFgOn }]}>{copy.tabs.list}</Text>
+              </Pressable>
+              <Pressable onPress={() => setTab("create")}
+                style={[styles.tab, tab === "create" && { backgroundColor: colors.accent, borderColor: colors.accent }]}>
+                <Text style={[styles.tabText, tab === "create" && { color: colors.accentFgOn }]}>{copy.tabs.create}</Text>
+              </Pressable>
+            </View>
 
-          {tab === "list" ? (
-            <View style={{ gap: 10 }}>
-              {Platform.OS === "web" && (
-                <input
-                  placeholder={copy.searchPlaceholder}
-                  value={query}
-                  onChange={(e: any) => setQuery(String(e.target.value))}
-                  onKeyDown={(e: any) => { if (e.key === "Enter") onRefreshQuery(query); }}
-                  style={{
-                    padding: 10,
-                    borderRadius: 10,
-                    width: "100%",
-                    border: `1px solid ${colors.border}`,
-                    background: colors.surface,
-                    color: colors.text,
-                    fontWeight: 700,
+            {tab === "list" ? (
+              <View style={{ gap: 10 }}>
+                {Platform.OS === "web" && (
+                  <input
+                    placeholder={copy.searchPlaceholder}
+                    value={query}
+                    onChange={(e: any) => setQuery(String(e.target.value))}
+                    onKeyDown={(e: any) => { if (e.key === "Enter") onRefreshQuery(query); }}
+                    style={{
+                      padding: 10,
+                      borderRadius: 10,
+                      width: "100%",
+                      border: `1px solid ${colors.border}`,
+                      background: colors.surface,
+                      color: colors.text,
+                      fontWeight: 700,
+                      fontSize: 16,
+                    }}
+                  />
+                )}
+                <Pressable onPress={() => onRefreshQuery(query)} style={[styles.smallBtn, { alignSelf: "flex-start", borderColor: colors.border }]}>
+                  <Text style={{ color: colors.subtext, fontWeight: "800" }}>{copy.searchButton}</Text>
+                </Pressable>
+
+                <View style={[styles.card, { gap: 6 }]}>
+                  {loading ? <ActivityIndicator /> : customers.length === 0 ? (
+                    <Text style={{ color: colors.subtext }}>{copy.empty}</Text>
+                  ) : (
+                    customers.map(c => (
+                      <Pressable key={c.id} onPress={() => onPick(c)} style={styles.listRow}>
+                        <MaterialCommunityIcons name="account" size={18} color={colors.accent} />
+                        <Text style={{ color: colors.text, fontWeight: "800" }}>
+                          {c.first_name} {c.last_name}
+                        </Text>
+                        {c.email ? <Text style={{ color: colors.subtext, marginLeft: 6, fontSize: 12 }}>{c.email}</Text> : null}
+                      </Pressable>
+                    ))
+                  )}
+                </View>
+              </View>
+            ) : (
+              <View style={{ marginTop: 4 }}>
+                <UserForm
+                  onSaved={(row) => {
+                    onSaved({
+                      id: row.id,
+                      first_name: row.first_name,
+                      last_name: row.last_name,
+                      phone: row.phone,
+                      email: row.email,
+                      date_of_birth: row.date_of_birth,
+                    });
+                    onClose();
+                  }}
+                  onCancel={() => setTab("list")}
+                  colors={{
+                    text: colors.text,
+                    subtext: colors.subtext,
+                    border: colors.border,
+                    surface: colors.surface,
+                    accent: colors.accent,
+                    accentFgOn: colors.accentFgOn,
+                    danger: colors.danger,
                   }}
                 />
-              )}
-              <Pressable onPress={() => onRefreshQuery(query)} style={[styles.smallBtn, { alignSelf: "flex-start", borderColor: colors.border }]}>
-                <Text style={{ color: colors.subtext, fontWeight: "800" }}>{copy.searchButton}</Text>
-              </Pressable>
-
-              <View style={[styles.card, { gap: 6 }]}>
-                {loading ? <ActivityIndicator /> : customers.length === 0 ? (
-                  <Text style={{ color: colors.subtext }}>{copy.empty}</Text>
-                ) : (
-                  customers.map(c => (
-                    <Pressable key={c.id} onPress={() => onPick(c)} style={styles.listRow}>
-                      <MaterialCommunityIcons name="account" size={18} color={colors.accent} />
-                      <Text style={{ color: colors.text, fontWeight: "800" }}>
-                        {c.first_name} {c.last_name}
-                      </Text>
-                      {c.email ? <Text style={{ color: colors.subtext, marginLeft: 6, fontSize: 12 }}>{c.email}</Text> : null}
-                    </Pressable>
-                  ))
-                )}
               </View>
-            </View>
-          ) : (
-            <View style={{ marginTop: 4 }}>
-              <UserForm
-                onSaved={(row) => {
-                  onSaved({
-                    id: row.id,
-                    first_name: row.first_name,
-                    last_name: row.last_name,
-                    phone: row.phone,
-                    email: row.email,
-                    date_of_birth: row.date_of_birth,
-                  });
-                  onClose();
-                }}
-                onCancel={() => setTab("list")}
-                colors={{
-                  text: colors.text,
-                  subtext: colors.subtext,
-                  border: colors.border,
-                  surface: colors.surface,
-                  accent: colors.accent,
-                  accentFgOn: colors.accentFgOn,
-                  danger: colors.danger,
-                }}
-              />
-            </View>
-          )}
+            )}
+          </ScrollView>
         </View>
       </View>
     </Modal>
@@ -2918,6 +2925,7 @@ const createStyles = (colors: ThemeColors) => StyleSheet.create({
   sheet: {
     width: 560,
     maxWidth: "100%",
+    maxHeight: "90%",
     borderRadius: 16,
     borderWidth: 1,
     borderColor: colors.border,
@@ -2925,6 +2933,8 @@ const createStyles = (colors: ThemeColors) => StyleSheet.create({
     padding: 16,
     gap: 12,
   },
+  sheetHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 12 },
+  sheetScroll: { alignSelf: "stretch", flexGrow: 1 },
   tab: { borderWidth: 1, borderColor: colors.border, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999 },
   tabText: { color: colors.text, fontWeight: "800" },
 


### PR DESCRIPTION
## Summary
- wrap the client selection modal contents in a scrollable container with a maximum height so the search controls remain accessible on small screens
- add dedicated styling for the modal header and scroll view to improve spacing and layout consistency
- raise the web search input font size to prevent iOS from zooming when it receives focus

## Testing
- npm test *(fails: vitest not found; dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c1ef66688327b8335e6851207058