### PR TITLE
Refactor ServiceForm and AssistantChat to use dedicated hooks

### DIFF
--- a/src/hooks/useAssistantChat.ts
+++ b/src/hooks/useAssistantChat.ts
@@ -1,0 +1,412 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Platform } from "react-native";
+
+import { runBookingAgent } from "../lib/bookingAgent";
+import { BARBERS, type Service } from "../lib/domain";
+import { isOpenAiConfigured, transcribeAudio } from "../lib/openai";
+
+export type DisplayMessage = {
+  role: "assistant" | "user";
+  content: string;
+};
+
+export type AssistantChatCopy = {
+  initialMessage: string;
+  apiKeyWarning: string;
+  contextPrefix: string;
+  quickRepliesTitle: string;
+  quickRepliesToggleShow: string;
+  quickRepliesToggleHide: string;
+  quickReplyAccessibility: (suggestion: string) => string;
+  quickReplies: {
+    existingBookings: string;
+    bookService: string;
+    bookSpecificService: (serviceName: string) => string;
+    barberAvailability: (barberName: string) => string;
+  };
+  inputPlaceholder: string;
+  sendAccessibility: string;
+  suggestionsAccessibility: {
+    show: string;
+    hide: string;
+  };
+  voiceButtonAccessibility: {
+    start: string;
+    stop: string;
+  };
+  errors: {
+    generic: string;
+    missingApiKey: string;
+    voiceWebOnly: string;
+    voiceUnsupported: string;
+    voiceStartFailed: string;
+    noAudio: string;
+    processFailed: string;
+  };
+};
+
+type UseAssistantChatOptions = {
+  systemPrompt: string;
+  contextSummary: string;
+  services: Service[];
+  copy: AssistantChatCopy;
+  onBookingsMutated?: () => Promise<void> | void;
+};
+
+type UseAssistantChatResult = {
+  messages: DisplayMessage[];
+  input: string;
+  setInput: (value: string) => void;
+  pending: boolean;
+  error: string | null;
+  canSend: boolean;
+  assistantEnabled: boolean;
+  quickReplies: string[];
+  suggestionsVisible: boolean;
+  showSuggestions: () => void;
+  hideSuggestions: () => void;
+  isRecording: boolean;
+  voiceTranscribing: boolean;
+  voiceButtonDisabled: boolean;
+  handleSend: () => void;
+  handleQuickReply: (suggestion: string) => void;
+  handleVoicePress: () => Promise<void>;
+};
+
+export function useAssistantChat({
+  systemPrompt,
+  contextSummary,
+  services,
+  copy,
+  onBookingsMutated,
+}: UseAssistantChatOptions): UseAssistantChatResult {
+  const [messages, setMessages] = useState<DisplayMessage[]>([
+    { role: "assistant", content: copy.initialMessage },
+  ]);
+  const [input, setInput] = useState("");
+  const [pending, setPending] = useState(false);
+  const [voiceTranscribing, setVoiceTranscribing] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestionsVisible, setSuggestionsVisible] = useState(false);
+
+  const messagesRef = useRef(messages);
+  const mediaRecorderRef = useRef<any>(null);
+  const recordedChunksRef = useRef<any[]>([]);
+  const lastApiWarningRef = useRef(copy.apiKeyWarning);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  useEffect(() => {
+    setMessages((prev) => {
+      if (prev.length === 0) {
+        return [{ role: "assistant", content: copy.initialMessage }];
+      }
+      const next = [...prev];
+      const first = next[0];
+      if (first?.role === "assistant" && first.content !== copy.initialMessage) {
+        next[0] = { role: "assistant", content: copy.initialMessage };
+        return next;
+      }
+      return prev;
+    });
+  }, [copy.initialMessage]);
+
+  const quickReplies = useMemo(() => {
+    const replies = [copy.quickReplies.existingBookings, copy.quickReplies.bookService];
+
+    services.slice(0, 2).forEach((service) => {
+      replies.push(copy.quickReplies.bookSpecificService(service.name));
+    });
+
+    BARBERS.slice(0, 2).forEach((barber) => {
+      replies.push(copy.quickReplies.barberAvailability(barber.name));
+    });
+
+    return replies;
+  }, [copy.quickReplies, services]);
+
+  useEffect(() => {
+    const trimmed = contextSummary.trim();
+    setMessages((prev) => {
+      const contextPrefix = copy.contextPrefix;
+      const existingIndex = prev.findIndex(
+        (msg) => msg.role === "assistant" && msg.content.startsWith(contextPrefix),
+      );
+
+      if (!trimmed) {
+        if (existingIndex === -1) return prev;
+        const next = [...prev];
+        next.splice(existingIndex, 1);
+        return next;
+      }
+
+      const contextContent = `${contextPrefix}\n${trimmed}`;
+      if (existingIndex !== -1) {
+        if (prev[existingIndex].content === contextContent) {
+          return prev;
+        }
+        const next = [...prev];
+        next[existingIndex] = { role: "assistant", content: contextContent };
+        return next;
+      }
+
+      const next = [...prev];
+      const insertIndex = next.length > 0 ? 1 : 0;
+      next.splice(insertIndex, 0, { role: "assistant", content: contextContent });
+      return next;
+    });
+  }, [contextSummary, copy.contextPrefix]);
+
+  useEffect(() => {
+    setMessages((prev) => {
+      const filtered = prev.filter(
+        (msg) =>
+          !(
+            msg.role === "assistant" &&
+            (msg.content === lastApiWarningRef.current || msg.content === copy.apiKeyWarning)
+          ),
+      );
+
+      if (isOpenAiConfigured) {
+        lastApiWarningRef.current = copy.apiKeyWarning;
+        return filtered;
+      }
+
+      if (
+        filtered.some(
+          (msg) => msg.role === "assistant" && msg.content === copy.apiKeyWarning,
+        )
+      ) {
+        lastApiWarningRef.current = copy.apiKeyWarning;
+        return filtered;
+      }
+
+      lastApiWarningRef.current = copy.apiKeyWarning;
+      return [...filtered, { role: "assistant", content: copy.apiKeyWarning }];
+    });
+  }, [copy.apiKeyWarning, isOpenAiConfigured]);
+
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current) {
+        try {
+          mediaRecorderRef.current.stop();
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    };
+  }, []);
+
+  const voiceSupported = Platform.OS === "web";
+
+  const canSend = useMemo(() => {
+    return Boolean(input.trim()) && !pending && isOpenAiConfigured && !voiceTranscribing;
+  }, [input, pending, voiceTranscribing]);
+
+  const startVoiceRecording = useCallback(async () => {
+    if (!isOpenAiConfigured) {
+      setError(copy.errors.missingApiKey);
+      return;
+    }
+    const globalNavigator: any = Platform.OS === "web" ? (globalThis as any).navigator : null;
+    if (!globalNavigator?.mediaDevices?.getUserMedia) {
+      setError(copy.errors.voiceWebOnly);
+      return;
+    }
+
+    try {
+      const RecorderCtor = (globalThis as any).MediaRecorder;
+      if (typeof RecorderCtor !== "function") {
+        setError(copy.errors.voiceUnsupported);
+        return;
+      }
+
+      const stream = await globalNavigator.mediaDevices.getUserMedia({ audio: true });
+      recordedChunksRef.current = [];
+      const recorder = new RecorderCtor(stream);
+      recorder.ondataavailable = (event: any) => {
+        if (event.data && event.data.size > 0) {
+          recordedChunksRef.current.push(event.data);
+        }
+      };
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setError(null);
+      setIsRecording(true);
+    } catch (e: any) {
+      const message = e?.message ? String(e.message) : copy.errors.voiceStartFailed;
+      setError(message);
+      setIsRecording(false);
+    }
+  }, [
+    copy.errors.missingApiKey,
+    copy.errors.voiceStartFailed,
+    copy.errors.voiceUnsupported,
+    copy.errors.voiceWebOnly,
+    isOpenAiConfigured,
+  ]);
+
+  const stopVoiceRecording = useCallback(async () => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder) return null;
+
+    return new Promise<any>((resolve, reject) => {
+      recorder.onstop = () => {
+        try {
+          const chunks = recordedChunksRef.current;
+          const BlobCtor = (globalThis as any).Blob;
+          const blob =
+            chunks.length && typeof BlobCtor === "function"
+              ? new BlobCtor(chunks, { type: recorder.mimeType || "audio/webm" })
+              : null;
+          recorder.stream.getTracks().forEach((track: any) => track.stop());
+          mediaRecorderRef.current = null;
+          recordedChunksRef.current = [];
+          resolve(blob);
+        } catch (err) {
+          reject(err);
+        }
+      };
+
+      try {
+        recorder.stop();
+      } catch (err) {
+        mediaRecorderRef.current = null;
+        reject(err);
+      }
+    });
+  }, []);
+
+  const sendMessage = useCallback(
+    async (rawText: string) => {
+      const trimmed = rawText.trim();
+      if (!trimmed || pending) return;
+
+      const userMessage: DisplayMessage = { role: "user", content: trimmed };
+      const nextMessages = [...messagesRef.current, userMessage];
+      setMessages(nextMessages);
+      setPending(true);
+      setError(null);
+
+      try {
+        const reply = await runBookingAgent({
+          systemPrompt,
+          contextSummary,
+          conversation: nextMessages,
+          onBookingsMutated,
+          services,
+        });
+        setMessages((prev) => [...prev, { role: "assistant", content: reply }]);
+      } catch (e: any) {
+        const message = e?.message ? String(e.message) : copy.errors.generic;
+        setError(message);
+      } finally {
+        setPending(false);
+      }
+    },
+    [contextSummary, copy.errors.generic, onBookingsMutated, pending, services, systemPrompt],
+  );
+
+  const handleSend = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setInput("");
+    void sendMessage(trimmed);
+  }, [input, sendMessage]);
+
+  const handleQuickReply = useCallback(
+    (suggestion: string) => {
+      if (!suggestion) return;
+      setInput("");
+      setSuggestionsVisible(false);
+      void sendMessage(suggestion);
+    },
+    [sendMessage],
+  );
+
+  const handleVoicePress = useCallback(async () => {
+    if (pending || voiceTranscribing) return;
+
+    if (isRecording) {
+      setIsRecording(false);
+      setVoiceTranscribing(true);
+      try {
+        const blob = await stopVoiceRecording();
+        if (!blob) {
+          setError(copy.errors.noAudio);
+          return;
+        }
+        const mimeType = blob.type || "audio/webm";
+        const extension = (() => {
+          if (!mimeType) return "webm";
+          if (mimeType.includes("mp4") || mimeType.includes("m4a")) {
+            return "m4a";
+          }
+          if (mimeType.includes("ogg")) {
+            return "ogg";
+          }
+          if (mimeType.includes("wav")) {
+            return "wav";
+          }
+          if (mimeType.includes("mp3")) {
+            return "mp3";
+          }
+          if (mimeType.includes("webm")) {
+            return "webm";
+          }
+          return "webm";
+        })();
+        const transcript = await transcribeAudio({
+          blob,
+          fileName: `voice-message.${extension}`,
+          mimeType,
+        });
+        await sendMessage(transcript);
+      } catch (e: any) {
+        const message = e?.message ? String(e.message) : copy.errors.processFailed;
+        setError(message);
+      } finally {
+        setVoiceTranscribing(false);
+      }
+    } else {
+      await startVoiceRecording();
+    }
+  }, [
+    copy.errors.noAudio,
+    copy.errors.processFailed,
+    isRecording,
+    pending,
+    sendMessage,
+    startVoiceRecording,
+    stopVoiceRecording,
+    voiceTranscribing,
+  ]);
+
+  const showSuggestions = useCallback(() => setSuggestionsVisible(true), []);
+  const hideSuggestions = useCallback(() => setSuggestionsVisible(false), []);
+
+  return {
+    messages,
+    input,
+    setInput,
+    pending,
+    error,
+    canSend,
+    assistantEnabled: isOpenAiConfigured,
+    quickReplies,
+    suggestionsVisible,
+    showSuggestions,
+    hideSuggestions,
+    isRecording,
+    voiceTranscribing,
+    voiceButtonDisabled:
+      !isOpenAiConfigured || pending || voiceTranscribing || (!voiceSupported && !isRecording),
+    handleSend,
+    handleQuickReply,
+    handleVoicePress,
+  };
+}

