### PR TITLE
Add product inventory management page

### DIFF
--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback } from "react";
+import { View, Text, TextInput, Pressable, StyleSheet, Alert, ScrollView } from "react-native";
+
+import type { Product } from "../lib/domain";
+import { useProductForm } from "../hooks/useProductForm";
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { ProductFormCopy } from "../locales/types";
+import { formCardColors, type FormCardColors } from "../theme/colors";
+
+type Props = {
+  mode?: "create" | "edit";
+  product?: Product | null;
+  onCreated?: (product: Product) => void;
+  onUpdated?: (product: Product) => void;
+  onCancel?: () => void;
+  colors?: FormCardColors;
+  copy?: ProductFormCopy;
+};
+
+export default function ProductForm({
+  mode = "create",
+  product = null,
+  onCreated,
+  onUpdated,
+  onCancel,
+  colors = formCardColors,
+  copy = defaultComponentCopy.productForm,
+}: Props) {
+  const {
+    isEditMode,
+    name,
+    setName,
+    sku,
+    setSku,
+    priceText,
+    handlePriceChange,
+    costText,
+    handleCostChange,
+    stockText,
+    handleStockChange,
+    description,
+    setDescription,
+    errors,
+    valid,
+    saving,
+    submit,
+  } = useProductForm({
+    mode,
+    product,
+    copy,
+    onCreated,
+    onUpdated,
+  });
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      const result = await submit();
+      if (!result || result.status === "invalid" || !result.product) {
+        return;
+      }
+
+      if (result.status === "created") {
+        Alert.alert(
+          copy.alerts.createdTitle,
+          copy.alerts.createdMessage(result.product.name, result.product.stock_quantity),
+        );
+      } else if (result.status === "updated") {
+        Alert.alert(
+          copy.alerts.updatedTitle,
+          copy.alerts.updatedMessage(result.product.name, result.product.stock_quantity),
+        );
+      }
+    } catch (err: any) {
+      Alert.alert(
+        isEditMode ? copy.alerts.updateErrorTitle : copy.alerts.createErrorTitle,
+        err?.message ?? String(err),
+      );
+    }
+  }, [copy.alerts, isEditMode, submit]);
+
+  return (
+    <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+      <Text style={[styles.title, { color: colors.text }]}> 
+        {isEditMode ? copy.editTitle : copy.createTitle}
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.subtext }]}> 
+        {isEditMode ? copy.editSubtitle : copy.createSubtitle}
+      </Text>
+
+      <FormField
+        label={copy.fields.nameLabel}
+        value={name}
+        onChangeText={setName}
+        placeholder={copy.fields.namePlaceholder}
+        error={errors.name}
+        colors={colors}
+      />
+
+      <View style={styles.row}>
+        <FormField
+          label={copy.fields.priceLabel}
+          value={priceText}
+          onChangeText={handlePriceChange}
+          keyboardType="decimal-pad"
+          placeholder={copy.fields.pricePlaceholder}
+          error={errors.price}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+        <FormField
+          label={copy.fields.costLabel}
+          value={costText}
+          onChangeText={handleCostChange}
+          keyboardType="decimal-pad"
+          placeholder={copy.fields.costPlaceholder}
+          error={errors.cost}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+      </View>
+
+      <View style={styles.row}>
+        <FormField
+          label={copy.fields.stockLabel}
+          value={stockText}
+          onChangeText={handleStockChange}
+          keyboardType="number-pad"
+          placeholder={copy.fields.stockPlaceholder}
+          error={errors.stock}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+        <FormField
+          label={copy.fields.skuLabel}
+          value={sku}
+          onChangeText={setSku}
+          placeholder={copy.fields.skuPlaceholder}
+          colors={colors}
+          style={{ flex: 1 }}
+        />
+      </View>
+
+      <View style={{ marginBottom: 12 }}>
+        <Text style={[styles.label, { color: colors.subtext }]}>{copy.fields.descriptionLabel}</Text>
+        <ScrollView style={{ maxHeight: 120 }}>
+          <TextInput
+            value={description}
+            onChangeText={setDescription}
+            multiline
+            placeholder={copy.fields.descriptionPlaceholder}
+            placeholderTextColor="#94a3b8"
+            style={[styles.textArea, { borderColor: colors.border, color: colors.text }]}
+          />
+        </ScrollView>
+      </View>
+
+      <Pressable
+        onPress={handleSubmit}
+        disabled={!valid}
+        style={[
+          styles.button,
+          {
+            backgroundColor: valid ? colors.accent : "rgba(255,255,255,0.08)",
+            borderColor: valid ? colors.accent : colors.border,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={isEditMode ? copy.accessibility.submitEdit : copy.accessibility.submitCreate}
+      >
+        <Text style={[styles.buttonText, { color: valid ? colors.accentFgOn : colors.subtext }]}>
+          {saving
+            ? copy.buttons.saving
+            : isEditMode
+              ? copy.buttons.edit
+              : copy.buttons.create}
+        </Text>
+      </Pressable>
+
+      {onCancel ? (
+        <Pressable
+          onPress={() => {
+            if (!saving) onCancel();
+          }}
+          style={[styles.secondaryButton, { borderColor: colors.border }]}
+          accessibilityRole="button"
+          accessibilityLabel={copy.accessibility.cancel}
+        >
+          <Text style={[styles.secondaryButtonText, { color: colors.subtext }]}>{copy.buttons.cancel}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function FormField({ label, error, colors, style, ...rest }: {
+  label: string;
+  error?: string;
+  colors: FormCardColors;
+  style?: any;
+} & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={[{ marginBottom: 12 }, style]}>
+      <Text style={[styles.label, { color: colors.subtext }]}>{label}</Text>
+      <TextInput
+        {...rest}
+        placeholderTextColor="#94a3b8"
+        style={[styles.input, { borderColor: error ? colors.danger : colors.border, color: colors.text }]}
+      />
+      {error ? <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+  },
+  title: { fontSize: 18, fontWeight: "800" },
+  subtitle: { fontSize: 13, fontWeight: "600" },
+  row: { flexDirection: "row", gap: 12 },
+  label: { fontSize: 12, fontWeight: "700", marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    fontWeight: "700",
+    backgroundColor: "rgba(15,23,42,0.35)",
+  },
+  textArea: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    fontWeight: "700",
+    backgroundColor: "rgba(15,23,42,0.35)",
+    minHeight: 96,
+  },
+  errorText: { marginTop: 4, fontSize: 12, fontWeight: "700" },
+  button: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  buttonText: { fontSize: 14, fontWeight: "800" },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  secondaryButtonText: { fontSize: 13, fontWeight: "800" },
+});

--- a/src/hooks/useProductForm.ts
+++ b/src/hooks/useProductForm.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { Product } from "../lib/domain";
+import { createProduct, updateProduct } from "../lib/products";
+import type { ProductFormCopy } from "../locales/types";
+import { centsToInput, parsePrice } from "./useServiceForm";
+
+export type ProductFormMode = "create" | "edit";
+
+export type UseProductFormOptions = {
+  mode: ProductFormMode;
+  product: Product | null | undefined;
+  copy: ProductFormCopy;
+  onCreated?: (product: Product) => void;
+  onUpdated?: (product: Product) => void;
+};
+
+export type SubmitStatus = "invalid" | "created" | "updated";
+
+export type SubmitResult = {
+  status: SubmitStatus;
+  product?: Product;
+};
+
+export type UseProductFormReturn = {
+  isEditMode: boolean;
+  name: string;
+  setName: (value: string) => void;
+  sku: string;
+  setSku: (value: string) => void;
+  priceText: string;
+  handlePriceChange: (text: string) => void;
+  costText: string;
+  handleCostChange: (text: string) => void;
+  stockText: string;
+  handleStockChange: (text: string) => void;
+  description: string;
+  setDescription: (value: string) => void;
+  errors: Record<string, string>;
+  valid: boolean;
+  saving: boolean;
+  submit: () => Promise<SubmitResult>;
+};
+
+export function useProductForm({
+  mode,
+  product = null,
+  copy,
+  onCreated,
+  onUpdated,
+}: UseProductFormOptions): UseProductFormReturn {
+  const isEditMode = mode === "edit";
+
+  const [name, setName] = useState(() => (isEditMode && product ? product.name : ""));
+  const [sku, setSku] = useState(() => (isEditMode && product && product.sku ? product.sku : ""));
+  const [priceText, setPriceText] = useState(() =>
+    isEditMode && product
+      ? centsToInput(product.price_cents)
+      : copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""),
+  );
+  const [costText, setCostText] = useState(() =>
+    isEditMode && product && Number.isFinite(product.cost_cents)
+      ? centsToInput(product.cost_cents ?? 0)
+      : "",
+  );
+  const [stockText, setStockText] = useState(() =>
+    isEditMode && product
+      ? String(product.stock_quantity)
+      : copy.fields.stockPlaceholder.replace(/[^0-9]/g, ""),
+  );
+  const [description, setDescription] = useState(() =>
+    isEditMode && product && product.description ? product.description : "",
+  );
+  const [saving, setSaving] = useState(false);
+
+  const setFromProduct = useCallback(
+    (value: Product | null) => {
+      if (value) {
+        setName(value.name);
+        setSku(value.sku ?? "");
+        setPriceText(centsToInput(value.price_cents));
+        setCostText(Number.isFinite(value.cost_cents ?? NaN) ? centsToInput(value.cost_cents ?? 0) : "");
+        setStockText(String(value.stock_quantity));
+        setDescription(value.description ?? "");
+      } else {
+        setName("");
+        setSku("");
+        setPriceText(copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setCostText("");
+        setStockText(copy.fields.stockPlaceholder.replace(/[^0-9]/g, ""));
+        setDescription("");
+      }
+    },
+    [copy.fields.pricePlaceholder, copy.fields.stockPlaceholder],
+  );
+
+  useEffect(() => {
+    if (isEditMode && product) {
+      setFromProduct(product);
+    } else if (!isEditMode) {
+      setFromProduct(null);
+    }
+  }, [isEditMode, product, setFromProduct]);
+
+  const priceCents = useMemo(() => parsePrice(priceText), [priceText]);
+  const costCents = useMemo(() => {
+    if (!costText.trim()) return null;
+    const value = parsePrice(costText);
+    return Number.isFinite(value) ? value : NaN;
+  }, [costText]);
+  const stockQuantity = useMemo(() => {
+    const numeric = Number(stockText);
+    return Number.isFinite(numeric) ? Math.round(numeric) : NaN;
+  }, [stockText]);
+
+  const errors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = copy.fields.nameError;
+    if (!Number.isFinite(priceCents) || priceCents < 0) errs.price = copy.fields.priceError;
+    if (!Number.isFinite(stockQuantity) || stockQuantity < 0)
+      errs.stock = copy.fields.stockError;
+    if (costCents !== null && !Number.isFinite(costCents)) errs.cost = copy.fields.costError;
+    return errs;
+  }, [
+    copy.fields.costError,
+    copy.fields.nameError,
+    copy.fields.priceError,
+    copy.fields.stockError,
+    costCents,
+    name,
+    priceCents,
+    stockQuantity,
+  ]);
+
+  const readyToSubmit = useMemo(
+    () => Object.keys(errors).length === 0 && (!isEditMode || !!product),
+    [errors, isEditMode, product],
+  );
+
+  const valid = readyToSubmit && !saving;
+
+  const handlePriceChange = useCallback((text: string) => {
+    setPriceText(text.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const handleCostChange = useCallback((text: string) => {
+    setCostText(text.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const handleStockChange = useCallback((text: string) => {
+    setStockText(text.replace(/[^0-9]/g, ""));
+  }, []);
+
+  const submit = useCallback(async (): Promise<SubmitResult> => {
+    if (!readyToSubmit || saving) {
+      return { status: "invalid" };
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        sku: sku.trim() || null,
+        price_cents: priceCents,
+        stock_quantity: stockQuantity,
+        description: description.trim() || null,
+        cost_cents: costCents ?? null,
+      };
+
+      if (isEditMode && product) {
+        const updated = await updateProduct(product.id, payload);
+        setFromProduct(updated);
+        onUpdated?.(updated);
+        return { status: "updated", product: updated };
+      }
+
+      const created = await createProduct(payload);
+      setFromProduct(null);
+      onCreated?.(created);
+      return { status: "created", product: created };
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    costCents,
+    description,
+    isEditMode,
+    name,
+    onCreated,
+    onUpdated,
+    priceCents,
+    product,
+    readyToSubmit,
+    saving,
+    setFromProduct,
+    sku,
+    stockQuantity,
+  ]);
+
+  return {
+    isEditMode,
+    name,
+    setName,
+    sku,
+    setSku,
+    priceText,
+    handlePriceChange,
+    costText,
+    handleCostChange,
+    stockText,
+    handleStockChange,
+    description,
+    setDescription,
+    errors,
+    valid,
+    saving,
+    submit,
+  };
+}

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -10,6 +10,19 @@ export type Service = {
   created_at?: string | null;
 };
 
+export type ProductId = string;
+export type Product = {
+  id: ProductId;
+  name: string;
+  price_cents: number;
+  stock_quantity: number;
+  sku?: string | null;
+  description?: string | null;
+  cost_cents?: number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
 export type BarberId = "joao" | "maria" | "carlos";
 export type Barber = {
   id: BarberId;

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,0 +1,174 @@
+import type { Product } from "./domain";
+
+export type ProductInput = {
+  name: string;
+  price_cents: number;
+  stock_quantity: number;
+  sku?: string | null;
+  description?: string | null;
+  cost_cents?: number | null;
+};
+
+let memoryProducts: Product[] = [
+  {
+    id: "prod-shampoo",
+    name: "Hydrating shampoo",
+    price_cents: 4500,
+    stock_quantity: 18,
+    sku: "SHAMP-01",
+    description: "Salon grade shampoo ideal for dry hair.",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    id: "prod-beard-oil",
+    name: "Beard oil",
+    price_cents: 5500,
+    stock_quantity: 9,
+    sku: "BEARD-02",
+    description: "Organic beard conditioning oil.",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+const clone = (product: Product): Product => ({ ...product });
+
+const generateId = () => `prod_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+
+export async function listProducts(): Promise<Product[]> {
+  return memoryProducts.map(clone);
+}
+
+export async function createProduct(payload: ProductInput): Promise<Product> {
+  const name = payload.name?.trim();
+  const price = Number(payload.price_cents);
+  const stock = Number(payload.stock_quantity);
+
+  if (!name) {
+    throw new Error("Name is required");
+  }
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error("Price must be 0 or more");
+  }
+  if (!Number.isFinite(stock) || stock < 0) {
+    throw new Error("Stock must be 0 or more");
+  }
+
+  const now = new Date().toISOString();
+  const product: Product = {
+    id: generateId(),
+    name,
+    price_cents: Math.round(price),
+    stock_quantity: Math.round(stock),
+    sku: payload.sku?.trim() || null,
+    description: payload.description?.trim() || null,
+    cost_cents: Number.isFinite(payload.cost_cents ?? NaN)
+      ? Math.round(Number(payload.cost_cents))
+      : null,
+    created_at: now,
+    updated_at: now,
+  };
+
+  memoryProducts = [...memoryProducts, product];
+  return clone(product);
+}
+
+export async function updateProduct(
+  id: string,
+  payload: ProductInput,
+): Promise<Product> {
+  if (!id) throw new Error("Product ID is required");
+
+  const index = memoryProducts.findIndex((item) => item.id === id);
+  if (index === -1) {
+    throw new Error("Product not found");
+  }
+
+  const name = payload.name?.trim();
+  const price = Number(payload.price_cents);
+  const stock = Number(payload.stock_quantity);
+
+  if (!name) {
+    throw new Error("Name is required");
+  }
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error("Price must be 0 or more");
+  }
+  if (!Number.isFinite(stock) || stock < 0) {
+    throw new Error("Stock must be 0 or more");
+  }
+
+  const now = new Date().toISOString();
+  const current = memoryProducts[index];
+  const updated: Product = {
+    ...current,
+    name,
+    price_cents: Math.round(price),
+    stock_quantity: Math.round(stock),
+    sku: payload.sku?.trim() || null,
+    description: payload.description?.trim() || null,
+    cost_cents: Number.isFinite(payload.cost_cents ?? NaN)
+      ? Math.round(Number(payload.cost_cents))
+      : null,
+    updated_at: now,
+  };
+
+  memoryProducts = [
+    ...memoryProducts.slice(0, index),
+    updated,
+    ...memoryProducts.slice(index + 1),
+  ];
+
+  return clone(updated);
+}
+
+export async function deleteProduct(id: string): Promise<void> {
+  if (!id) throw new Error("Product ID is required");
+  memoryProducts = memoryProducts.filter((product) => product.id !== id);
+}
+
+function ensureQuantity(quantity: number) {
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    throw new Error("Quantity must be greater than zero");
+  }
+  return Math.round(quantity);
+}
+
+async function adjustStock(id: string, delta: number): Promise<Product> {
+  const index = memoryProducts.findIndex((item) => item.id === id);
+  if (index === -1) {
+    throw new Error("Product not found");
+  }
+
+  const current = memoryProducts[index];
+  const nextStock = current.stock_quantity + delta;
+  if (nextStock < 0) {
+    throw new Error("Insufficient stock");
+  }
+
+  const now = new Date().toISOString();
+  const updated: Product = {
+    ...current,
+    stock_quantity: nextStock,
+    updated_at: now,
+  };
+
+  memoryProducts = [
+    ...memoryProducts.slice(0, index),
+    updated,
+    ...memoryProducts.slice(index + 1),
+  ];
+
+  return clone(updated);
+}
+
+export async function sellProduct(id: string, quantity: number): Promise<Product> {
+  const qty = ensureQuantity(quantity);
+  return adjustStock(id, -qty);
+}
+
+export async function restockProduct(id: string, quantity: number): Promise<Product> {
+  const qty = ensureQuantity(quantity);
+  return adjustStock(id, qty);
+}

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -4,6 +4,7 @@ import type {
   OccurrencePreviewCopy,
   RecurrenceModalCopy,
   ServiceFormCopy,
+  ProductFormCopy,
   UserFormCopy,
 } from "./types";
 
@@ -13,6 +14,7 @@ type ComponentCopy = {
   assistantChat: AssistantChatCopy;
   imageAssistant: ImageAssistantCopy;
   serviceForm: ServiceFormCopy;
+  productForm: ProductFormCopy;
   userForm: UserFormCopy;
   recurrenceModal: RecurrenceModalCopy;
   occurrencePreview: OccurrencePreviewCopy;
@@ -134,6 +136,49 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
         createErrorTitle: "Create service failed",
         updateErrorTitle: "Update service failed",
+      },
+    },
+    productForm: {
+      createTitle: "Register a product",
+      editTitle: "Edit product",
+      createSubtitle: "Track retail items, pricing and stock from a single place.",
+      editSubtitle: "Update the price, stock level or description for this product.",
+      fields: {
+        nameLabel: "Name",
+        namePlaceholder: "Shampoo",
+        nameError: "Name is required",
+        priceLabel: "Price",
+        pricePlaceholder: "49.90",
+        priceError: "Enter a valid price",
+        costLabel: "Cost",
+        costPlaceholder: "18.50",
+        costError: "Enter a valid cost",
+        stockLabel: "Stock",
+        stockPlaceholder: "12",
+        stockError: "Enter a stock quantity",
+        skuLabel: "SKU",
+        skuPlaceholder: "SKU-001",
+        descriptionLabel: "Description",
+        descriptionPlaceholder: "Notes about the product, scent or usage.",
+      },
+      buttons: {
+        create: "Save product",
+        edit: "Save changes",
+        saving: "Saving…",
+        cancel: "Cancel",
+      },
+      accessibility: {
+        submitCreate: "Save product",
+        submitEdit: "Save product changes",
+        cancel: "Cancel product form",
+      },
+      alerts: {
+        createdTitle: "Product saved",
+        createdMessage: (name: string, stock: number) => `${name} (${stock} in stock)`,
+        updatedTitle: "Product updated",
+        updatedMessage: (name: string, stock: number) => `${name} (${stock} in stock)`,
+        createErrorTitle: "Create product failed",
+        updateErrorTitle: "Update product failed",
       },
     },
     userForm: {
@@ -331,6 +376,49 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
         createErrorTitle: "Falha ao criar serviço",
         updateErrorTitle: "Falha ao atualizar serviço",
+      },
+    },
+    productForm: {
+      createTitle: "Cadastrar produto",
+      editTitle: "Editar produto",
+      createSubtitle: "Controle itens de venda, preços e estoque em um só lugar.",
+      editSubtitle: "Atualize preço, estoque ou descrição deste produto.",
+      fields: {
+        nameLabel: "Nome",
+        namePlaceholder: "Shampoo",
+        nameError: "Nome é obrigatório",
+        priceLabel: "Preço",
+        pricePlaceholder: "49,90",
+        priceError: "Informe um preço válido",
+        costLabel: "Custo",
+        costPlaceholder: "18,50",
+        costError: "Informe um custo válido",
+        stockLabel: "Estoque",
+        stockPlaceholder: "12",
+        stockError: "Informe a quantidade em estoque",
+        skuLabel: "SKU",
+        skuPlaceholder: "SKU-001",
+        descriptionLabel: "Descrição",
+        descriptionPlaceholder: "Anotações sobre o produto, fragrância ou uso.",
+      },
+      buttons: {
+        create: "Salvar produto",
+        edit: "Salvar alterações",
+        saving: "Salvando…",
+        cancel: "Cancelar",
+      },
+      accessibility: {
+        submitCreate: "Salvar produto",
+        submitEdit: "Salvar alterações do produto",
+        cancel: "Cancelar formulário de produto",
+      },
+      alerts: {
+        createdTitle: "Produto salvo",
+        createdMessage: (name: string, stock: number) => `${name} (${stock} em estoque)`,
+        updatedTitle: "Produto atualizado",
+        updatedMessage: (name: string, stock: number) => `${name} (${stock} em estoque)`,
+        createErrorTitle: "Falha ao criar produto",
+        updateErrorTitle: "Falha ao atualizar produto",
       },
     },
     userForm: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -74,6 +74,50 @@ export type ServiceFormCopy = {
   };
 };
 
+export type ProductFormCopy = {
+  createTitle: string;
+  editTitle: string;
+  createSubtitle: string;
+  editSubtitle: string;
+  fields: {
+    nameLabel: string;
+    namePlaceholder: string;
+    nameError: string;
+    priceLabel: string;
+    pricePlaceholder: string;
+    priceError: string;
+    costLabel: string;
+    costPlaceholder: string;
+    costError: string;
+    stockLabel: string;
+    stockPlaceholder: string;
+    stockError: string;
+    skuLabel: string;
+    skuPlaceholder: string;
+    descriptionLabel: string;
+    descriptionPlaceholder: string;
+  };
+  buttons: {
+    create: string;
+    edit: string;
+    saving: string;
+    cancel: string;
+  };
+  accessibility: {
+    submitCreate: string;
+    submitEdit: string;
+    cancel: string;
+  };
+  alerts: {
+    createdTitle: string;
+    createdMessage: (name: string, stock: number) => string;
+    updatedTitle: string;
+    updatedMessage: (name: string, stock: number) => string;
+    createErrorTitle: string;
+    updateErrorTitle: string;
+  };
+};
+
 export type ImageAssistantCopy = {
   title: string;
   subtitle: { before: string; highlight: string; after: string };


### PR DESCRIPTION
## Summary
- add a products screen with inventory list, selling/restocking modal, and navigation entry
- introduce a reusable product form hook/component backed by an in-memory repository
- extend localization data to cover product management copy in both languages

## Testing
- npm test *(fails: vitest binary is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e718ff42f88327b3f5dca606f82468