### PR TITLE
Replace service spotlight chart with donut visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
+    "react-native-svg": "^15.13.0",
     "react-native-web": "^0.20.0",
     "@react-native-community/datetimepicker": "8.4.1"
   },


### PR DESCRIPTION
## Summary
- replace the service spotlight pyramid graphic with an SVG-based donut chart that reflects the share of weekly bookings
- center the primary statistic inside the donut and keep the legend aligned with the new visualization
- add react-native-svg as a dependency to render the donut sectors cleanly

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6620e2f548327a44198bbf31ad59a