### PR TITLE
Add booking completion confirmation workflow

### DIFF
--- a/docs/supabase/add_performed_at_to_bookings.sql
+++ b/docs/supabase/add_performed_at_to_bookings.sql
@@ -1,0 +1,5 @@
+alter table public.bookings
+  add column if not exists performed_at timestamp with time zone;
+
+comment on column public.bookings.performed_at is
+  'Timestamp recorded when the service was confirmed as performed.';

--- a/src/lib/bookings.ts
+++ b/src/lib/bookings.ts
@@ -141,6 +141,19 @@ export async function cancelBooking(id: string) {
   }
 }
 
+export async function confirmBookingPerformed(id: string, performedAt = new Date().toISOString()) {
+  const gateway = getBookingGateway();
+  try {
+    const { data, status } = await gateway.markBookingPerformed(id, performedAt);
+    logger.info("bookings.confirmBookingPerformed succeeded", { id, status });
+    return data.performed_at ?? performedAt;
+  } catch (error) {
+    const status = error instanceof PersistenceError ? error.status : undefined;
+    logger.error("bookings.confirmBookingPerformed failed", { id, status, error });
+    throw error;
+  }
+}
+
 export async function listCustomers(query: string) {
   const gateway = getBookingGateway();
   const q = (query || "").trim();

--- a/src/lib/types/booking.ts
+++ b/src/lib/types/booking.ts
@@ -6,6 +6,7 @@ export type DbBooking = {
   service_id: string;
   barber: string;
   customer_id?: string | null;
+  performed_at?: string | null;
 };
 
 export type Customer = {


### PR DESCRIPTION
## Summary
- add a Supabase gateway method and booking helper to mark services as performed
- update the bookings view to let staff confirm completed appointments and only record the cash entry after confirmation
- document the new `performed_at` column required on the `bookings` table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e90838f2408327bcb82496ad1d84aa