### PR TITLE
Fix confirm service button on web

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2029,6 +2029,21 @@ export default function App() {
       const dateLabel = humanDate(booking.date, locale);
       const timeLabel = booking.start;
 
+      if (Platform.OS === "web") {
+        const promptMessage = bookingsCopy.results.confirmPromptMessage({
+          serviceName,
+          date: dateLabel,
+          time: timeLabel,
+        });
+        const confirmed = typeof window !== "undefined" && window.confirm
+          ? window.confirm(`${bookingsCopy.results.confirmPromptTitle}\n\n${promptMessage}`)
+          : true;
+        if (confirmed) {
+          void confirmBooking(booking);
+        }
+        return;
+      }
+
       Alert.alert(
         bookingsCopy.results.confirmPromptTitle,
         bookingsCopy.results.confirmPromptMessage({ serviceName, date: dateLabel, time: timeLabel }),


### PR DESCRIPTION
## Summary
- add a web-specific confirmation fallback for the Confirm Service action
- call the existing booking confirmation logic when the web confirmation prompt succeeds

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e910c84b388327b11a48ded688d818