### PR TITLE
Adjust next-week arrow alignment in DateSelector

### DIFF
--- a/src/components/DateSelector.tsx
+++ b/src/components/DateSelector.tsx
@@ -100,8 +100,12 @@ export default function DateSelector({
         {/* Tira horizontal de dias */}
         <ScrollView
           horizontal
+          style={styles.dayStripScroll}
           showsHorizontalScrollIndicator={false}
-          contentContainerStyle={[styles.dayStrip, { gap: 10, paddingVertical: 10 }]}
+          contentContainerStyle={[
+            styles.dayStrip,
+            { gap: 10, paddingVertical: 10, paddingRight: 0 },
+          ]}
         >
           {days.map(({ d, key }) => {
             const active = key === dateKey;
@@ -311,7 +315,13 @@ const styles = StyleSheet.create({
   },
   arrowIcon: { fontSize: 20, fontWeight: "800" },
 
-  dayStrip: {},
+  dayStripScroll: {
+    flexGrow: 0,
+  },
+  dayStrip: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
   dayPill: {
     width: 72,
     paddingVertical: 10,


### PR DESCRIPTION
## Summary
- stop the horizontal date strip from stretching so the next-week arrow sits beside the last day
- align the strip contents for consistent spacing between day pills and navigation arrows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67326d6d0832783ce525d0bf3bd74