### PR TITLE
Improve OpenAI and Supabase adapters type safety

### DIFF
--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -19,7 +19,7 @@ import {
   getCustomerById,
   type BookingWithCustomer,
 } from "./bookings";
-import { callOpenAIChatCompletion, isOpenAiConfigured } from "./openai";
+import { callOpenAIChatCompletion, isOpenAiConfigured, type ChatMessage } from "./openai";
 
 export type ConversationMessage = {
   role: "assistant" | "user";
@@ -173,18 +173,6 @@ function buildToolDefinitions(services: Service[]) {
     },
   ];
 }
-
-type ChatCompletionMessage = {
-  role: "system" | "user" | "assistant" | "tool";
-  content: string;
-  name?: string;
-  tool_call_id?: string;
-  tool_calls?: {
-    id: string;
-    type: "function";
-    function: { name: string; arguments: string };
-  }[];
-};
 
 async function listBookings(args: { date?: string }, serviceMap: Map<string, Service>): Promise<unknown> {
   if (!args?.date) {
@@ -394,7 +382,7 @@ export async function runBookingAgent(options: AgentRunOptions): Promise<string>
 
   const today = new Date();
   const currentDate = today.toISOString().split("T")[0];
-  const messages: ChatCompletionMessage[] = [
+  const messages: ChatMessage[] = [
     {
       role: "system",
       content: [

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,14 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from "@supabase/supabase-js";
 
-const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
-
-if (!url || !key) {
-  console.error('Supabase env missing',
-    { url: url, hasKey: !!key });
+function readEnv(name: "EXPO_PUBLIC_SUPABASE_URL" | "EXPO_PUBLIC_SUPABASE_ANON_KEY"): string {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Supabase configuration missing required environment variable: ${name}`);
+  }
+  return value;
 }
 
-export const supabase = createClient(url!, key!);
+const url = readEnv("EXPO_PUBLIC_SUPABASE_URL");
+const key = readEnv("EXPO_PUBLIC_SUPABASE_ANON_KEY");
+
+export const supabase = createClient(url, key);


### PR DESCRIPTION
## Summary
- replace loose `any` usage in the OpenAI adapter with structured request/response types and response validation
- harden audio transcription helpers by constraining blob/file handling and checking for expected payload fields
- require Supabase configuration to be present before creating the client instead of relying on non-null assertions

## Testing
- npm test -- --run *(fails: vitest executable unavailable because dependencies cannot be installed in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6eb7298f88327a89b1e1d94c903ef