### PR TITLE
Refactor infrastructure clients for dependency injection

### DIFF
--- a/src/lib/gateways/bookingGateway.ts
+++ b/src/lib/gateways/bookingGateway.ts
@@ -1,4 +1,4 @@
-import { supabase } from "../supabase";
+import { supabase, type SupabaseClientLike } from "../supabase";
 import type { Customer, DbBooking } from "../types/booking";
 
 export type GatewayResult<T> = {
@@ -50,18 +50,20 @@ export interface BookingGateway {
 }
 
 class SupabaseBookingGateway implements BookingGateway {
+  constructor(private readonly client: SupabaseClientLike) {}
+
   async fetchBookingsByDate(date: string): Promise<GatewayResult<DbBooking[]>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("bookings")
       .select('id,date,start,"end",service_id,barber,customer_id')
       .eq("date", date)
       .order("start");
     if (error) throw new PersistenceError("Failed to fetch bookings by date", status, { cause: error });
-    return { data: (data ?? []) as DbBooking[], status };
+    return { data: (data ?? []) as DbBooking[], status: status ?? 200 };
   }
 
   async fetchBookingsForRange(startDate: string, endDate: string): Promise<GatewayResult<DbBooking[]>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("bookings")
       .select('id,date,start,"end",service_id,barber,customer_id')
       .gte("date", startDate)
@@ -69,18 +71,18 @@ class SupabaseBookingGateway implements BookingGateway {
       .order("date")
       .order("start");
     if (error) throw new PersistenceError("Failed to fetch bookings for range", status, { cause: error });
-    return { data: (data ?? []) as DbBooking[], status };
+    return { data: (data ?? []) as DbBooking[], status: status ?? 200 };
   }
 
   async fetchRecentBookings(limit: number): Promise<GatewayResult<DbBooking[]>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("bookings")
       .select('id,date,start,"end",service_id,barber,customer_id')
       .order("date", { ascending: false })
       .order("start", { ascending: false })
       .limit(limit);
     if (error) throw new PersistenceError("Failed to fetch recent bookings", status, { cause: error });
-    return { data: (data ?? []) as DbBooking[], status };
+    return { data: (data ?? []) as DbBooking[], status: status ?? 200 };
   }
 
   async insertBooking(payload: {
@@ -91,30 +93,30 @@ class SupabaseBookingGateway implements BookingGateway {
     barber: string;
     customer_id?: string | null;
   }): Promise<GatewayResult<{ id: string | null }>> {
-    const { data, error, status } = await supabase.from("bookings").insert(payload).select("id").single();
+    const { data, error, status } = await this.client.from("bookings").insert(payload).select("id").single();
     if (error) throw new PersistenceError("Failed to create booking", status, { cause: error });
-    return { data: { id: data?.id ?? null }, status };
+    return { data: { id: data?.id ?? null }, status: status ?? 201 };
   }
 
   async deleteBooking(id: string): Promise<GatewayResult<{ deleted: number }>> {
-    const { data, error, status } = await supabase.from("bookings").delete().eq("id", id);
+    const { data, error, status } = await this.client.from("bookings").delete().eq("id", id);
     if (error) throw new PersistenceError("Failed to delete booking", status, { cause: error });
-    return { data: { deleted: Array.isArray(data) ? data.length : 0 }, status };
+    return { data: { deleted: Array.isArray(data) ? data.length : 0 }, status: status ?? 200 };
   }
 
   async fetchCustomersByIds(ids: readonly string[]): Promise<GatewayResult<Customer[]>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("customers")
       .select("id,first_name,last_name,phone,email,date_of_birth")
       .in("id", ids as string[]);
     if (error) throw new PersistenceError("Failed to fetch customers by ids", status, { cause: error });
-    return { data: (data ?? []) as Customer[], status };
+    return { data: (data ?? []) as Customer[], status: status ?? 200 };
   }
 
   async searchCustomers(opts: { query?: string | null; limit?: number }): Promise<GatewayResult<Customer[]>> {
     const limit = opts.limit ?? 20;
     const query = opts.query?.trim();
-    let request = supabase
+    let request = this.client
       .from("customers")
       .select("id,first_name,last_name,phone,email,date_of_birth");
 
@@ -130,27 +132,27 @@ class SupabaseBookingGateway implements BookingGateway {
 
     const { data, error, status } = await request;
     if (error) throw new PersistenceError("Failed to search customers", status, { cause: error });
-    return { data: (data ?? []) as Customer[], status };
+    return { data: (data ?? []) as Customer[], status: status ?? 200 };
   }
 
   async findCustomerById(id: string): Promise<GatewayResult<Customer | null>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("customers")
       .select("id,first_name,last_name,phone,email,date_of_birth")
       .eq("id", id)
       .maybeSingle();
     if (error) throw new PersistenceError("Failed to fetch customer by id", status, { cause: error });
-    return { data: (data ?? null) as Customer | null, status };
+    return { data: (data ?? null) as Customer | null, status: status ?? 200 };
   }
 
   async findCustomerByPhone(phone: string): Promise<GatewayResult<Customer | null>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("customers")
       .select("id,first_name,last_name,phone,email,date_of_birth")
       .eq("phone", phone)
       .maybeSingle();
     if (error) throw new PersistenceError("Failed to fetch customer by phone", status, { cause: error });
