### PR TITLE
Fix recent bookings query to fetch newest records first

### DIFF
--- a/src/lib/bookings.ts
+++ b/src/lib/bookings.ts
@@ -86,8 +86,8 @@ export async function listRecentBookings(limit = 200): Promise<BookingWithCustom
   const { data, error, status } = await supabase
     .from("bookings")
     .select('id,date,start,"end",service_id,barber,customer_id')
-    .order("date", { ascending: true })
-    .order("start", { ascending: true })
+    .order("date", { ascending: false })
+    .order("start", { ascending: false })
     .limit(limit);
 
   console.log("[listRecentBookings]", { status, error, limit });

--- a/tests/bookingService/functional/bookingLifecycle.functional.test.ts
+++ b/tests/bookingService/functional/bookingLifecycle.functional.test.ts
@@ -95,7 +95,8 @@ describe("booking service functional flow", () => {
 
     const bookings = await listRecentBookings(5);
 
-    expect(bookingsTable.order).toHaveBeenCalledWith("date", { ascending: true });
+    expect(bookingsTable.order).toHaveBeenCalledWith("date", { ascending: false });
+    expect(bookingsTable.order).toHaveBeenCalledWith("start", { ascending: false });
     expect(bookingsTable.limit).toHaveBeenCalledWith(5);
     expect(customersTable.in).toHaveBeenCalledWith("id", [customerRecord.id]);
     expect(bookings).toEqual([


### PR DESCRIPTION
## Summary
- update listRecentBookings to request descending order so we fetch the most recent rows
- adjust functional test expectation to match the new ordering requirements

## Testing
- npm install *(fails: 403 Forbidden fetching expo-localization)*

------
https://chatgpt.com/codex/tasks/task_e_68e69c84fc1c83279ee7862ec8c4e10a