### PR TITLE
Add typing indicator to assistant chat

### DIFF
--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -109,8 +109,20 @@ export default function AssistantChat({
             );
           })}
           {pending && (
-            <View style={[styles.bubble, { alignSelf: "flex-start", backgroundColor: colors.surface, borderColor: colors.border }]}>
-              <ActivityIndicator size="small" color={colors.subtext} />
+            <View
+              style={[
+                styles.bubble,
+                {
+                  alignSelf: "flex-start",
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              <View style={styles.typingRow}>
+                <ActivityIndicator size="small" color={colors.subtext} />
+                <Text style={[styles.typingText, { color: colors.subtext }]}>{copy.typingIndicator}</Text>
+              </View>
             </View>
           )}
         </ScrollView>
@@ -233,6 +245,15 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 16,
     borderWidth: 1,
+  },
+  typingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  typingText: {
+    fontSize: 13,
+    fontWeight: "600",
   },
   messageText: { fontSize: 14, fontWeight: "600", lineHeight: 20 },
   errorText: { fontSize: 12, fontWeight: "700" },

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -39,6 +39,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       inputPlaceholder: "Ask about bookings...",
       sendAccessibility: "Send message",
+      typingIndicator: "Typing…",
       suggestionsAccessibility: {
         show: "Show quick suggestions",
         hide: "Hide quick suggestions",
@@ -284,6 +285,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       inputPlaceholder: "Pergunte sobre os agendamentos...",
       sendAccessibility: "Enviar mensagem",
+      typingIndicator: "Digitando…",
       suggestionsAccessibility: {
         show: "Mostrar sugestões rápidas",
         hide: "Ocultar sugestões rápidas",

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -14,6 +14,7 @@ export type AssistantChatCopy = {
   };
   inputPlaceholder: string;
   sendAccessibility: string;
+  typingIndicator: string;
   suggestionsAccessibility: {
     show: string;
     hide: string;


### PR DESCRIPTION
## Summary
- add localized copy for a typing indicator message
- show a typing bubble with spinner while the assistant response is pending

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e827d8dda88327985ad49c2f495bac