### PR TITLE
Handle foreign key errors when deleting services

### DIFF
--- a/tests/bookingService/unit/services.test.ts
+++ b/tests/bookingService/unit/services.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from "vitest";
+import { createServicesRepository } from "../../../src/lib/services";
+import { supabaseMock } from "../testUtils/supabaseMock";
+
+describe("services repository", () => {
+  it("throws a helpful message when a foreign key violation occurs", async () => {
+    supabaseMock.useTable("services", {
+      data: null,
+      status: 409,
+      error: {
+        code: "23503",
+        message: "update or delete on table \"services\" violates foreign key constraint",
+      },
+    });
+
+    const repository = createServicesRepository(supabaseMock.client);
+
+    await expect(repository.deleteService("svc-1")).rejects.toThrow(
+      "This service is currently being used and cannot be deleted.",
+    );
+  });
+
+  it("detects foreign key violations reported without the postgres error code", async () => {
+    supabaseMock.useTable("services", {
+      data: null,
+      status: 409,
+      error: {
+        code: "PGRST116",
+        message: "Key (id)=(svc-1) is still referenced from table \"bookings\".",
+      },
+    });
+
+    const repository = createServicesRepository(supabaseMock.client);
+
+    await expect(repository.deleteService("svc-1")).rejects.toThrow(
+      "This service is currently being used and cannot be deleted.",
+    );
+  });
+
+  it("throws the original error when deletion fails for another reason", async () => {
+    const original = new Error("boom");
+    supabaseMock.useTable("services", { data: null, status: 500, error: original });
+
+    const repository = createServicesRepository(supabaseMock.client);
+
+    await expect(repository.deleteService("svc-1")).rejects.toThrow(original);
+  });
+});


### PR DESCRIPTION
## Summary
- broaden foreign key violation detection when deleting services so the UI surfaces a friendly alert
- add unit tests that cover the new error handling paths for service deletions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e835c1fad8832792faa406de8e8d2e