-    return { data: (data ?? null) as Customer | null, status };
+    return { data: (data ?? null) as Customer | null, status: status ?? 200 };
   }
 
   async insertCustomer(payload: {
@@ -158,39 +160,41 @@ class SupabaseBookingGateway implements BookingGateway {
     last_name: string;
     phone: string;
   }): Promise<GatewayResult<Customer>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("customers")
       .insert(payload)
       .select("id,first_name,last_name,phone,email,date_of_birth")
       .single();
     if (error) throw new PersistenceError("Failed to create customer", status, { cause: error });
-    return { data: data as Customer, status };
+    return { data: data as Customer, status: status ?? 201 };
   }
 
   async fetchBookingsForDates(dates: readonly string[]): Promise<GatewayResult<DbBooking[]>> {
-    const { data, error, status } = await supabase
+    const { data, error, status } = await this.client
       .from("bookings")
       .select('id,date,start,"end",service_id,barber,customer_id')
       .in("date", dates as string[]);
     if (error) throw new PersistenceError("Failed to fetch bookings for dates", status, { cause: error });
-    return { data: (data ?? []) as DbBooking[], status };
+    return { data: (data ?? []) as DbBooking[], status: status ?? 200 };
   }
 
-  async insertManyBookings(payload: {
-    date: string;
-    start: string;
-    end: string;
-    service_id: string;
-    barber: string;
-    customer_id?: string | null;
-  }[]): Promise<GatewayResult<null>> {
-    const { error, status } = await supabase.from("bookings").insert(payload);
+  async insertManyBookings(
+    payload: {
+      date: string;
+      start: string;
+      end: string;
+      service_id: string;
+      barber: string;
+      customer_id?: string | null;
+    }[],
+  ): Promise<GatewayResult<null>> {
+    const { error, status } = await this.client.from("bookings").insert(payload);
     if (error) throw new PersistenceError("Failed to create bookings", status, { cause: error });
-    return { data: null, status };
+    return { data: null, status: status ?? 201 };
   }
 }
 
