### PR TITLE
Externalize component copy and theme defaults

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import {
   formatPrice,
 } from "./src/lib/domain";
 import { polyglotServices } from "./src/lib/polyglot";
+import { COMPONENT_COPY } from "./src/locales/componentCopy";
 
 const getTodayDateKey = () => toDateKey(new Date());
 
@@ -298,82 +299,9 @@ const LANGUAGE_COPY = {
         deleteErrorTitle: "Delete service",
       },
     },
-    serviceForm: {
-      createTitle: "Register a service",
-      editTitle: "Edit service",
-      createSubtitle: "Services define the duration and price of each booking.",
-      editSubtitle: "Adjust the duration, price, or icon for this service.",
-      fields: {
-        nameLabel: "Name",
-        namePlaceholder: "Cut & Style",
-        nameError: "Name is required",
-        durationLabel: "Duration (minutes)",
-        durationPlaceholder: "45",
-        durationError: "Enter minutes > 0",
-        priceLabel: "Price",
-        pricePlaceholder: "30.00",
-        priceError: "Enter a valid price",
-        iconLabel: "Icon",
-        iconPlaceholder: "Choose an icon",
-        iconError: "Select an icon",
-        previewLabel: "Preview:",
-      },
-      buttons: {
-        create: "Create service",
-        edit: "Save changes",
-        saving: "Saving…",
-        cancel: "Cancel",
-      },
-      accessibility: {
-        submitCreate: "Create service",
-        submitEdit: "Save service changes",
-        cancel: "Cancel service form",
-      },
-      alerts: {
-        createdTitle: "Service created",
-        createdMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-        updatedTitle: "Service updated",
-        updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-        createErrorTitle: "Create service failed",
-        updateErrorTitle: "Update service failed",
-      },
-    },
+    serviceForm: COMPONENT_COPY.en.serviceForm,
     assistant: {
-      chat: {
-        initialMessage:
-          "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.",
-        apiKeyWarning: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.",
-        contextPrefix: "Booking context:",
-        quickRepliesTitle: "Suggested prompts",
-        quickRepliesToggleShow: "Show suggestions",
-        quickRepliesToggleHide: "Hide quick suggestions",
-        quickReplyAccessibility: (suggestion: string) => `Send quick message: ${suggestion}`,
-        quickReplies: {
-          existingBookings: "Show my existing bookings",
-          bookService: "Help me book a service",
-          bookSpecificService: (serviceName: string) => `Book a ${serviceName}`,
-          barberAvailability: (barberName: string) => `Available hours for ${barberName}`,
-        },
-        inputPlaceholder: "Ask about bookings...",
-        sendAccessibility: "Send message",
-        suggestionsAccessibility: {
-          show: "Show quick suggestions",
-          hide: "Hide quick suggestions",
-        },
-        voiceButtonAccessibility: {
-          start: "Start voice input",
-          stop: "Stop voice input",
-        },
-        errors: {
-          generic: "Something went wrong.",
-          missingApiKey: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.",
-          voiceWebOnly: "Voice capture is currently supported on the web experience only.",
-          voiceUnsupported: "Voice capture is not supported in this browser.",
-          voiceStartFailed: "Unable to start voice recording.",
-          noAudio: "No audio captured. Try again.",
-          processFailed: "Failed to process voice message.",
-        },
-      },
+      chat: COMPONENT_COPY.en.assistantChat,
       contextSummary: {
         hours: (start: string, end: string) => `Hours: ${start}–${end}`,
         services: (list: string) => `Services: ${list}`,
@@ -423,48 +351,10 @@ const LANGUAGE_COPY = {
         ],
       },
     },
-    imageAssistant: {
-      title: "Image assistant",
-      subtitle: {
-        before: "Generate marketing visuals for your shop using the OpenAI image API deployed under ",
-        highlight: "/api/GenerateImage",
-        after: ".",
-      },
-      helperMessage:
-        "Set EXPO_PUBLIC_IMAGE_API_TOKEN to authenticate requests to the GenerateImage function.",
-      promptLabel: "Prompt",
-      promptPlaceholder:
-        "Create a premium hero image for a barber shop website featuring a modern haircut session.",
-      sizeLabel: "Size",
-      sizeOptions: [
-        { label: "Square • 256px", value: "256x256" },
-        { label: "Detailed • 512px", value: "512x512" },
-        { label: "Showcase • 1024px", value: "1024x1024" },
-      ] as const,
-      qualityLabel: "Quality",
-      qualityOptions: [
-        { label: "Standard", value: "standard", helper: "Fastest option for quick previews." },
-        { label: "HD", value: "hd", helper: "Sharper output, slightly slower." },
-      ] as const,
-      optionAccessibility: {
-        size: (label: string) => `Select ${label} size`,
-        quality: (label: string) => `Use ${label} quality`,
-      },
-      generateButton: "Generate image",
-      generateAccessibility: "Generate marketing image",
-      errors: {
-        generateFailed: "Unable to generate image.",
-      },
-      history: {
-        title: "Recent results",
-        clearLabel: "Clear",
-        clearAccessibility: "Clear generated images",
-        promptLabel: "Prompt:",
-        revisedPrefix: "Revised prompt:",
-        meta: (size: string, quality: string) => `Size: ${size} • Quality: ${quality}`,
-        generatedAt: (timestamp: string) => `Generated ${timestamp}`,
-      },
-    },
+    imageAssistant: COMPONENT_COPY.en.imageAssistant,
+    userForm: COMPONENT_COPY.en.userForm,
+    recurrenceModal: COMPONENT_COPY.en.recurrenceModal,
+    occurrencePreview: COMPONENT_COPY.en.occurrencePreview,
     weekTitle: "This week",
     overviewSubtitle: (range?: string | null) =>
       `Overview of bookings scheduled for ${range?.trim() ? range : "the current week"}.`,
@@ -672,82 +562,9 @@ const LANGUAGE_COPY = {
         deleteErrorTitle: "Excluir serviço",
       },
     },
