### PR TITLE
Integrate products inventory with Supabase tracking

### DIFF
--- a/docs/supabase/product_inventory.sql
+++ b/docs/supabase/product_inventory.sql
@@ -1,0 +1,115 @@
+-- Creates supporting structures for product inventory tracking in Supabase
+-- Run inside the `public` schema of your Supabase project.
+
+-- Ensure the products table exists with timestamps
+create table if not exists public.products (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  price_cents integer not null check (price_cents >= 0),
+  stock_quantity integer not null default 0 check (stock_quantity >= 0),
+  sku text unique,
+  description text,
+  cost_cents integer,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists products_sku_idx on public.products (sku);
+
+-- Supabase projects include this helper, but create it if missing.
+create or replace function public.update_updated_at_column()
+returns trigger as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger on_products_updated
+before update on public.products
+for each row
+execute function public.update_updated_at_column();
+
+-- Table to store every stock movement (sales and restocks)
+create table if not exists public.product_stock_movements (
+  id uuid primary key default gen_random_uuid(),
+  product_id uuid not null references public.products(id) on delete cascade,
+  movement_type text not null check (movement_type in ('sell', 'restock')),
+  quantity integer not null check (quantity > 0),
+  delta integer not null,
+  note text,
+  created_at timestamptz not null default timezone('utc', now()),
+  created_by uuid references auth.users(id)
+);
+
+create index if not exists product_stock_movements_product_created_at_idx
+  on public.product_stock_movements (product_id, created_at desc);
+
+-- RPC helper to atomically register a stock movement and keep totals in sync
+create or replace function public.record_product_movement(
+  p_product_id uuid,
+  p_quantity integer,
+  p_movement_type text,
+  p_note text default null
+)
+returns public.products
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_delta integer;
+  v_product public.products;
+begin
+  if p_quantity is null or p_quantity <= 0 then
+    raise exception using message = 'Quantity must be greater than zero';
+  end if;
+
+  if p_movement_type not in ('sell', 'restock') then
+    raise exception using message = 'Invalid movement type';
+  end if;
+
+  select *
+    into v_product
+    from public.products
+   where id = p_product_id
+   for update;
+
+  if not found then
+    raise exception using message = 'Product not found';
+  end if;
+
+  v_delta := case when p_movement_type = 'sell' then -p_quantity else p_quantity end;
+
+  if v_product.stock_quantity + v_delta < 0 then
+    raise exception using message = 'Insufficient stock';
+  end if;
+
+  update public.products
+     set stock_quantity = stock_quantity + v_delta,
+         updated_at = timezone('utc', now())
+   where id = p_product_id
+   returning * into v_product;
+
+  insert into public.product_stock_movements (
+    product_id,
+    movement_type,
+    quantity,
+    delta,
+    note,
+    created_by
+  ) values (
+    p_product_id,
+    p_movement_type,
+    p_quantity,
+    v_delta,
+    p_note,
+    auth.uid()
+  );
+
+  return v_product;
+end;
+$$;
+
+comment on function public.record_product_movement is
+  'Updates product stock and stores the movement (sell/restock) in a single transaction.';

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -27,4 +27,23 @@ const defaultConfig: SupabaseClientConfig = {
   anonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "",
 };
 
-export const supabase = createSupabaseClient(defaultConfig);
+export const hasSupabaseCredentials = Boolean(defaultConfig.url && defaultConfig.anonKey);
+
+export function isSupabaseConfigured() {
+  return hasSupabaseCredentials;
+}
+
+function createUnconfiguredClient(): SupabaseClient {
+  const message = "Supabase client is not configured";
+  const handler = () => {
+    throw new Error(message);
+  };
+  return {
+    from: handler as SupabaseClient["from"],
+    rpc: handler as SupabaseClient["rpc"],
+  } as SupabaseClient;
+}
+
+export const supabase = hasSupabaseCredentials
+  ? createSupabaseClient(defaultConfig)
+  : createUnconfiguredClient();

--- a/tests/bookingService/setup.ts
+++ b/tests/bookingService/setup.ts
@@ -1,12 +1,15 @@
-import { beforeEach, vi } from "vitest";
+import { beforeAll, beforeEach } from "vitest";
 import { supabaseMock } from "./testUtils/supabaseMock";
-import { resetBookingGateway } from "../../src/lib/gateways/bookingGateway";
+import {
+  createSupabaseBookingGateway,
+  setBookingGateway,
+} from "../../src/lib/gateways/bookingGateway";
 
-vi.mock("../../src/lib/supabase", () => ({
-  supabase: supabaseMock.client,
-}));
+beforeAll(() => {
+  setBookingGateway(createSupabaseBookingGateway(supabaseMock.client));
+});
 
 beforeEach(() => {
   supabaseMock.reset();
-  resetBookingGateway();
+  setBookingGateway(createSupabaseBookingGateway(supabaseMock.client));
 });

--- a/tests/bookingService/testUtils/supabaseMock.ts
+++ b/tests/bookingService/testUtils/supabaseMock.ts
@@ -54,9 +54,12 @@ export function createSupabaseMock() {
     return handler;
   });
 
+  const rpc = vi.fn(async () => ({ data: null, error: null, status: 200 }));
+
   return {
-    client: { from },
+    client: { from, rpc },
     from,
+    rpc,
     useTable<T>(table: string, response: SupabaseResponse<T> = { data: null, error: null, status: 200 }) {
       const builder = new MockQueryBuilder<T>(response);
       tables.set(table, builder);
@@ -67,7 +70,8 @@ export function createSupabaseMock() {
     },
     reset() {
       tables.clear();
-      from.mockReset();
+      from.mockClear();
+      rpc.mockClear();
     },
   };
 }


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the `products` table, `product_stock_movements` ledger, and RPC helper to adjust stock atomically
- refactor the products data layer to use Supabase when credentials exist, including sell/restock helpers that call the new RPC
- harden shared infrastructure by stubbing the Supabase client when env vars are missing, propagating PostgREST error messages, and updating tests to configure the Supabase mock client directly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7bd094d7c8327a02dbc8fddb2c3bd