### PR TITLE
Introduce booking gateway abstraction

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,7 +16,6 @@ import {
   Linking,
 } from "react-native";
 import Svg, { Circle, G } from "react-native-svg";
-import { supabase } from "./src/lib/supabase";
 import { MaterialCommunityIcons, Ionicons } from "@expo/vector-icons";
 import * as Localization from "expo-localization";
 
@@ -137,7 +136,9 @@ const buildDateTime = (
 import {
   getBookings,
   getBookingsForRange,
+  getBookingsForDates,
   createBooking,
+  createBookingsBulk,
   cancelBooking,
   listCustomers,
   listRecentBookings,
@@ -1490,11 +1491,7 @@ export default function App() {
     try {
       setLoading(true);
       const dates = Array.from(new Set(raw.map((r) => r.date)));
-      const { data: existingAll, error } = await supabase
-        .from("bookings")
-        .select('id,date,start,"end",service_id,barber')
-        .in("date", dates);
-      if (error) throw error;
+      const existingAll = await getBookingsForDates(dates);
 
       const byDate = new Map<string, { start: string; end: string; barber: string }[]>();
       (existingAll ?? []).forEach((b) => {
@@ -1554,8 +1551,7 @@ export default function App() {
     }
     try {
       setLoading(true);
-      const { error } = await supabase.from("bookings").insert(toInsert);
-      if (error) throw error;
+      await createBookingsBulk(toInsert);
       setPreviewOpen(false);
       await load();
       await loadWeek();

--- a/src/lib/gateways/bookingGateway.ts
+++ b/src/lib/gateways/bookingGateway.ts
@@ -1,0 +1,209 @@
+import { supabase } from "../supabase";
+import type { Customer, DbBooking } from "../types/booking";
+
+export type GatewayResult<T> = {
+  data: T;
+  status: number;
+};
+
+export class PersistenceError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "PersistenceError";
+    this.status = status;
+  }
+}
+
+export interface BookingGateway {
+  fetchBookingsByDate(date: string): Promise<GatewayResult<DbBooking[]>>;
+  fetchBookingsForRange(startDate: string, endDate: string): Promise<GatewayResult<DbBooking[]>>;
+  fetchRecentBookings(limit: number): Promise<GatewayResult<DbBooking[]>>;
+  insertBooking(payload: {
+    date: string;
+    start: string;
+    end: string;
+    service_id: string;
+    barber: string;
+    customer_id?: string | null;
+  }): Promise<GatewayResult<{ id: string | null }>>;
+  deleteBooking(id: string): Promise<GatewayResult<{ deleted: number }>>;
+  fetchCustomersByIds(ids: readonly string[]): Promise<GatewayResult<Customer[]>>;
+  searchCustomers(opts: { query?: string | null; limit?: number }): Promise<GatewayResult<Customer[]>>;
+  findCustomerById(id: string): Promise<GatewayResult<Customer | null>>;
+  findCustomerByPhone(phone: string): Promise<GatewayResult<Customer | null>>;
+  insertCustomer(payload: {
+    first_name: string;
+    last_name: string;
+    phone: string;
+  }): Promise<GatewayResult<Customer>>;
+  fetchBookingsForDates(dates: readonly string[]): Promise<GatewayResult<DbBooking[]>>;
+  insertManyBookings(payload: {
+    date: string;
+    start: string;
+    end: string;
+    service_id: string;
+    barber: string;
+    customer_id?: string | null;
+  }[]): Promise<GatewayResult<null>>;
+}
+
+class SupabaseBookingGateway implements BookingGateway {
+  async fetchBookingsByDate(date: string): Promise<GatewayResult<DbBooking[]>> {
+    const { data, error, status } = await supabase
+      .from("bookings")
+      .select('id,date,start,"end",service_id,barber,customer_id')
+      .eq("date", date)
+      .order("start");
+    if (error) throw new PersistenceError("Failed to fetch bookings by date", status, { cause: error });
+    return { data: (data ?? []) as DbBooking[], status };
+  }
+
+  async fetchBookingsForRange(startDate: string, endDate: string): Promise<GatewayResult<DbBooking[]>> {
+    const { data, error, status } = await supabase
+      .from("bookings")
+      .select('id,date,start,"end",service_id,barber,customer_id')
+      .gte("date", startDate)
+      .lte("date", endDate)
+      .order("date")
+      .order("start");
+    if (error) throw new PersistenceError("Failed to fetch bookings for range", status, { cause: error });
+    return { data: (data ?? []) as DbBooking[], status };
+  }
+
+  async fetchRecentBookings(limit: number): Promise<GatewayResult<DbBooking[]>> {
+    const { data, error, status } = await supabase
+      .from("bookings")
+      .select('id,date,start,"end",service_id,barber,customer_id')
+      .order("date", { ascending: false })
+      .order("start", { ascending: false })
+      .limit(limit);
+    if (error) throw new PersistenceError("Failed to fetch recent bookings", status, { cause: error });
+    return { data: (data ?? []) as DbBooking[], status };
+  }
+
+  async insertBooking(payload: {
+    date: string;
+    start: string;
+    end: string;
+    service_id: string;
+    barber: string;
+    customer_id?: string | null;
+  }): Promise<GatewayResult<{ id: string | null }>> {
+    const { data, error, status } = await supabase.from("bookings").insert(payload).select("id").single();
+    if (error) throw new PersistenceError("Failed to create booking", status, { cause: error });
+    return { data: { id: data?.id ?? null }, status };
+  }
+
+  async deleteBooking(id: string): Promise<GatewayResult<{ deleted: number }>> {
+    const { data, error, status } = await supabase.from("bookings").delete().eq("id", id);
+    if (error) throw new PersistenceError("Failed to delete booking", status, { cause: error });
+    return { data: { deleted: Array.isArray(data) ? data.length : 0 }, status };
+  }
+
+  async fetchCustomersByIds(ids: readonly string[]): Promise<GatewayResult<Customer[]>> {
+    const { data, error, status } = await supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .in("id", ids as string[]);
+    if (error) throw new PersistenceError("Failed to fetch customers by ids", status, { cause: error });
+    return { data: (data ?? []) as Customer[], status };
+  }
+
+  async searchCustomers(opts: { query?: string | null; limit?: number }): Promise<GatewayResult<Customer[]>> {
+    const limit = opts.limit ?? 20;
+    const query = opts.query?.trim();
+    let request = supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth");
+
+    if (query) {
+      request = request.or(
+        `first_name.ilike.%${query}%,last_name.ilike.%${query}%,email.ilike.%${query}%,phone.ilike.%${query}%`,
+      );
+    } else {
+      request = request.order("first_name");
+    }
+
+    request = request.limit(limit);
+
+    const { data, error, status } = await request;
+    if (error) throw new PersistenceError("Failed to search customers", status, { cause: error });
+    return { data: (data ?? []) as Customer[], status };
+  }
+
+  async findCustomerById(id: string): Promise<GatewayResult<Customer | null>> {
+    const { data, error, status } = await supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw new PersistenceError("Failed to fetch customer by id", status, { cause: error });
+    return { data: (data ?? null) as Customer | null, status };
+  }
+
+  async findCustomerByPhone(phone: string): Promise<GatewayResult<Customer | null>> {
+    const { data, error, status } = await supabase
+      .from("customers")
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .eq("phone", phone)
+      .maybeSingle();
+    if (error) throw new PersistenceError("Failed to fetch customer by phone", status, { cause: error });
+    return { data: (data ?? null) as Customer | null, status };
+  }
+
+  async insertCustomer(payload: {
+    first_name: string;
+    last_name: string;
+    phone: string;
+  }): Promise<GatewayResult<Customer>> {
+    const { data, error, status } = await supabase
+      .from("customers")
+      .insert(payload)
+      .select("id,first_name,last_name,phone,email,date_of_birth")
+      .single();
+    if (error) throw new PersistenceError("Failed to create customer", status, { cause: error });
+    return { data: data as Customer, status };
+  }
+
+  async fetchBookingsForDates(dates: readonly string[]): Promise<GatewayResult<DbBooking[]>> {
+    const { data, error, status } = await supabase
+      .from("bookings")
+      .select('id,date,start,"end",service_id,barber,customer_id')
+      .in("date", dates as string[]);
+    if (error) throw new PersistenceError("Failed to fetch bookings for dates", status, { cause: error });
+    return { data: (data ?? []) as DbBooking[], status };
+  }
+
+  async insertManyBookings(payload: {
+    date: string;
+    start: string;
+    end: string;
+    service_id: string;
+    barber: string;
+    customer_id?: string | null;
+  }[]): Promise<GatewayResult<null>> {
+    const { error, status } = await supabase.from("bookings").insert(payload);
+    if (error) throw new PersistenceError("Failed to create bookings", status, { cause: error });
+    return { data: null, status };
+  }
+}
+
+let activeGateway: BookingGateway = new SupabaseBookingGateway();
+
+export function getBookingGateway(): BookingGateway {
+  return activeGateway;
+}
+
+export function setBookingGateway(gateway: BookingGateway): void {
+  activeGateway = gateway;
+}
+
+export function resetBookingGateway(): void {
+  activeGateway = new SupabaseBookingGateway();
+}
+
+export function createSupabaseBookingGateway(): BookingGateway {
+  return new SupabaseBookingGateway();
+}

--- a/src/lib/types/booking.ts
+++ b/src/lib/types/booking.ts
@@ -1,0 +1,18 @@
+export type DbBooking = {
+  id: string;
+  date: string;
+  start: string;
+  end: string;
+  service_id: string;
+  barber: string;
+  customer_id?: string | null;
+};
+
+export type Customer = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  phone?: string | null;
+  email?: string | null;
+  date_of_birth?: string | null;
+};

--- a/tests/bookingService/setup.ts
+++ b/tests/bookingService/setup.ts
@@ -1,5 +1,6 @@
 import { beforeEach, vi } from "vitest";
 import { supabaseMock } from "./testUtils/supabaseMock";
+import { resetBookingGateway } from "../../src/lib/gateways/bookingGateway";
 
 vi.mock("../../src/lib/supabase", () => ({
   supabase: supabaseMock.client,
@@ -7,4 +8,5 @@ vi.mock("../../src/lib/supabase", () => ({
 
 beforeEach(() => {
   supabaseMock.reset();
+  resetBookingGateway();
 });


### PR DESCRIPTION
## Summary
- extract booking and customer record types into a shared module
- add a Supabase-backed booking gateway and expose helper setters for overriding it
- refactor booking services and recurrence flows to route all persistence through the gateway abstraction

## Testing
- npm test *(fails: local vitest binary unavailable without installing dependencies; npm install blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e3e27b948327a6d1ac215cfb535a