-    serviceForm: {
-      createTitle: "Cadastrar serviço",
-      editTitle: "Editar serviço",
-      createSubtitle: "Os serviços definem a duração e o preço de cada agendamento.",
-      editSubtitle: "Ajuste a duração, o preço ou o ícone deste serviço.",
-      fields: {
-        nameLabel: "Nome",
-        namePlaceholder: "Corte & Estilo",
-        nameError: "Nome é obrigatório",
-        durationLabel: "Duração (minutos)",
-        durationPlaceholder: "45",
-        durationError: "Informe minutos > 0",
-        priceLabel: "Preço",
-        pricePlaceholder: "30,00",
-        priceError: "Informe um preço válido",
-        iconLabel: "Ícone",
-        iconPlaceholder: "Escolha um ícone",
-        iconError: "Selecione um ícone válido",
-        previewLabel: "Prévia:",
-      },
-      buttons: {
-        create: "Criar serviço",
-        edit: "Salvar alterações",
-        saving: "Salvando…",
-        cancel: "Cancelar",
-      },
-      accessibility: {
-        submitCreate: "Criar serviço",
-        submitEdit: "Salvar alterações do serviço",
-        cancel: "Cancelar formulário de serviço",
-      },
-      alerts: {
-        createdTitle: "Serviço criado",
-        createdMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-        updatedTitle: "Serviço atualizado",
-        updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-        createErrorTitle: "Falha ao criar serviço",
-        updateErrorTitle: "Falha ao atualizar serviço",
-      },
-    },
+    serviceForm: COMPONENT_COPY.pt.serviceForm,
     assistant: {
-      chat: {
-        initialMessage:
-          "Olá! Sou o seu agente AIBarber. Posso verificar disponibilidade, agendar serviços e cancelar compromissos existentes para você.",
-        apiKeyWarning: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar o assistente.",
-        contextPrefix: "Contexto de agendamentos:",
-        quickRepliesTitle: "Prompts sugeridos",
-        quickRepliesToggleShow: "Mostrar sugestões",
-        quickRepliesToggleHide: "Ocultar sugestões rápidas",
-        quickReplyAccessibility: (suggestion: string) => `Enviar mensagem rápida: ${suggestion}`,
-        quickReplies: {
-          existingBookings: "Mostrar meus agendamentos",
-          bookService: "Ajudar a agendar um serviço",
-          bookSpecificService: (serviceName: string) => `Agendar ${serviceName}`,
-          barberAvailability: (barberName: string) => `Horários disponíveis para ${barberName}`,
-        },
-        inputPlaceholder: "Pergunte sobre os agendamentos...",
-        sendAccessibility: "Enviar mensagem",
-        suggestionsAccessibility: {
-          show: "Mostrar sugestões rápidas",
-          hide: "Ocultar sugestões rápidas",
-        },
-        voiceButtonAccessibility: {
-          start: "Iniciar entrada por voz",
-          stop: "Parar entrada por voz",
-        },
-        errors: {
-          generic: "Algo deu errado.",
-          missingApiKey: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar a entrada por voz.",
-          voiceWebOnly: "A captura de voz está disponível apenas na experiência web no momento.",
-          voiceUnsupported: "A captura de voz não é suportada neste navegador.",
-          voiceStartFailed: "Não foi possível iniciar a gravação de voz.",
-          noAudio: "Nenhum áudio capturado. Tente novamente.",
-          processFailed: "Falha ao processar a mensagem de voz.",
-        },
-      },
+      chat: COMPONENT_COPY.pt.assistantChat,
       contextSummary: {
         hours: (start: string, end: string) => `Horário: ${start}–${end}`,
         services: (list: string) => `Serviços: ${list}`,
@@ -797,48 +614,10 @@ const LANGUAGE_COPY = {
         ],
       },
     },
-    imageAssistant: {
-      title: "Laboratório de imagens",
-      subtitle: {
-        before: "Gere visuais de marketing para a sua barbearia usando a API de imagens da OpenAI disponível em ",
-        highlight: "/api/GenerateImage",
-        after: ".",
-      },
-      helperMessage:
-        "Defina EXPO_PUBLIC_IMAGE_API_TOKEN para autenticar as requisições para a função GenerateImage.",
-      promptLabel: "Prompt",
-      promptPlaceholder:
-        "Crie uma imagem hero premium para o site de uma barbearia mostrando um corte moderno.",
-      sizeLabel: "Tamanho",
-      sizeOptions: [
-        { label: "Quadrado • 256px", value: "256x256" },
-        { label: "Detalhado • 512px", value: "512x512" },
-        { label: "Vitrine • 1024px", value: "1024x1024" },
-      ] as const,
-      qualityLabel: "Qualidade",
-      qualityOptions: [
-        { label: "Padrão", value: "standard", helper: "Opção mais rápida para pré-visualizações." },
-        { label: "HD", value: "hd", helper: "Resultado mais nítido, um pouco mais lento." },
-      ] as const,
-      optionAccessibility: {
-        size: (label: string) => `Selecionar tamanho ${label}`,
-        quality: (label: string) => `Usar qualidade ${label}`,
-      },
-      generateButton: "Gerar imagem",
-      generateAccessibility: "Gerar imagem de marketing",
-      errors: {
-        generateFailed: "Não foi possível gerar a imagem.",
-      },
-      history: {
-        title: "Resultados recentes",
-        clearLabel: "Limpar",
-        clearAccessibility: "Limpar imagens geradas",
-        promptLabel: "Prompt:",
-        revisedPrefix: "Prompt revisado:",
-        meta: (size: string, quality: string) => `Tamanho: ${size} • Qualidade: ${quality}`,
-        generatedAt: (timestamp: string) => `Gerado em ${timestamp}`,
-      },
-    },
+    imageAssistant: COMPONENT_COPY.pt.imageAssistant,
+    userForm: COMPONENT_COPY.pt.userForm,
+    recurrenceModal: COMPONENT_COPY.pt.recurrenceModal,
+    occurrencePreview: COMPONENT_COPY.pt.occurrencePreview,
     weekTitle: "Esta semana",
     overviewSubtitle: (range?: string | null) =>
       `Visão geral dos agendamentos marcados para ${range?.trim() ? range : "a semana atual"}.`,
@@ -2420,6 +2199,7 @@ export default function App() {
           fixedService={selectedLocalizedService?.name ?? ""}
           fixedBarber={BARBER_MAP[selectedBarber.id]?.name || selectedBarber.id}
           colors={{ text: colors.text, subtext: colors.subtext, surface: colors.surface, border: colors.border, accent: colors.accent, bg: colors.sidebarBg }}
+          copy={copy.recurrenceModal}
         />
         <OccurrencePreviewModal
           visible={previewOpen}
@@ -2427,6 +2207,7 @@ export default function App() {
           onClose={() => setPreviewOpen(false)}
           onConfirm={confirmPreviewInsert}
           colors={{ text: colors.text, subtext: colors.subtext, surface: colors.surface, border: colors.border, accent: colors.accent, bg: colors.bg, danger: colors.danger }}
+          copy={copy.occurrencePreview}
         />
 
         {/* Modal de clientes (lista + criar via UserForm) */}
@@ -3522,6 +3303,7 @@ function ClientModal({
                     accentFgOn: colors.accentFgOn,
                     danger: colors.danger,
                   }}
+                  copy={copy.userForm}
                 />
               </View>
             )}

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -13,43 +13,9 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 
 import type { Service } from "../lib/domain";