-let activeGateway: BookingGateway = new SupabaseBookingGateway();
+let activeGateway: BookingGateway = createSupabaseBookingGateway();
 
 export function getBookingGateway(): BookingGateway {
   return activeGateway;
@@ -201,9 +205,10 @@ export function setBookingGateway(gateway: BookingGateway): void {
 }
 
 export function resetBookingGateway(): void {
-  activeGateway = new SupabaseBookingGateway();
+  activeGateway = createSupabaseBookingGateway();
 }
 
-export function createSupabaseBookingGateway(): BookingGateway {
-  return new SupabaseBookingGateway();
+export function createSupabaseBookingGateway(client: SupabaseClientLike = supabase): BookingGateway {
+  return new SupabaseBookingGateway(client);
 }
+

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,6 +1,5 @@
 const API_URL = "https://api.openai.com/v1/chat/completions";
 const AUDIO_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions";
-const API_KEY = process.env.EXPO_PUBLIC_OPENAI_API_KEY;
 
 export type ChatCompletionToolCall = {
   id: string;
@@ -62,8 +61,6 @@ type ChatCompletionPayload = {
   tools?: ChatCompletionToolDefinition[];
 };
 
-export const isOpenAiConfigured = typeof API_KEY === "string" && API_KEY.length > 0;
-
 function buildErrorMessage(status: number, body: unknown) {
   if (body && typeof body === "object" && "error" in body) {
     const err = (body as OpenAIErrorBody).error;
@@ -74,50 +71,6 @@ function buildErrorMessage(status: number, body: unknown) {
   if (status >= 400 && status < 500) return `Request failed with status ${status}.`;
   if (status >= 500) return "OpenAI service is currently unavailable.";
   return "Unexpected error calling OpenAI.";
-}
-
-export async function callOpenAIChatCompletion(
-  payload: ChatCompletionPayload,
-): Promise<ChatCompletionResponseBody> {
-  if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
-  }
-
-  const bodyPayload = {
-    model: "gpt-4o-mini",
-    temperature: 0.7,
-    ...payload,
-  };
-
-  const response = await fetch(API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${API_KEY}`,
-    },
-    body: JSON.stringify(bodyPayload),
-  });
-
-  const body: unknown = await response.json();
-  if (!response.ok) {
-    throw new Error(buildErrorMessage(response.status, body));
-  }
-
-  if (!body || typeof body !== "object" || !Array.isArray((body as ChatCompletionResponseBody).choices)) {
-    throw new Error("Unexpected response format from OpenAI chat completion.");
-  }
-
-  return body as ChatCompletionResponseBody;
-}
-
-export async function fetchAssistantReply(messages: ChatMessage[]): Promise<string> {
-  const body = await callOpenAIChatCompletion({ messages });
-  const content = body?.choices?.[0]?.message?.content;
-  if (typeof content !== "string" || !content.trim()) {
-    throw new Error("OpenAI assistant did not return any content.");
-  }
-
-  return content.trim();
 }
 
 type BlobLike = Blob & { size?: number };
@@ -132,54 +85,136 @@ type TranscribeAudioInput =
   | { uri: string; fileName?: string; mimeType?: string }
   | { blob: BlobLike; fileName?: string; mimeType?: string };
 
-export async function transcribeAudio(input: TranscribeAudioInput) {
-  if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+export type OpenAIClientConfig = {
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  apiUrl?: string;
+  transcriptionUrl?: string;
+};
+
+export type OpenAIClient = {
+  isConfigured: boolean;
+  callChatCompletion(payload: ChatCompletionPayload): Promise<ChatCompletionResponseBody>;
+  fetchAssistantReply(messages: ChatMessage[]): Promise<string>;
+  transcribeAudio(input: TranscribeAudioInput): Promise<string>;
+};
+
+export function createOpenAIClient(config: OpenAIClientConfig): OpenAIClient {
+  const apiUrl = config.apiUrl ?? API_URL;
+  const transcriptionUrl = config.transcriptionUrl ?? AUDIO_TRANSCRIPTION_URL;
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const isConfigured = typeof config.apiKey === "string" && config.apiKey.length > 0;
+
+  const ensureConfigured = () => {
+    if (!isConfigured) {
+      throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    }
+  };
+
+  async function callChatCompletion(payload: ChatCompletionPayload): Promise<ChatCompletionResponseBody> {
+    ensureConfigured();
+
+    const bodyPayload = {
+      model: "gpt-4o-mini",
+      temperature: 0.7,
+      ...payload,
+    };
+
+    const response = await fetchImpl(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify(bodyPayload),
+    });
+
+    const body: unknown = await response.json();
+    if (!response.ok) {
+      throw new Error(buildErrorMessage(response.status, body));
+    }
+
+    if (!body || typeof body !== "object" || !Array.isArray((body as ChatCompletionResponseBody).choices)) {
+      throw new Error("Unexpected response format from OpenAI chat completion.");
+    }
+
+    return body as ChatCompletionResponseBody;
   }
 
-  const formData = new FormData();
-  formData.append("model", "gpt-4o-mini-transcribe");
+  async function fetchAssistantReply(messages: ChatMessage[]): Promise<string> {
+    const body = await callChatCompletion({ messages });
+    const content = body?.choices?.[0]?.message?.content;
+    if (typeof content !== "string" || !content.trim()) {
+      throw new Error("OpenAI assistant did not return any content.");
+    }
 
-  if ("blob" in input) {
-    const { blob, fileName = "voice-message.webm", mimeType } = input;
-    const typedBlob =
-      mimeType && blob && typeof blob.slice === "function"
-        ? blob.slice(0, blob.size ?? undefined, mimeType)
-        : blob;
-    formData.append("file", typedBlob as Blob, fileName);
-  } else {
-    const { uri, fileName = "voice-message.m4a", mimeType = "audio/m4a" } = input;
-    formData.append(
-      "file",
-      {
-        uri,
-        name: fileName,
-        type: mimeType,
-      } as ReactNativeFileLike,
-    );
+    return content.trim();
   }
 
-  const response = await fetch(AUDIO_TRANSCRIPTION_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-    },
-    body: formData,
-  });
+  async function transcribeAudio(input: TranscribeAudioInput) {
+    ensureConfigured();
 
-  const body: unknown = await response.json();
-  if (!response.ok) {
-    throw new Error(buildErrorMessage(response.status, body));
+    const formData = new FormData();
+    formData.append("model", "gpt-4o-mini-transcribe");
+
+    if ("blob" in input) {
+      const { blob, fileName = "voice-message.webm", mimeType } = input;
+      const typedBlob =
+        mimeType && blob && typeof blob.slice === "function"
+          ? blob.slice(0, blob.size ?? undefined, mimeType)
+          : blob;
+      formData.append("file", typedBlob as Blob, fileName);
+    } else {
+      const { uri, fileName = "voice-message.m4a", mimeType = "audio/m4a" } = input;
+      formData.append(
+        "file",
+        {
+          uri,
+          name: fileName,
+          type: mimeType,
+        } as ReactNativeFileLike,
+      );
+    }
+
+    const response = await fetchImpl(transcriptionUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: formData,
+    });
+
+    const body: unknown = await response.json();
+    if (!response.ok) {
+      throw new Error(buildErrorMessage(response.status, body));
+    }
+
+    if (!body || typeof body !== "object" || !("text" in body)) {
+      throw new Error("Unexpected response format from OpenAI transcription.");
+    }
+
+    const text: unknown = (body as { text?: unknown }).text;
+    if (typeof text !== "string" || !text.trim()) {
+      throw new Error("Transcription did not return any text.");
+    }
+
+    return text.trim();
   }
 
-  if (!body || typeof body !== "object" || !("text" in body)) {
-    throw new Error("Unexpected response format from OpenAI transcription.");
-  }
-
-  const text: unknown = (body as { text?: unknown }).text;
-  if (typeof text !== "string" || !text.trim()) {
-    throw new Error("Transcription did not return any text.");
-  }
-
-  return text.trim();
+  return {
+    isConfigured,
+    callChatCompletion,
+    fetchAssistantReply,
+    transcribeAudio,
+  };
 }
+
+const defaultClient = createOpenAIClient({
+  apiKey: process.env.EXPO_PUBLIC_OPENAI_API_KEY ?? "",
+});
+
+export const isOpenAiConfigured = defaultClient.isConfigured;
+export const callOpenAIChatCompletion = defaultClient.callChatCompletion;
+export const fetchAssistantReply = defaultClient.fetchAssistantReply;
+export const transcribeAudio = defaultClient.transcribeAudio;
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,30 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+export type SupabaseClientConfig = {
+  url: string;
+  anonKey: string;
+};
 
-if (!url || !key) {
-  console.error('Supabase env missing',
-    { url: url, hasKey: !!key });
+export type SupabaseClientFactory = typeof createClient;
+
+export type SupabaseClientLike = Pick<SupabaseClient, "from">;
+
+export function createSupabaseClient(
+  config: SupabaseClientConfig,
+  clientFactory: SupabaseClientFactory = createClient,
+): SupabaseClient {
+  const { url, anonKey } = config;
+
+  if (!url || !anonKey) {
+    console.error("Supabase env missing", { url, hasKey: !!anonKey });
+  }
+
+  return clientFactory(url, anonKey);
 }
 
-export const supabase = createClient(url!, key!);
+const defaultConfig: SupabaseClientConfig = {
+  url: process.env.EXPO_PUBLIC_SUPABASE_URL ?? "",
+  anonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "",
+};
+
+export const supabase = createSupabaseClient(defaultConfig);

--- a/tests/openai/openaiClient.test.ts
+++ b/tests/openai/openaiClient.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenAIClient } from "../../src/lib/openai";
+
+describe("createOpenAIClient", () => {
+  it("uses the provided fetch implementation for chat completions", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "response-id",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Hello" },
+            finish_reason: null,
+          },
+        ],
+      }),
+    }));
+
+    const client = createOpenAIClient({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const payload = { messages: [{ role: "user" as const, content: "Hi" }] };
+    const response = await client.callChatCompletion(payload);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: `Bearer test-key` }),
+      }),
+    );
+    expect(response.choices[0]?.message.content).toBe("Hello");
+  });
+
+  it("throws a configuration error when the API key is missing", async () => {
+    const client = createOpenAIClient({ apiKey: "" });
+    await expect(
+      client.callChatCompletion({ messages: [{ role: "user", content: "" }] }),
+    ).rejects.toThrowError(/OpenAI API key is not configured/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- introduce configurable factory helpers for Supabase and OpenAI clients so callers can inject test doubles
- refactor Supabase-dependent repositories and gateways to accept injected clients while keeping default instances
- add unit coverage for the OpenAI client factory to verify custom fetch usage and configuration errors

## Testing
- npm run test *(fails: vitest binary unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ff996fdc8327967022151bc70ec0