### PR TITLE
Prevent iOS zoom on assistant chat input

### DIFF
--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -307,7 +307,7 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    fontSize: 14,
+    fontSize: 16,
     fontWeight: "600",
     maxHeight: 100,
   },


### PR DESCRIPTION
## Summary
- increase the assistant chat input font size to 16px to avoid iOS Safari's automatic zoom when focusing the field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e718596ecc8327aba0bf1d3f6c6e47