### PR TITLE
Allow barber selection without selecting a client

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2108,15 +2108,9 @@ export default function App() {
                   </View>
                 </View>
 
-                {/* Barber selector (desabilita se não houver cliente) */}
-                <View style={{ opacity: selectedCustomer ? 1 : 0.6 }}>
-                  <Text style={styles.sectionLabel}>{bookServiceCopy.barberSectionTitle}</Text>
-                  <BarberSelector
-                    selected={selectedBarber}
-                    onChange={setSelectedBarber}
-                    disabled={!selectedCustomer}
-                  />
-                </View>
+                {/* Barber selector */}
+                <Text style={styles.sectionLabel}>{bookServiceCopy.barberSectionTitle}</Text>
+                <BarberSelector selected={selectedBarber} onChange={setSelectedBarber} />
               </View>
 
               {/* Date selector */}

--- a/src/components/BarberSelector.tsx
+++ b/src/components/BarberSelector.tsx
@@ -10,20 +10,11 @@ export type Barber = DomainBarber;
 type Props = {
   selected: Barber;
   onChange: (b: Barber) => void;
-  /** novo */
-  disabled?: boolean;
 };
 
-export default function BarberSelector({ selected, onChange, disabled = false }: Props) {
+export default function BarberSelector({ selected, onChange }: Props) {
   return (
-    <View
-      style={[
-        styles.row,
-        disabled && { opacity: 0.6 },
-      ]}
-      // Quando desabilitado, não deixa clicar
-      pointerEvents={disabled ? "none" : "auto"}
-    >
+    <View style={styles.row}>
       {BARBERS.map((b) => {
         const active = b.id === selected.id;
         return (


### PR DESCRIPTION
## Summary
- enable the barber selector even when no client has been chosen
- simplify the BarberSelector component by removing the disabled state handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66a416eb483278507e9d5beef3a29