### PR TITLE
Add localized product names and adjust product form defaults

### DIFF
--- a/src/hooks/useProductForm.ts
+++ b/src/hooks/useProductForm.ts
@@ -56,7 +56,7 @@ export function useProductForm({
   const [priceText, setPriceText] = useState(() =>
     isEditMode && product
       ? centsToInput(product.price_cents)
-      : copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""),
+      : "",
   );
   const [costText, setCostText] = useState(() =>
     isEditMode && product && Number.isFinite(product.cost_cents)
@@ -66,7 +66,7 @@ export function useProductForm({
   const [stockText, setStockText] = useState(() =>
     isEditMode && product
       ? String(product.stock_quantity)
-      : copy.fields.stockPlaceholder.replace(/[^0-9]/g, ""),
+      : "",
   );
   const [description, setDescription] = useState(() =>
     isEditMode && product && product.description ? product.description : "",
@@ -85,13 +85,13 @@ export function useProductForm({
       } else {
         setName("");
         setSku("");
-        setPriceText(copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setPriceText("");
         setCostText("");
-        setStockText(copy.fields.stockPlaceholder.replace(/[^0-9]/g, ""));
+        setStockText("");
         setDescription("");
       }
     },
-    [copy.fields.pricePlaceholder, copy.fields.stockPlaceholder],
+    [],
   );
 
   useEffect(() => {

--- a/src/lib/polyglot.ts
+++ b/src/lib/polyglot.ts
@@ -1,4 +1,4 @@
-import type { Service } from "./domain";
+import type { Product, Service } from "./domain";
 
 export type LanguageCode = "en" | "pt";
 
@@ -45,6 +45,43 @@ const SERVICE_TRANSLATIONS = new Map(
   Object.entries(RAW_SERVICE_TRANSLATIONS).map(([key, value]) => [normalizeKey(key), value]),
 );
 
+const RAW_PRODUCT_TRANSLATIONS: Record<string, Partial<Record<LanguageCode, string>>> = {
+  shampoo: { pt: "Shampoo" },
+  "hydrating shampoo": { pt: "Shampoo hidratante" },
+  "moisturizing shampoo": { pt: "Shampoo hidratante" },
+  conditioner: { pt: "Condicionador" },
+  "leave in": { pt: "Leave-in" },
+  "leave-in": { pt: "Leave-in" },
+  "beard oil": { pt: "Óleo para barba" },
+  "hair oil": { pt: "Óleo capilar" },
+  "hair tonic": { pt: "Tônico capilar" },
+  "scalp tonic": { pt: "Tônico para couro cabeludo" },
+  "beard shampoo": { pt: "Shampoo para barba" },
+  "beard wash": { pt: "Shampoo para barba" },
+  "beard balm": { pt: "Balm para barba" },
+  "after shave": { pt: "Loção pós-barba" },
+  aftershave: { pt: "Loção pós-barba" },
+  "shaving cream": { pt: "Creme de barbear" },
+  "shaving foam": { pt: "Espuma de barbear" },
+  "hair pomade": { pt: "Pomada capilar" },
+  pomade: { pt: "Pomada" },
+  "hair wax": { pt: "Cera modeladora" },
+  "styling wax": { pt: "Cera modeladora" },
+  "hair gel": { pt: "Gel para cabelo" },
+  gel: { pt: "Gel" },
+  "styling powder": { pt: "Pó modelador" },
+  "sea salt spray": { pt: "Spray de sal marinho" },
+  "texture spray": { pt: "Spray texturizador" },
+  "grooming kit": { pt: "Kit de cuidados" },
+  "beard kit": { pt: "Kit para barba" },
+  "pre shave": { pt: "Pré-barba" },
+  "pre-shave": { pt: "Pré-barba" },
+};
+
+const PRODUCT_TRANSLATIONS = new Map(
+  Object.entries(RAW_PRODUCT_TRANSLATIONS).map(([key, value]) => [normalizeKey(key), value]),
+);
+
 function normalizeKey(value?: string | null): string {
   if (!value) return "";
   return value
@@ -84,5 +121,37 @@ export function polyglotServices(services: Service[], language: LanguageCode): S
     const localized = lookupServiceTranslation(svc, language);
     if (!localized || localized === svc.name) return svc;
     return { ...svc, name: localized };
+  });
+}
+
+function lookupProductTranslation(
+  product: Pick<Product, "id" | "name">,
+  language: LanguageCode,
+): string | null {
+  if (language === "en") return product.name;
+
+  const idTranslation = PRODUCT_TRANSLATIONS.get(normalizeKey(product.id))?.[language];
+  if (idTranslation) return idTranslation;
+
+  const nameTranslation = PRODUCT_TRANSLATIONS.get(normalizeKey(product.name))?.[language];
+  if (nameTranslation) return nameTranslation;
+
+  return null;
+}
+
+export function polyglotProductName(
+  product: Pick<Product, "id" | "name">,
+  language: LanguageCode,
+): string {
+  return lookupProductTranslation(product, language) ?? product.name;
+}
+
+export function polyglotProducts(products: Product[], language: LanguageCode): Product[] {
+  if (language === "en") return products;
+
+  return products.map((product) => {
+    const localized = lookupProductTranslation(product, language);
+    if (!localized || localized === product.name) return product;
+    return { ...product, name: localized };
   });
 }


### PR DESCRIPTION
## Summary
- add Portuguese translations for common product names and expose polyglot helpers
- localize product listings, alerts, and stock modal content using translated names
- clear placeholder defaults when opening the create product form so fields start empty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e916ee6eec832789b8f32e2ba02973