### PR TITLE
fix: standardize AIBarber naming

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aibarber-api",
   "version": "1.0.0",
-  "description": "Azure Functions backend for AiBarber image generation",
+  "description": "Azure Functions backend for AIBarber image generation",
   "main": "GenerateImage/index.js",
   "license": "MIT",
   "type": "commonjs",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# AiBarber Backend Deployment Guide
+# AIBarber Backend Deployment Guide
 
 This guide walks through configuring the new Azure Functions backend under the `api/` folder and wiring it up to your Azure Static Web Apps (SWA) deployment pipeline.
 
@@ -119,4 +119,4 @@ Define `VITE_IMAGE_API_TOKEN` (Vite build) or `EXPO_PUBLIC_IMAGE_API_TOKEN` (Exp
 - [ ] Secrets are never committed to the repository.
 - [ ] `api/` folder is checked in so that SWA deploys the Functions app.
 
-Following this guide ensures your OpenAI-powered image generation endpoint is securely deployed alongside the AiBarber front-end using Azure Static Web Apps and GitHub Actions.
+Following this guide ensures your OpenAI-powered image generation endpoint is securely deployed alongside the AIBarber front-end using Azure Static Web Apps and GitHub Actions.


### PR DESCRIPTION
## Summary
- standardize the product name to "AIBarber" in the deployment guide
- update the API package description to use the correct product capitalization

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e699ae2b8883279ee793e0a4d67c08