### PR TITLE
Skip Azure deploy in Dependabot PRs

### DIFF
--- a/.github/workflows/azure-static-web-apps-lively-plant-0be70001e.yml
+++ b/.github/workflows/azure-static-web-apps-lively-plant-0be70001e.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.actor != 'dependabot[bot]')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     env:
       EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}


### PR DESCRIPTION
## Summary
- prevent the Azure Static Web Apps deployment job from running on Dependabot-authored pull requests to avoid missing secret failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e910133208832791e25a0f31ae9462