### PR TITLE
Harden image generation function and document security review

### DIFF
--- a/api/GenerateImage/index.js
+++ b/api/GenerateImage/index.js
@@ -21,7 +21,18 @@ module.exports = async function (context, req) {
   const configuredToken = process.env.IMAGE_API_TOKEN;
   const providedToken = req.headers['x-api-key'] || req.headers['x-functions-key'];
 
-  if (configuredToken && configuredToken !== providedToken) {
+  if (!configuredToken) {
+    context.log.error('Missing IMAGE_API_TOKEN configuration.');
+    context.res = {
+      status: 500,
+      body: {
+        error: 'Server misconfiguration: missing image API token.',
+      },
+    };
+    return;
+  }
+
+  if (!providedToken || configuredToken !== providedToken) {
     context.res = {
       status: 401,
       body: {
@@ -31,13 +42,60 @@ module.exports = async function (context, req) {
     return;
   }
 
-  const { prompt, size = '1024x1024', quality = 'standard', response_format = 'b64_json' } = req.body || {};
+  const {
+    prompt,
+    size = '1024x1024',
+    quality = 'standard',
+    response_format = 'b64_json',
+  } = req.body || {};
 
-  if (!prompt || typeof prompt !== 'string') {
+  if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
     context.res = {
       status: 400,
       body: {
         error: 'A non-empty "prompt" field is required in the request body.',
+      },
+    };
+    return;
+  }
+
+  if (prompt.length > 1000) {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'Prompt is too long. Limit to 1000 characters.',
+      },
+    };
+    return;
+  }
+
+  const allowedSizes = new Set(['256x256', '512x512', '1024x1024']);
+  if (!allowedSizes.has(size)) {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'Invalid "size" requested.',
+      },
+    };
+    return;
+  }
+
+  const allowedQualities = new Set(['standard', 'hd']);
+  if (!allowedQualities.has(quality)) {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'Invalid "quality" requested.',
+      },
+    };
+    return;
+  }
+
+  if (response_format !== 'b64_json') {
+    context.res = {
+      status: 400,
+      body: {
+        error: 'Unsupported "response_format" requested.',
       },
     };
     return;

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -1,0 +1,29 @@
+# Security Review - AI Barber Application
+
+## Summary
+- **Scope**: Azure Function `api/GenerateImage`, Expo front-end OpenAI integrations, deployment guidance.
+- **Date**: 2025-10-08 (UTC)
+- **Reviewer**: Automated security assessment by ChatGPT.
+
+## Findings
+
+### 1. Missing authentication enforcement on image generation endpoint
+- **Severity**: High
+- **Issue**: The Azure Function previously accepted requests without verifying an API token when `IMAGE_API_TOKEN` was not configured, allowing unauthenticated use of the OpenAI image endpoint.
+- **Remediation**: The function now fails fast when the token is absent and requires clients to supply the matching `x-api-key` (or `x-functions-key`).
+
+### 2. Insufficient input validation for OpenAI image parameters
+- **Severity**: Medium
+- **Issue**: Client-supplied `size`, `quality`, `response_format`, and arbitrarily long prompts were forwarded directly to OpenAI, risking service abuse and unexpected costs.
+- **Remediation**: Added server-side validation to enforce known-safe values and reasonable prompt length limits.
+
+### 3. Front-end OpenAI API key exposure (informational)
+- **Severity**: High (architectural)
+- **Issue**: The Expo client uses `EXPO_PUBLIC_OPENAI_API_KEY`, which is bundled into the client and exposed to end users. Anyone with the app can extract the key and abuse it.
+- **Recommendation**: Proxy OpenAI requests through a secured backend (such as an authenticated Azure Function) instead of calling OpenAI directly from the client. Remove public API key usage and store secrets server-side.
+
+## Additional Recommendations
+- Implement request logging with caution to avoid storing prompts that may contain sensitive data; prefer structured logging with redaction options.
+- Add rate limiting and anomaly detection to the image generation endpoint to prevent abuse.
+- Consider automated security testing (SAST/DAST) within CI/CD pipelines to catch regressions.
+


### PR DESCRIPTION
## Summary
- enforce API token configuration and validation on the image generation Azure Function
- validate client-supplied parameters and prompt length before calling OpenAI
- add a security review document capturing current findings and recommendations

## Testing
- npm test -- --runInBand *(fails: vitest not installed in environment)*
- npm install *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6604d3bcc8327a14a53f0424201fd