### PR TITLE
Fix Image Assistant setup instructions

### DIFF
--- a/docs/IMAGE_ASSISTANT_SETUP.md
+++ b/docs/IMAGE_ASSISTANT_SETUP.md
@@ -53,11 +53,11 @@ Make sure `IMAGE_API_TOKEN` matches the value used in `.env.local`. The function
 Use two terminals (or run the commands in the background):
 
 ```bash
-npm run dev            # starts Expo for the front-end (web, iOS, or Android)
+npm start                    # starts Expo for the front-end (web, iOS, or Android)
 npm run start --prefix api   # starts the Azure Functions app (func start)
 ```
 
-> If you prefer the Static Web Apps CLI, you can alternatively run `npx swa start http://localhost:8081 --run "npm run dev"`.
+> If you prefer the Static Web Apps CLI, you can alternatively run `npx swa start http://localhost:8081 --run "npm start"`.
 
 ## 5. Generate images
 


### PR DESCRIPTION
## Summary
- update the Image Assistant setup guide to reference the npm start script for Expo
- adjust Static Web Apps CLI example to match the available npm script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6951de2e08327a15793f6db0905f4