-import { useAssistantChat, type AssistantChatCopy } from "../hooks/useAssistantChat";
-
-const DEFAULT_COPY: AssistantChatCopy = {
-  initialMessage:
-    "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.",
-  apiKeyWarning: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.",
-  contextPrefix: "Booking context:",
-  quickRepliesTitle: "Suggested prompts",
-  quickRepliesToggleShow: "Show suggestions",
-  quickRepliesToggleHide: "Hide quick suggestions",
-  quickReplyAccessibility: (suggestion: string) => `Send quick message: ${suggestion}`,
-  quickReplies: {
-    existingBookings: "Show my existing bookings",
-    bookService: "Help me book a service",
-    bookSpecificService: (serviceName: string) => `Book a ${serviceName}`,
-    barberAvailability: (barberName: string) => `Available hours for ${barberName}`,
-  },
-  inputPlaceholder: "Ask about bookings...",
-  sendAccessibility: "Send message",
-  suggestionsAccessibility: {
-    show: "Show quick suggestions",
-    hide: "Hide quick suggestions",
-  },
-  voiceButtonAccessibility: {
-    start: "Start voice input",
-    stop: "Stop voice input",
-  },
-  errors: {
-    generic: "Something went wrong.",
-    missingApiKey: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.",
-    voiceWebOnly: "Voice capture is currently supported on the web experience only.",
-    voiceUnsupported: "Voice capture is not supported in this browser.",
-    voiceStartFailed: "Unable to start voice recording.",
-    noAudio: "No audio captured. Try again.",
-    processFailed: "Failed to process voice message.",
-  },
-};
+import { useAssistantChat } from "../hooks/useAssistantChat";
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { AssistantChatCopy } from "../locales/types";
 
 type AssistantChatProps = {
   colors: {
@@ -75,7 +41,7 @@ export default function AssistantChat({
   contextSummary,
   onBookingsMutated,
   services,
-  copy = DEFAULT_COPY,
+  copy = defaultComponentCopy.assistantChat,
 }: AssistantChatProps) {
   const scrollRef = useRef<ScrollView>(null);
 

--- a/src/components/ImageAssistant.tsx
+++ b/src/components/ImageAssistant.tsx
@@ -15,75 +15,8 @@ import {
   isImageApiConfigured,
   type GenerateImageResponse,
 } from "../lib/imageApi";
-
-type ImageAssistantCopy = {
-  title: string;
-  subtitle: { before: string; highlight: string; after: string };
-  helperMessage: string;
-  promptLabel: string;
-  promptPlaceholder: string;
-  sizeLabel: string;
-  sizeOptions: ReadonlyArray<{ label: string; value: "256x256" | "512x512" | "1024x1024" }>;
-  qualityLabel: string;
-  qualityOptions: ReadonlyArray<{ label: string; value: "standard" | "hd"; helper: string }>;
-  optionAccessibility: {
-    size: (label: string) => string;
-    quality: (label: string) => string;
-  };
-  generateButton: string;
-  generateAccessibility: string;
-  errors: { generateFailed: string };
-  history: {
-    title: string;
-    clearLabel: string;
-    clearAccessibility: string;
-    promptLabel: string;
-    revisedPrefix: string;
-    meta: (size: string, quality: string) => string;
-    generatedAt: (timestamp: string) => string;
-  };
-};
-
-const DEFAULT_COPY: ImageAssistantCopy = {
-  title: "Image assistant",
-  subtitle: {
-    before: "Generate marketing visuals for your shop using the OpenAI image API deployed under ",
-    highlight: "/api/GenerateImage",
-    after: ".",
-  },
-  helperMessage: "Set EXPO_PUBLIC_IMAGE_API_TOKEN to authenticate requests to the GenerateImage function.",
-  promptLabel: "Prompt",
-  promptPlaceholder: "Create a premium hero image for a barber shop website featuring a modern haircut session.",
-  sizeLabel: "Size",
-  sizeOptions: [
-    { label: "Square • 256px", value: "256x256" },
-    { label: "Detailed • 512px", value: "512x512" },
-    { label: "Showcase • 1024px", value: "1024x1024" },
-  ],
-  qualityLabel: "Quality",
-  qualityOptions: [
-    { label: "Standard", value: "standard", helper: "Fastest option for quick previews." },
-    { label: "HD", value: "hd", helper: "Sharper output, slightly slower." },
-  ],
-  optionAccessibility: {
-    size: (label: string) => `Select ${label} size`,
-    quality: (label: string) => `Use ${label} quality`,
-  },
-  generateButton: "Generate image",
-  generateAccessibility: "Generate marketing image",
-  errors: {
-    generateFailed: "Unable to generate image.",
-  },
-  history: {
-    title: "Recent results",
-    clearLabel: "Clear",
-    clearAccessibility: "Clear generated images",
-    promptLabel: "Prompt:",
-    revisedPrefix: "Revised prompt:",
-    meta: (size: string, quality: string) => `Size: ${size} • Quality: ${quality}`,
-    generatedAt: (timestamp: string) => `Generated ${timestamp}`,
-  },
-};
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { ImageAssistantCopy } from "../locales/types";
 
 type ImageAssistantProps = {
   colors: {
@@ -114,7 +47,10 @@ function toDataUri(image: GenerateImageResponse["data"]): string {
   throw new Error("The image response did not include any renderable data.");
 }
 
-export default function ImageAssistant({ colors, copy = DEFAULT_COPY }: ImageAssistantProps) {
+export default function ImageAssistant({
+  colors,
+  copy = defaultComponentCopy.imageAssistant,
+}: ImageAssistantProps) {
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<"256x256" | "512x512" | "1024x1024">("1024x1024");
   const [quality, setQuality] = useState<"standard" | "hd">("standard");

--- a/src/components/OccurrencePreviewModal.tsx
+++ b/src/components/OccurrencePreviewModal.tsx
@@ -2,6 +2,10 @@
 import React from "react";
 import { Modal, View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
 
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { OccurrencePreviewCopy } from "../locales/types";
+import { modalColorsWithDanger, type ModalColorsWithDanger } from "../theme/colors";
+
 export type PreviewItem = {
   date: string;   // YYYY-MM-DD
   start: string;  // HH:MM
@@ -15,22 +19,17 @@ type Props = {
   items: PreviewItem[];
   onClose: () => void;
   onConfirm: () => void;
-  colors?: {
-    text: string; subtext: string; surface: string; border: string; accent: string; bg: string; danger: string;
-  };
+  colors?: ModalColorsWithDanger;
+  copy?: OccurrencePreviewCopy;
 };
 
 export default function OccurrencePreviewModal({
-  visible, items, onClose, onConfirm,
-  colors = {
-    text: "#e5e7eb",
-    subtext: "#cbd5e1",
-    surface: "rgba(255,255,255,0.06)",
-    border: "rgba(255,255,255,0.12)",
-    accent: "#60a5fa",
-    bg: "#0b0d13",
-    danger: "#ef4444",
-  }
+  visible,
+  items,
+  onClose,
+  onConfirm,
+  colors = modalColorsWithDanger,
+  copy = defaultComponentCopy.occurrencePreview,
 }: Props) {
   const okCount = items.filter(i => i.ok).length;
   const badCount = items.length - okCount;
@@ -39,20 +38,22 @@ export default function OccurrencePreviewModal({
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.backdrop}>
         <View style={[styles.sheet, { backgroundColor: colors.bg, borderColor: colors.border }]}>
-          <Text style={[styles.title, { color: colors.text }]}>Preview recurring bookings</Text>
-          <Text style={{ color: colors.subtext, marginBottom: 8 }}>
-            {okCount} will be created {badCount ? `• ${badCount} skipped` : ""}
-          </Text>
+          <Text style={[styles.title, { color: colors.text }]}>{copy.title}</Text>
+          <Text style={{ color: colors.subtext, marginBottom: 8 }}>{copy.summary(okCount, badCount)}</Text>
 
           <View style={[styles.headerRow, { borderColor: colors.border }]}>
-            <Text style={[styles.hCell, { color: colors.subtext }]}>Date</Text>
-            <Text style={[styles.hCell, { color: colors.subtext }]}>Time</Text>
-            <Text style={[styles.hCell, { color: colors.subtext }]}>Status</Text>
+            <Text style={[styles.hCell, { color: colors.subtext }]}>{copy.headers.date}</Text>
+            <Text style={[styles.hCell, { color: colors.subtext }]}>{copy.headers.time}</Text>
+            <Text style={[styles.hCell, { color: colors.subtext }]}>{copy.headers.status}</Text>
           </View>
 
           <ScrollView style={{ maxHeight: 360 }}>
             {items.map((it, idx) => {
-              const status = it.ok ? "OK" : (it.reason === "conflict" ? "Conflict" : "Outside hours");
+              const status = it.ok
+                ? copy.status.ok
+                : it.reason === "conflict"
+                  ? copy.status.conflict
+                  : copy.status.outsideHours;
               const color = it.ok ? colors.text : colors.danger;
               return (
                 <View key={idx} style={[styles.row, { borderColor: colors.border, backgroundColor: colors.surface }]}>
@@ -66,7 +67,7 @@ export default function OccurrencePreviewModal({
 
           <View style={{ flexDirection: "row", justifyContent: "flex-end", gap: 10, marginTop: 12 }}>
             <Pressable style={[styles.btn, { borderColor: colors.border }]} onPress={onClose}>
-              <Text style={{ color: colors.subtext, fontWeight: "700" }}>Back</Text>
+              <Text style={{ color: colors.subtext, fontWeight: "700" }}>{copy.actions.back}</Text>
             </Pressable>
             <Pressable
               disabled={okCount === 0}
@@ -81,7 +82,7 @@ export default function OccurrencePreviewModal({
               onPress={onConfirm}
             >
               <Text style={{ color: okCount ? "#071018" : colors.subtext, fontWeight: "800" }}>
-                Create {okCount}
+                {copy.actions.confirm(okCount)}
               </Text>
             </Pressable>
           </View>

--- a/src/components/RecurrenceModal.tsx
+++ b/src/components/RecurrenceModal.tsx
@@ -2,6 +2,10 @@
 import React, { useState } from "react";
 import { Modal, View, Text, Pressable, TextInput, StyleSheet } from "react-native";
 
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { RecurrenceModalCopy } from "../locales/types";
+import { modalColors, type ModalColors } from "../theme/colors";
+
 type Props = {
   visible: boolean;
   onClose: () => void;
@@ -14,19 +18,22 @@ type Props = {
   fixedTime: string;   // horário selecionado na tela principal (HH:MM)
   fixedService: string; // serviço atual (ex.: "Cut")
   fixedBarber: string;  // barbeiro atual (ex.: "João")
-  colors?: {
-    text: string; subtext: string; surface: string; border: string; accent: string; bg: string;
-  };
+  colors?: ModalColors;
+  copy?: RecurrenceModalCopy;
 };
 
 const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n));
 
 export default function RecurrenceModal({
-  visible, onClose, onSubmit, fixedDate, fixedTime, fixedService, fixedBarber,
-  colors = {
-    text: "#e5e7eb", subtext: "#cbd5e1", surface: "rgba(255,255,255,0.06)",
-    border: "rgba(255,255,255,0.12)", accent: "#60a5fa", bg: "#0b0d13"
-  }
+  visible,
+  onClose,
+  onSubmit,
+  fixedDate,
+  fixedTime,
+  fixedService,
+  fixedBarber,
+  colors = modalColors,
+  copy = defaultComponentCopy.recurrenceModal,
 }: Props) {
   const [count, setCount] = useState("10"); // default continua 10
 
@@ -52,34 +59,34 @@ export default function RecurrenceModal({
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.backdrop}>
         <View style={[styles.sheet, { backgroundColor: colors.bg, borderColor: colors.border }]}>
-          <Text style={[styles.title, { color: colors.text }]}>Repeat booking</Text>
+          <Text style={[styles.title, { color: colors.text }]}>{copy.title}</Text>
 
           {/* Info fixas */}
           <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>Service</Text>
+            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{copy.labels.service}</Text>
             <Text style={[styles.infoValue, { color: colors.text }]}>{fixedService}</Text>
           </View>
           <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>Barber</Text>
+            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{copy.labels.barber}</Text>
             <Text style={[styles.infoValue, { color: colors.text }]}>{fixedBarber}</Text>
           </View>
           <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>Start date</Text>
+            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{copy.labels.startDate}</Text>
             <Text style={[styles.infoValue, { color: colors.text }]}>{humanDate(fixedDate)}</Text>
           </View>
           <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>Time</Text>
+            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{copy.labels.time}</Text>
             <Text style={[styles.infoValue, { color: colors.text }]}>{fixedTime}</Text>
           </View>
 
           {/* Count */}
           <View style={{ marginTop: 8 }}>
-            <Text style={[styles.label, { color: colors.subtext }]}>Count (1–10)</Text>
+            <Text style={[styles.label, { color: colors.subtext }]}>{copy.labels.count}</Text>
             <TextInput
               value={count}
               onChangeText={onCountChange}
               onBlur={onCountBlur}
-              placeholder="10"
+              placeholder={copy.placeholders.count}
               placeholderTextColor={colors.subtext}
               style={[styles.input, { color: colors.text, borderColor: colors.border, backgroundColor: colors.surface }]}
               keyboardType="numeric"
@@ -90,10 +97,10 @@ export default function RecurrenceModal({
           {/* Actions */}
           <View style={[styles.actions, { borderTopColor: colors.border }]}>
             <Pressable style={[styles.btn, { borderColor: colors.border }]} onPress={onClose}>
-              <Text style={{ color: colors.subtext, fontWeight: "700" }}>Cancel</Text>
+              <Text style={{ color: colors.subtext, fontWeight: "700" }}>{copy.actions.cancel}</Text>
             </Pressable>
             <Pressable style={[styles.btn, { backgroundColor: colors.accent, borderColor: colors.accent }]} onPress={submit}>
-              <Text style={{ color: "#071018", fontWeight: "800" }}>Preview</Text>
+              <Text style={{ color: "#071018", fontWeight: "800" }}>{copy.actions.preview}</Text>
             </Pressable>
           </View>
         </View>

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -4,98 +4,9 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 import type { Service } from "../lib/domain";
 import { useServiceForm } from "../hooks/useServiceForm";
-
-const DEFAULT_COLORS = {
-  text: "#e5e7eb",
-  subtext: "#cbd5e1",
-  border: "rgba(255,255,255,0.12)",
-  surface: "rgba(255,255,255,0.06)",
-  accent: "#60a5fa",
-  accentFgOn: "#091016",
-  danger: "#ef4444",
-};
-
-type ServiceFormCopy = {
-  createTitle: string;
-  editTitle: string;
-  createSubtitle: string;
-  editSubtitle: string;
-  fields: {
-    nameLabel: string;
-    namePlaceholder: string;
-    nameError: string;
-    durationLabel: string;
-    durationPlaceholder: string;
-    durationError: string;
-    priceLabel: string;
-    pricePlaceholder: string;
-    priceError: string;
-    iconLabel: string;
-    iconPlaceholder: string;
-    iconError: string;
-    previewLabel: string;
-  };
-  buttons: {
-    create: string;
-    edit: string;
-    saving: string;
-    cancel: string;
-  };
-  accessibility: {
-    submitCreate: string;
-    submitEdit: string;
-    cancel: string;
-  };
-  alerts: {
-    createdTitle: string;
-    createdMessage: (name: string, minutes: number) => string;
-    updatedTitle: string;
-    updatedMessage: (name: string, minutes: number) => string;
-    createErrorTitle: string;
-    updateErrorTitle: string;
-  };
-};
-
-const DEFAULT_COPY: ServiceFormCopy = {
-  createTitle: "Register a service",
-  editTitle: "Edit service",
-  createSubtitle: "Services define the duration and price of each booking.",
-  editSubtitle: "Adjust the duration, price, or icon for this service.",
-  fields: {
-    nameLabel: "Name",
-    namePlaceholder: "Cut & Style",
-    nameError: "Name is required",
-    durationLabel: "Duration (minutes)",
-    durationPlaceholder: "45",
-    durationError: "Enter minutes > 0",
-    priceLabel: "Price",
-    pricePlaceholder: "30.00",
-    priceError: "Enter a valid price",
-    iconLabel: "Icon",
-    iconPlaceholder: "Choose an icon",
-    iconError: "Select an icon",
-    previewLabel: "Preview:",
-  },
-  buttons: {
-    create: "Create service",
-    edit: "Save changes",
-    saving: "Saving…",
-    cancel: "Cancel",
-  },
-  accessibility: {
-    submitCreate: "Create service",
-    submitEdit: "Save service changes",
-    cancel: "Cancel service form",
-  },
-  alerts: {
-    createdTitle: "Service created",
-    createdMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-    updatedTitle: "Service updated",
-    updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
-    createErrorTitle: "Create service failed",
-    updateErrorTitle: "Update service failed",
-  },
-};
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { ServiceFormCopy } from "../locales/types";
+import { formCardColors, type FormCardColors } from "../theme/colors";
 
 type Props = {
   mode?: "create" | "edit";
@@ -103,7 +14,7 @@ type Props = {
   onCreated?: (service: Service) => void;
   onUpdated?: (service: Service) => void;
   onCancel?: () => void;
-  colors?: typeof DEFAULT_COLORS;
+  colors?: FormCardColors;
   copy?: ServiceFormCopy;
 };
 
@@ -113,8 +24,8 @@ export default function ServiceForm({
   onCreated,
   onUpdated,
   onCancel,
-  colors = DEFAULT_COLORS,
-  copy = DEFAULT_COPY,
+  colors = formCardColors,
+  copy = defaultComponentCopy.serviceForm,
 }: Props) {
   const {
     isEditMode,
@@ -348,7 +259,7 @@ export default function ServiceForm({
 function FormField({ label, error, colors, style, ...rest }: {
   label: string;
   error?: string;
-  colors: typeof DEFAULT_COLORS;
+  colors: FormCardColors;
   style?: any;
 } & React.ComponentProps<typeof TextInput>) {
   return (

--- a/src/hooks/useAssistantChat.ts
+++ b/src/hooks/useAssistantChat.ts
@@ -4,46 +4,13 @@ import { Platform } from "react-native";
 import { runBookingAgent } from "../lib/bookingAgent";
 import { BARBERS, type Service } from "../lib/domain";
 import { isOpenAiConfigured, transcribeAudio } from "../lib/openai";
+import type { AssistantChatCopy } from "../locales/types";
 
 export type DisplayMessage = {
   role: "assistant" | "user";
   content: string;
 };
 
-export type AssistantChatCopy = {
-  initialMessage: string;
-  apiKeyWarning: string;
-  contextPrefix: string;
-  quickRepliesTitle: string;
-  quickRepliesToggleShow: string;
-  quickRepliesToggleHide: string;
-  quickReplyAccessibility: (suggestion: string) => string;
-  quickReplies: {
-    existingBookings: string;
-    bookService: string;
-    bookSpecificService: (serviceName: string) => string;
-    barberAvailability: (barberName: string) => string;
-  };
-  inputPlaceholder: string;
-  sendAccessibility: string;
-  suggestionsAccessibility: {
-    show: string;
-    hide: string;
-  };
-  voiceButtonAccessibility: {
-    start: string;
-    stop: string;
-  };
-  errors: {
-    generic: string;
-    missingApiKey: string;
-    voiceWebOnly: string;
-    voiceUnsupported: string;
-    voiceStartFailed: string;
-    noAudio: string;
-    processFailed: string;
-  };
-};
 
 type UseAssistantChatOptions = {
   systemPrompt: string;

--- a/src/hooks/useServiceForm.ts
+++ b/src/hooks/useServiceForm.ts
@@ -3,19 +3,9 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 import type { Service } from "../lib/domain";
 import { createService, updateService } from "../lib/services";
+import type { ServiceFormCopy } from "../locales/types";
 
 type ServiceFormMode = "create" | "edit";
-
-type ServiceFormCopy = {
-  fields: {
-    nameError: string;
-    durationError: string;
-    priceError: string;
-    iconError: string;
-    durationPlaceholder: string;
-    pricePlaceholder: string;
-  };
-};
 
 type UseServiceFormOptions = {
   mode: ServiceFormMode;

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -1,0 +1,418 @@
+import type {
+  AssistantChatCopy,
+  ImageAssistantCopy,
+  OccurrencePreviewCopy,
+  RecurrenceModalCopy,
+  ServiceFormCopy,
+  UserFormCopy,
+} from "./types";
+
+type SupportedLanguage = "en" | "pt";
+
+type ComponentCopy = {
+  assistantChat: AssistantChatCopy;
+  imageAssistant: ImageAssistantCopy;
+  serviceForm: ServiceFormCopy;
+  userForm: UserFormCopy;
+  recurrenceModal: RecurrenceModalCopy;
+  occurrencePreview: OccurrencePreviewCopy;
+};
+
+export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
+  en: {
+    assistantChat: {
+      initialMessage:
+        "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.",
+      apiKeyWarning: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.",
+      contextPrefix: "Booking context:",
+      quickRepliesTitle: "Suggested prompts",
+      quickRepliesToggleShow: "Show suggestions",
+      quickRepliesToggleHide: "Hide quick suggestions",
+      quickReplyAccessibility: (suggestion: string) => `Send quick message: ${suggestion}`,
+      quickReplies: {
+        existingBookings: "Show my existing bookings",
+        bookService: "Help me book a service",
+        bookSpecificService: (serviceName: string) => `Book a ${serviceName}`,
+        barberAvailability: (barberName: string) => `Available hours for ${barberName}`,
+      },
+      inputPlaceholder: "Ask about bookings...",
+      sendAccessibility: "Send message",
+      suggestionsAccessibility: {
+        show: "Show quick suggestions",
+        hide: "Hide quick suggestions",
+      },
+      voiceButtonAccessibility: {
+        start: "Start voice input",
+        stop: "Stop voice input",
+      },
+      errors: {
+        generic: "Something went wrong.",
+        missingApiKey: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.",
+        voiceWebOnly: "Voice capture is currently supported on the web experience only.",
+        voiceUnsupported: "Voice capture is not supported in this browser.",
+        voiceStartFailed: "Unable to start voice recording.",
+        noAudio: "No audio captured. Try again.",
+        processFailed: "Failed to process voice message.",
+      },
+    },
+    imageAssistant: {
+      title: "Image assistant",
+      subtitle: {
+        before: "Generate marketing visuals for your shop using the OpenAI image API deployed under ",
+        highlight: "/api/GenerateImage",
+        after: ".",
+      },
+      helperMessage: "Set EXPO_PUBLIC_IMAGE_API_TOKEN to authenticate requests to the GenerateImage function.",
+      promptLabel: "Prompt",
+      promptPlaceholder:
+        "Create a premium hero image for a barber shop website featuring a modern haircut session.",
+      sizeLabel: "Size",
+      sizeOptions: [
+        { label: "Square • 256px", value: "256x256" },
+        { label: "Detailed • 512px", value: "512x512" },
+        { label: "Showcase • 1024px", value: "1024x1024" },
+      ],
+      qualityLabel: "Quality",
+      qualityOptions: [
+        { label: "Standard", value: "standard", helper: "Fastest option for quick previews." },
+        { label: "HD", value: "hd", helper: "Sharper output, slightly slower." },
+      ],
+      optionAccessibility: {
+        size: (label: string) => `Select ${label} size`,
+        quality: (label: string) => `Use ${label} quality`,
+      },
+      generateButton: "Generate image",
+      generateAccessibility: "Generate marketing image",
+      errors: {
+        generateFailed: "Unable to generate image.",
+      },
+      history: {
+        title: "Recent results",
+        clearLabel: "Clear",
+        clearAccessibility: "Clear generated images",
+        promptLabel: "Prompt:",
+        revisedPrefix: "Revised prompt:",
+        meta: (size: string, quality: string) => `Size: ${size} • Quality: ${quality}`,
+        generatedAt: (timestamp: string) => `Generated ${timestamp}`,
+      },
+    },
+    serviceForm: {
+      createTitle: "Register a service",
+      editTitle: "Edit service",
+      createSubtitle: "Services define the duration and price of each booking.",
+      editSubtitle: "Adjust the duration, price, or icon for this service.",
+      fields: {
+        nameLabel: "Name",
+        namePlaceholder: "Cut & Style",
+        nameError: "Name is required",
+        durationLabel: "Duration (minutes)",
+        durationPlaceholder: "45",
+        durationError: "Enter minutes > 0",
+        priceLabel: "Price",
+        pricePlaceholder: "30.00",
+        priceError: "Enter a valid price",
+        iconLabel: "Icon",
+        iconPlaceholder: "Choose an icon",
+        iconError: "Select an icon",
+        previewLabel: "Preview:",
+      },
+      buttons: {
+        create: "Create service",
+        edit: "Save changes",
+        saving: "Saving…",
+        cancel: "Cancel",
+      },
+      accessibility: {
+        submitCreate: "Create service",
+        submitEdit: "Save service changes",
+        cancel: "Cancel service form",
+      },
+      alerts: {
+        createdTitle: "Service created",
+        createdMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
+        updatedTitle: "Service updated",
+        updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
+        createErrorTitle: "Create service failed",
+        updateErrorTitle: "Update service failed",
+      },
+    },
+    userForm: {
+      title: "Create user",
+      fields: {
+        firstName: {
+          label: "First name",
+          placeholder: "e.g., Ana",
+          required: "Required",
+        },
+        lastName: {
+          label: "Surname",
+          placeholder: "e.g., Silva",
+          required: "Required",
+        },
+        phone: {
+          label: "Cell phone",
+          placeholder: "(11) 99999-9999",
+          invalid: "Enter a valid phone",
+        },
+        email: {
+          label: "Email",
+          placeholder: "ana@email.com",
+          invalid: "Enter a valid email",
+        },
+        dateOfBirth: {
+          label: "Date of birth",
+          invalid: "Select a valid date",
+          future: "Date of birth cannot be in the future",
+          minAge: (minAge: number) => `Minimum age is ${minAge}`,
+        },
+      },
+      buttons: {
+        cancel: "Cancel",
+        submit: "Save user",
+        submitAccessibility: "Save user",
+      },
+      alerts: {
+        savedTitle: "User saved",
+        savedMessage: (first: string, last: string) => `${first} ${last}`,
+        failedTitle: "Save failed",
+        failedFallback: "Unable to save the user.",
+      },
+    },
+    recurrenceModal: {
+      title: "Repeat booking",
+      labels: {
+        service: "Service",
+        barber: "Barber",
+        startDate: "Start date",
+        time: "Time",
+        count: "Count (1–10)",
+      },
+      placeholders: {
+        count: "10",
+      },
+      actions: {
+        cancel: "Cancel",
+        preview: "Preview",
+      },
+    },
+    occurrencePreview: {
+      title: "Preview recurring bookings",
+      summary: (created: number, skipped: number) =>
+        `${created} will be created${skipped ? ` • ${skipped} skipped` : ""}`,
+      headers: {
+        date: "Date",
+        time: "Time",
+        status: "Status",
+      },
+      status: {
+        ok: "OK",
+        conflict: "Conflict",
+        outsideHours: "Outside hours",
+      },
+      actions: {
+        back: "Back",
+        confirm: (count: number) => `Create ${count}`,
+      },
+    },
+  },
+  pt: {
+    assistantChat: {
+      initialMessage:
+        "Olá! Sou o seu agente AIBarber. Posso verificar disponibilidade, agendar serviços e cancelar compromissos existentes para você.",
+      apiKeyWarning: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar o assistente.",
+      contextPrefix: "Contexto de agendamentos:",
+      quickRepliesTitle: "Prompts sugeridos",
+      quickRepliesToggleShow: "Mostrar sugestões",
+      quickRepliesToggleHide: "Ocultar sugestões rápidas",
+      quickReplyAccessibility: (suggestion: string) => `Enviar mensagem rápida: ${suggestion}`,
+      quickReplies: {
+        existingBookings: "Mostrar meus agendamentos",
+        bookService: "Ajudar a agendar um serviço",
+        bookSpecificService: (serviceName: string) => `Agendar ${serviceName}`,
+        barberAvailability: (barberName: string) => `Horários disponíveis para ${barberName}`,
+      },
+      inputPlaceholder: "Pergunte sobre os agendamentos...",
+      sendAccessibility: "Enviar mensagem",
+      suggestionsAccessibility: {
+        show: "Mostrar sugestões rápidas",
+        hide: "Ocultar sugestões rápidas",
+      },
+      voiceButtonAccessibility: {
+        start: "Iniciar entrada por voz",
+        stop: "Parar entrada por voz",
+      },
+      errors: {
+        generic: "Algo deu errado.",
+        missingApiKey: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar a entrada por voz.",
+        voiceWebOnly: "A captura de voz está disponível apenas na experiência web no momento.",
+        voiceUnsupported: "A captura de voz não é suportada neste navegador.",
+        voiceStartFailed: "Não foi possível iniciar a gravação de voz.",
+        noAudio: "Nenhum áudio capturado. Tente novamente.",
+        processFailed: "Falha ao processar a mensagem de voz.",
+      },
+    },
+    imageAssistant: {
+      title: "Laboratório de imagens",
+      subtitle: {
+        before: "Gere visuais de marketing para a sua barbearia usando a API de imagens da OpenAI disponível em ",
+        highlight: "/api/GenerateImage",
+        after: ".",
+      },
+      helperMessage:
+        "Defina EXPO_PUBLIC_IMAGE_API_TOKEN para autenticar as requisições para a função GenerateImage.",
+      promptLabel: "Prompt",
+      promptPlaceholder:
+        "Crie uma imagem hero premium para o site de uma barbearia mostrando um corte moderno.",
+      sizeLabel: "Tamanho",
+      sizeOptions: [
+        { label: "Quadrado • 256px", value: "256x256" },
+        { label: "Detalhado • 512px", value: "512x512" },
+        { label: "Vitrine • 1024px", value: "1024x1024" },
+      ],
+      qualityLabel: "Qualidade",
+      qualityOptions: [
+        { label: "Padrão", value: "standard", helper: "Opção mais rápida para pré-visualizações." },
+        { label: "HD", value: "hd", helper: "Resultado mais nítido, um pouco mais lento." },
+      ],
+      optionAccessibility: {
+        size: (label: string) => `Selecionar tamanho ${label}`,
+        quality: (label: string) => `Usar qualidade ${label}`,
+      },
+      generateButton: "Gerar imagem",
+      generateAccessibility: "Gerar imagem de marketing",
+      errors: {
+        generateFailed: "Não foi possível gerar a imagem.",
+      },
+      history: {
+        title: "Resultados recentes",
+        clearLabel: "Limpar",
+        clearAccessibility: "Limpar imagens geradas",
+        promptLabel: "Prompt:",
+        revisedPrefix: "Prompt revisado:",
+        meta: (size: string, quality: string) => `Tamanho: ${size} • Qualidade: ${quality}`,
+        generatedAt: (timestamp: string) => `Gerado em ${timestamp}`,
+      },
+    },
+    serviceForm: {
+      createTitle: "Cadastrar serviço",
+      editTitle: "Editar serviço",
+      createSubtitle: "Os serviços definem a duração e o preço de cada agendamento.",
+      editSubtitle: "Ajuste a duração, o preço ou o ícone deste serviço.",
+      fields: {
+        nameLabel: "Nome",
+        namePlaceholder: "Corte & Estilo",
+        nameError: "Nome é obrigatório",
+        durationLabel: "Duração (minutos)",
+        durationPlaceholder: "45",
+        durationError: "Informe minutos > 0",
+        priceLabel: "Preço",
+        pricePlaceholder: "30,00",
+        priceError: "Informe um preço válido",
+        iconLabel: "Ícone",
+        iconPlaceholder: "Escolha um ícone",
+        iconError: "Selecione um ícone",
+        previewLabel: "Prévia:",
+      },
+      buttons: {
+        create: "Criar serviço",
+        edit: "Salvar alterações",
+        saving: "Salvando…",
+        cancel: "Cancelar",
+      },
+      accessibility: {
+        submitCreate: "Criar serviço",
+        submitEdit: "Salvar alterações do serviço",
+        cancel: "Cancelar formulário de serviço",
+      },
+      alerts: {
+        createdTitle: "Serviço criado",
+        createdMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
+        updatedTitle: "Serviço atualizado",
+        updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
+        createErrorTitle: "Falha ao criar serviço",
+        updateErrorTitle: "Falha ao atualizar serviço",
+      },
+    },
+    userForm: {
+      title: "Criar cliente",
+      fields: {
+        firstName: {
+          label: "Nome",
+          placeholder: "ex.: Ana",
+          required: "Obrigatório",
+        },
+        lastName: {
+          label: "Sobrenome",
+          placeholder: "ex.: Silva",
+          required: "Obrigatório",
+        },
+        phone: {
+          label: "Celular",
+          placeholder: "(11) 99999-9999",
+          invalid: "Informe um telefone válido",
+        },
+        email: {
+          label: "E-mail",
+          placeholder: "ana@email.com",
+          invalid: "Informe um e-mail válido",
+        },
+        dateOfBirth: {
+          label: "Data de nascimento",
+          invalid: "Selecione uma data válida",
+          future: "A data não pode estar no futuro",
+          minAge: (minAge: number) => `Idade mínima de ${minAge} anos`,
+        },
+      },
+      buttons: {
+        cancel: "Cancelar",
+        submit: "Salvar cliente",
+        submitAccessibility: "Salvar cliente",
+      },
+      alerts: {
+        savedTitle: "Cliente salvo",
+        savedMessage: (first: string, last: string) => `${first} ${last}`,
+        failedTitle: "Falha ao salvar",
+        failedFallback: "Não foi possível salvar o cliente.",
+      },
+    },
+    recurrenceModal: {
+      title: "Repetir agendamento",
+      labels: {
+        service: "Serviço",
+        barber: "Barbeiro",
+        startDate: "Data inicial",
+        time: "Horário",
+        count: "Quantidade (1–10)",
+      },
+      placeholders: {
+        count: "10",
+      },
+      actions: {
+        cancel: "Cancelar",
+        preview: "Pré-visualizar",
+      },
+    },
+    occurrencePreview: {
+      title: "Prévia de recorrências",
+      summary: (created: number, skipped: number) =>
+        `${created} serão criados${skipped ? ` • ${skipped} ignorados` : ""}`,
+      headers: {
+        date: "Data",
+        time: "Horário",
+        status: "Status",
+      },
+      status: {
+        ok: "OK",
+        conflict: "Conflito",
+        outsideHours: "Fora do horário",
+      },
+      actions: {
+        back: "Voltar",
+        confirm: (count: number) => `Criar ${count}`,
+      },
+    },
+  },
+} as const;
+
+export const DEFAULT_COMPONENT_LANGUAGE: SupportedLanguage = "en";
+export const defaultComponentCopy = COMPONENT_COPY[DEFAULT_COMPONENT_LANGUAGE];

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -1,0 +1,167 @@
+export type AssistantChatCopy = {
+  initialMessage: string;
+  apiKeyWarning: string;
+  contextPrefix: string;
+  quickRepliesTitle: string;
+  quickRepliesToggleShow: string;
+  quickRepliesToggleHide: string;
+  quickReplyAccessibility: (suggestion: string) => string;
+  quickReplies: {
+    existingBookings: string;
+    bookService: string;
+    bookSpecificService: (serviceName: string) => string;
+    barberAvailability: (barberName: string) => string;
+  };
+  inputPlaceholder: string;
+  sendAccessibility: string;
+  suggestionsAccessibility: {
+    show: string;
+    hide: string;
+  };
+  voiceButtonAccessibility: {
+    start: string;
+    stop: string;
+  };
+  errors: {
+    generic: string;
+    missingApiKey: string;
+    voiceWebOnly: string;
+    voiceUnsupported: string;
+    voiceStartFailed: string;
+    noAudio: string;
+    processFailed: string;
+  };
+};
+
+export type ServiceFormCopy = {
+  createTitle: string;
+  editTitle: string;
+  createSubtitle: string;
+  editSubtitle: string;
+  fields: {
+    nameLabel: string;
+    namePlaceholder: string;
+    nameError: string;
+    durationLabel: string;
+    durationPlaceholder: string;
+    durationError: string;
+    priceLabel: string;
+    pricePlaceholder: string;
+    priceError: string;
+    iconLabel: string;
+    iconPlaceholder: string;
+    iconError: string;
+    previewLabel: string;
+  };
+  buttons: {
+    create: string;
+    edit: string;
+    saving: string;
+    cancel: string;
+  };
+  accessibility: {
+    submitCreate: string;
+    submitEdit: string;
+    cancel: string;
+  };
+  alerts: {
+    createdTitle: string;
+    createdMessage: (name: string, minutes: number) => string;
+    updatedTitle: string;
+    updatedMessage: (name: string, minutes: number) => string;
+    createErrorTitle: string;
+    updateErrorTitle: string;
+  };
+};
+
+export type ImageAssistantCopy = {
+  title: string;
+  subtitle: { before: string; highlight: string; after: string };
+  helperMessage: string;
+  promptLabel: string;
+  promptPlaceholder: string;
+  sizeLabel: string;
+  sizeOptions: ReadonlyArray<{ label: string; value: "256x256" | "512x512" | "1024x1024" }>;
+  qualityLabel: string;
+  qualityOptions: ReadonlyArray<{ label: string; value: "standard" | "hd"; helper: string }>;
+  optionAccessibility: {
+    size: (label: string) => string;
+    quality: (label: string) => string;
+  };
+  generateButton: string;
+  generateAccessibility: string;
+  errors: { generateFailed: string };
+  history: {
+    title: string;
+    clearLabel: string;
+    clearAccessibility: string;
+    promptLabel: string;
+    revisedPrefix: string;
+    meta: (size: string, quality: string) => string;
+    generatedAt: (timestamp: string) => string;
+  };
+};
+
+export type UserFormCopy = {
+  title: string;
+  fields: {
+    firstName: { label: string; placeholder: string; required: string };
+    lastName: { label: string; placeholder: string; required: string };
+    phone: { label: string; placeholder: string; invalid: string };
+    email: { label: string; placeholder: string; invalid: string };
+    dateOfBirth: {
+      label: string;
+      invalid: string;
+      future: string;
+      minAge: (minAge: number) => string;
+    };
+  };
+  buttons: {
+    cancel: string;
+    submit: string;
+    submitAccessibility: string;
+  };
+  alerts: {
+    savedTitle: string;
+    savedMessage: (firstName: string, lastName: string) => string;
+    failedTitle: string;
+    failedFallback: string;
+  };
+};
+
+export type RecurrenceModalCopy = {
+  title: string;
+  labels: {
+    service: string;
+    barber: string;
+    startDate: string;
+    time: string;
+    count: string;
+  };
+  placeholders: {
+    count: string;
+  };
+  actions: {
+    cancel: string;
+    preview: string;
+  };
+};
+
+export type OccurrencePreviewCopy = {
+  title: string;
+  summary: (created: number, skipped: number) => string;
+  headers: {
+    date: string;
+    time: string;
+    status: string;
+  };
+  status: {
+    ok: string;
+    conflict: string;
+    outsideHours: string;
+  };
+  actions: {
+    back: string;
+    confirm: (count: number) => string;
+  };
+};

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,54 @@
+export const palette = {
+  textPrimary: "#e5e7eb",
+  textSecondary: "#cbd5e1",
+  accentPrimary: "#60a5fa",
+  accentOnDark: "#091016",
+  danger: "#ef4444",
+  borderStrong: "rgba(255,255,255,0.12)",
+  borderMuted: "rgba(255,255,255,0.07)",
+  surfaceElevated: "rgba(255,255,255,0.06)",
+  surfaceSubtle: "rgba(255,255,255,0.045)",
+  backgroundDark: "#0b0d13",
+} as const;
+
+export const formCardColors = {
+  text: palette.textPrimary,
+  subtext: palette.textSecondary,
+  border: palette.borderStrong,
+  surface: palette.surfaceElevated,
+  accent: palette.accentPrimary,
+  accentFgOn: palette.accentOnDark,
+  danger: palette.danger,
+} as const;
+
+export type FormCardColors = typeof formCardColors;
+
+export const subtleFormCardColors = {
+  text: palette.textPrimary,
+  subtext: palette.textSecondary,
+  border: palette.borderMuted,
+  surface: palette.surfaceSubtle,
+  accent: palette.accentPrimary,
+  accentFgOn: palette.accentOnDark,
+  danger: palette.danger,
+} as const;
+
+export type SubtleFormCardColors = typeof subtleFormCardColors;
+
+export const modalColors = {
+  text: palette.textPrimary,
+  subtext: palette.textSecondary,
+  surface: palette.surfaceElevated,
+  border: palette.borderStrong,
+  accent: palette.accentPrimary,
+  bg: palette.backgroundDark,
+} as const;
+
+export type ModalColors = typeof modalColors;
+
+export const modalColorsWithDanger = {
+  ...modalColors,
+  danger: palette.danger,
+} as const;
+
+export type ModalColorsWithDanger = typeof modalColorsWithDanger;


### PR DESCRIPTION
## Summary
- centralize assistant, form, and modal strings in `src/locales` so components and language packs reuse the same copy
- add `src/theme/colors.ts` to share default dark theme palettes across forms and modals and update consumers to opt in
- wire App translations to the shared copy and pass the localized resources to modals and forms

## Testing
- `npm test` *(fails: vitest executable missing; `npm install` blocked with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e745111483278d3084a14de207f6