--- a/src/hooks/useServiceForm.ts
+++ b/src/hooks/useServiceForm.ts
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import type { Service } from "../lib/domain";
+import { createService, updateService } from "../lib/services";
+
+type ServiceFormMode = "create" | "edit";
+
+type ServiceFormCopy = {
+  fields: {
+    nameError: string;
+    durationError: string;
+    priceError: string;
+    iconError: string;
+    durationPlaceholder: string;
+    pricePlaceholder: string;
+  };
+};
+
+type UseServiceFormOptions = {
+  mode: ServiceFormMode;
+  service: Service | null | undefined;
+  copy: ServiceFormCopy;
+  onCreated?: (service: Service) => void;
+  onUpdated?: (service: Service) => void;
+};
+
+type SubmitStatus = "invalid" | "created" | "updated";
+
+type SubmitResult = {
+  status: SubmitStatus;
+  service?: Service;
+};
+
+type UseServiceFormReturn = {
+  isEditMode: boolean;
+  name: string;
+  setName: (value: string) => void;
+  minutesText: string;
+  handleMinutesChange: (text: string) => void;
+  priceText: string;
+  handlePriceChange: (text: string) => void;
+  iconName: keyof typeof MaterialCommunityIcons.glyphMap;
+  selectIcon: (name: keyof typeof MaterialCommunityIcons.glyphMap) => void;
+  iconPickerVisible: boolean;
+  showIconPicker: () => void;
+  hideIconPicker: () => void;
+  iconSearch: string;
+  setIconSearch: (value: string) => void;
+  filteredIcons: (keyof typeof MaterialCommunityIcons.glyphMap)[];
+  iconValid: boolean;
+  errors: Record<string, string>;
+  valid: boolean;
+  saving: boolean;
+  submit: () => Promise<SubmitResult>;
+};
+
+const DEFAULT_ICON: keyof typeof MaterialCommunityIcons.glyphMap = "content-cut";
+
+export function useServiceForm({
+  mode,
+  service = null,
+  copy,
+  onCreated,
+  onUpdated,
+}: UseServiceFormOptions): UseServiceFormReturn {
+  const isEditMode = mode === "edit";
+
+  const [name, setName] = useState(() => (isEditMode && service ? service.name : ""));
+  const [minutesText, setMinutesText] = useState(() =>
+    isEditMode && service
+      ? String(service.estimated_minutes)
+      : copy.fields.durationPlaceholder.replace(/[^0-9]/g, ""),
+  );
+  const [priceText, setPriceText] = useState(() =>
+    isEditMode && service
+      ? centsToInput(service.price_cents)
+      : copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""),
+  );
+  const [iconName, setIconName] = useState<keyof typeof MaterialCommunityIcons.glyphMap>(() =>
+    (isEditMode && service ? service.icon : DEFAULT_ICON) as keyof typeof MaterialCommunityIcons.glyphMap,
+  );
+  const [saving, setSaving] = useState(false);
+  const [iconPickerVisible, setIconPickerVisible] = useState(false);
+  const [iconSearch, setIconSearch] = useState("");
+
+  const setFromService = useCallback(
+    (svc: Service | null) => {
+      if (svc) {
+        setName(svc.name);
+        setMinutesText(String(svc.estimated_minutes));
+        setPriceText(centsToInput(svc.price_cents));
+        setIconName(svc.icon as keyof typeof MaterialCommunityIcons.glyphMap);
+      } else {
+        setName("");
+        setMinutesText(copy.fields.durationPlaceholder.replace(/[^0-9]/g, ""));
+        setPriceText(copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setIconName(DEFAULT_ICON);
+      }
+      setIconPickerVisible(false);
+      setIconSearch("");
+    },
+    [copy.fields.durationPlaceholder, copy.fields.pricePlaceholder],
+  );
+
+  useEffect(() => {
+    if (isEditMode && service) {
+      setFromService(service);
+    } else if (!isEditMode) {
+      setFromService(null);
+    }
+  }, [isEditMode, service, setFromService]);
+
+  const iconNames = useMemo(
+    () => Object.keys(MaterialCommunityIcons.glyphMap) as (keyof typeof MaterialCommunityIcons.glyphMap)[],
+    [],
+  );
+
+  const curatedIconNames = useMemo(() => {
+    const keywords = [
+      "hair",
+      "cut",
+      "razor",
+      "scissor",
+      "comb",
+      "beard",
+      "spa",
+      "spray",
+      "brush",
+      "style",
+      "face",
+      "account",
+    ];
+    const keywordMatches = iconNames.filter((name) =>
+      keywords.some((keyword) => String(name).toLowerCase().includes(keyword)),
+    );
+    const extras = [
+      "content-cut",
+      "hair-dryer",
+      "spray-bottle",
+      "account-tie",
+      "account",
+      "face-woman-shimmer",
+      "face-man-shimmer",
+      "mustache",
+      "tshirt-crew",
+      "eyedropper",
+    ] as (keyof typeof MaterialCommunityIcons.glyphMap)[];
+    const extrasPresent = extras.filter((name) => iconNames.includes(name));
+    const unique = Array.from(new Set([...extrasPresent, ...keywordMatches]));
+    unique.sort();
+    return unique;
+  }, [iconNames]);
+
+  const filteredIcons = useMemo(() => {
+    const query = iconSearch.trim().toLowerCase();
+    const baseList = query ? iconNames : curatedIconNames;
+    const matches = baseList.filter((name) => String(name).toLowerCase().includes(query));
+    if (iconName && !matches.includes(iconName)) {
+      matches.unshift(iconName);
+    }
+    return matches.slice(0, 120);
+  }, [curatedIconNames, iconName, iconNames, iconSearch]);
+
+  const minutes = useMemo(() => {
+    const numeric = Number(minutesText);
+    return Number.isFinite(numeric) ? Math.round(numeric) : NaN;
+  }, [minutesText]);
+
+  const priceCents = useMemo(() => parsePrice(priceText), [priceText]);
+
+  const iconValid = useMemo(
+    () => !!MaterialCommunityIcons.glyphMap[iconName as keyof typeof MaterialCommunityIcons.glyphMap],
+    [iconName],
+  );
+
+  const errors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = copy.fields.nameError;
+    if (!Number.isFinite(minutes) || minutes <= 0) errs.minutes = copy.fields.durationError;
+    if (!Number.isFinite(priceCents) || priceCents < 0) errs.price = copy.fields.priceError;
+    if (!iconValid) errs.icon = copy.fields.iconError;
+    return errs;
+  }, [copy.fields.durationError, copy.fields.iconError, copy.fields.nameError, copy.fields.priceError, iconValid, minutes, name, priceCents]);
+
+  const readyToSubmit = useMemo(
+    () => Object.keys(errors).length === 0 && (!isEditMode || !!service),
+    [errors, isEditMode, service],
+  );
+
+  const valid = readyToSubmit && !saving;
+
+  const handleMinutesChange = useCallback((text: string) => {
+    setMinutesText(text.replace(/[^0-9]/g, ""));
+  }, []);
+
+  const handlePriceChange = useCallback((text: string) => {
+    setPriceText(text.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const showIconPicker = useCallback(() => {
+    setIconPickerVisible(true);
+  }, []);
+
+  const hideIconPicker = useCallback(() => {
+    setIconPickerVisible(false);
+    setIconSearch("");
+  }, []);
+
+  const selectIcon = useCallback(
+    (next: keyof typeof MaterialCommunityIcons.glyphMap) => {
+      setIconName(next);
+      hideIconPicker();
+    },
+    [hideIconPicker],
+  );
+
+  const submit = useCallback(async (): Promise<SubmitResult> => {
+    if (!readyToSubmit || saving) {
+      return { status: "invalid" };
+    }
+    setSaving(true);
+    try {
+      if (isEditMode && service) {
+        const updated = await updateService(service.id, {
+          name: name.trim(),
+          estimated_minutes: minutes,
+          price_cents: priceCents,
+          icon: iconName,
+        });
+        setFromService(updated);
+        onUpdated?.(updated);
+        return { status: "updated", service: updated };
+      }
+
+      const created = await createService({
+        name: name.trim(),
+        estimated_minutes: minutes,
+        price_cents: priceCents,
+        icon: iconName,
+      });
+      setFromService(null);
+      onCreated?.(created);
+      return { status: "created", service: created };
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    iconName,
+    isEditMode,
+    minutes,
+    name,
+    onCreated,
+    onUpdated,
+    priceCents,
+    readyToSubmit,
+    saving,
+    service,
+    setFromService,
+  ]);
+
+  return {
+    isEditMode,
+    name,
+    setName,
+    minutesText,
+    handleMinutesChange,
+    priceText,
+    handlePriceChange,
+    iconName,
+    selectIcon,
+    iconPickerVisible,
+    showIconPicker,
+    hideIconPicker,
+    iconSearch,
+    setIconSearch,
+    filteredIcons,
+    iconValid,
+    errors,
+    valid,
+    saving,
+    submit,
+  };
+}
+
+export function parsePrice(input: string): number {
+  if (!input) return NaN;
+  const normalized = input.replace(/[^0-9.,]/g, "").replace(/,/g, ".");
+  const value = Number.parseFloat(normalized);
+  if (!Number.isFinite(value)) return NaN;
+  return Math.round(value * 100);
+}
+
+export function centsToInput(cents: number) {
+  if (!Number.isFinite(cents)) return "0.00";
+  return (Math.round(cents) / 100).toFixed(2);
+}


### PR DESCRIPTION
## Summary
- extract service form state, validation, and persistence orchestration into a reusable `useServiceForm` hook and simplify the UI component to presentation concerns
- introduce a `useAssistantChat` hook that manages assistant conversation, quick replies, and voice capture workflows, leaving the component focused on rendering
- update `ServiceForm` and `AssistantChat` components to consume the new hooks and keep user feedback (alerts, accessibility) localized to the views

## Testing
- `npm run test` *(fails: vitest binary missing because npm install is blocked by registry 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ddba1f7083279f41f076cbc75f52