### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,35 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
+const missingConfigMessage = 'Supabase configuration is missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY environment variables.';
+
+const createUnconfiguredClient = (): SupabaseClient => {
+  const fail = () => {
+    throw new Error(missingConfigMessage);
+  };
+
+  return new Proxy(
+    {},
+    {
+      get() {
+        fail();
+      },
+      apply() {
+        fail();
+      },
+    },
+  ) as SupabaseClient;
+};
+
 if (!url || !key) {
-  console.error('Supabase env missing',
-    { url: url, hasKey: !!key });
+  console.error('Supabase environment variables are missing', {
+    hasUrl: Boolean(url),
+    hasKey: Boolean(key),
+  });
 }
 
-export const supabase = createClient(url!, key!);
+export const supabase: SupabaseClient =
+  url && key ? createClient(url, key) : createUnconfiguredClient();
+export const isSupabaseConfigured = Boolean(url && key);


### PR DESCRIPTION
## Summary
- prevent Supabase client from being created when required environment variables are missing
- provide a proxy client and configuration flag to fail with a clear error message when Supabase is unavailable

## Testing
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e69527386883279f15033d471c8a88