### PR TITLE
Add service packages management page

### DIFF
--- a/src/components/ServicePackageForm.tsx
+++ b/src/components/ServicePackageForm.tsx
@@ -1,0 +1,457 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  TextInput,
+  StyleSheet,
+  Modal,
+  ScrollView,
+  Alert,
+} from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import type { Service, ServicePackage } from "../lib/domain";
+import { formatPrice } from "../lib/domain";
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { ServicePackageFormCopy } from "../locales/types";
+import { formCardColors, type FormCardColors } from "../theme/colors";
+import { useServicePackageForm } from "../hooks/useServicePackageForm";
+
+type Props = {
+  mode?: "create" | "edit";
+  services: Service[];
+  servicePackage?: ServicePackage | null;
+  onCreated?: (value: ServicePackage) => void;
+  onUpdated?: (value: ServicePackage) => void;
+  onCancel?: () => void;
+  colors?: FormCardColors;
+  copy?: ServicePackageFormCopy;
+};
+
+export default function ServicePackageForm({
+  mode = "create",
+  services,
+  servicePackage = null,
+  onCreated,
+  onUpdated,
+  onCancel,
+  colors = formCardColors,
+  copy = defaultComponentCopy.servicePackageForm,
+}: Props) {
+  const {
+    isEditMode,
+    name,
+    setName,
+    description,
+    setDescription,
+    regularPriceText,
+    handleRegularPriceChange,
+    packagePriceText,
+    handlePackagePriceChange,
+    items,
+    itemErrors,
+    addItem,
+    removeItem,
+    updateItemService,
+    updateItemQuantity,
+    canAddService,
+    errors,
+    valid,
+    saving,
+    submit,
+  } = useServicePackageForm({
+    mode,
+    servicePackage,
+    services,
+    copy,
+    onCreated,
+    onUpdated,
+  });
+
+  const [pickerItemKey, setPickerItemKey] = useState<string | null>(null);
+
+  const serviceMap = useMemo(() => Object.fromEntries(services.map((svc) => [svc.id, svc])), [services]);
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      const result = await submit();
+      if (!result || result.status === "invalid" || !result.servicePackage) return;
+
+      const { servicePackage: pkg, status } = result;
+      if (status === "created") {
+        Alert.alert(copy.alerts.createdTitle, copy.alerts.createdMessage(pkg.name));
+      } else if (status === "updated") {
+        Alert.alert(copy.alerts.updatedTitle, copy.alerts.updatedMessage(pkg.name));
+      }
+    } catch (error: any) {
+      Alert.alert(
+        isEditMode ? copy.alerts.updateErrorTitle : copy.alerts.createErrorTitle,
+        error?.message ?? String(error),
+      );
+    }
+  }, [copy.alerts, isEditMode, submit]);
+
+  const pickerVisible = pickerItemKey !== null;
+  const pickerItem = pickerItemKey ? items.find((item) => item.key === pickerItemKey) : null;
+
+  const handleSelectService = useCallback(
+    (serviceId: string) => {
+      if (pickerItemKey) {
+        updateItemService(pickerItemKey, serviceId);
+        setPickerItemKey(null);
+      }
+    },
+    [pickerItemKey, updateItemService],
+  );
+
+  const handleCancelPicker = useCallback(() => setPickerItemKey(null), []);
+
+  return (
+    <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface }]}> 
+      <Text style={[styles.title, { color: colors.text }]}>
+        {isEditMode ? copy.editTitle : copy.createTitle}
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.subtext }]}>
+        {isEditMode ? copy.editSubtitle : copy.createSubtitle}
+      </Text>
+
+      <FormField
+        label={copy.fields.nameLabel}
+        value={name}
+        onChangeText={setName}
+        placeholder={copy.fields.namePlaceholder}
+        colors={colors}
+        error={errors.name}
+      />
+
+      <FormField
+        label={copy.fields.descriptionLabel}
+        value={description}
+        onChangeText={setDescription}
+        placeholder={copy.fields.descriptionPlaceholder}
+        colors={colors}
+        multiline
+        numberOfLines={4}
+        style={{ height: 96, textAlignVertical: "top" }}
+      />
+
+      <View style={styles.row}>
+        <FormField
+          label={copy.fields.regularPriceLabel}
+          value={regularPriceText}
+          onChangeText={handleRegularPriceChange}
+          placeholder={copy.fields.regularPricePlaceholder}
+          keyboardType="decimal-pad"
+          colors={colors}
+          error={errors.regularPrice}
+          containerStyle={{ flex: 1, marginBottom: 0 }}
+        />
+        <FormField
+          label={copy.fields.priceLabel}
+          value={packagePriceText}
+          onChangeText={handlePackagePriceChange}
+          placeholder={copy.fields.pricePlaceholder}
+          keyboardType="decimal-pad"
+          colors={colors}
+          error={errors.packagePrice}
+          containerStyle={{ flex: 1, marginBottom: 0 }}
+        />
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={[styles.label, { color: colors.subtext }]}>{copy.fields.servicesLabel}</Text>
+        <Text style={[styles.helper, { color: colors.subtext }]}>{copy.fields.servicesHelper}</Text>
+
+        {items.map((item, index) => {
+          const currentService = item.serviceId ? serviceMap[item.serviceId] : null;
+          const currentErrors = itemErrors[item.key];
+          return (
+            <View key={item.key} style={[styles.packageRow, { borderColor: colors.border }]}>
+              <Pressable
+                onPress={() => setPickerItemKey(item.key)}
+                style={[styles.serviceSelector, { borderColor: colors.border }]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.accessibility.selectService}
+              >
+                <MaterialCommunityIcons
+                  name={currentService ? currentService.icon : "clipboard-alert"}
+                  size={20}
+                  color={currentService ? colors.accent : colors.subtext}
+                />
+                <Text style={{ color: colors.text, fontWeight: "700", flex: 1 }} numberOfLines={1}>
+                  {currentService ? currentService.name : copy.fields.servicesEmpty}
+                </Text>
+                <MaterialCommunityIcons name="chevron-down" size={20} color={colors.subtext} />
+              </Pressable>
+              {currentErrors?.service ? (
+                <Text style={[styles.errorText, { color: colors.danger }]}>{currentErrors.service}</Text>
+              ) : null}
+
+              <FormField
+                label={copy.fields.quantityLabel}
+                value={item.quantityText}
+                onChangeText={(value) => updateItemQuantity(item.key, value)}
+                placeholder={copy.fields.quantityPlaceholder}
+                keyboardType="number-pad"
+                colors={colors}
+                error={currentErrors?.quantity}
+              />
+
+              <Pressable
+                onPress={() => removeItem(item.key)}
+                style={[styles.removeButton, { borderColor: colors.border }]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.accessibility.removeService(
+                  currentService?.name ?? copy.fields.servicesEmpty,
+                )}
+              >
+                <MaterialCommunityIcons name="trash-can-outline" size={18} color={colors.danger} />
+                <Text style={{ color: colors.danger, fontWeight: "700" }}>{copy.buttons.removeService}</Text>
+              </Pressable>
+            </View>
+          );
+        })}
+
+        {errors.items ? <Text style={[styles.errorText, { color: colors.danger }]}>{errors.items}</Text> : null}
+
+        <Pressable
+          onPress={addItem}
+          disabled={!canAddService}
+          style={[
+            styles.addButton,
+            {
+              borderColor: colors.accent,
+              backgroundColor: canAddService ? "rgba(59,130,246,0.12)" : "transparent",
+              opacity: canAddService ? 1 : 0.5,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={copy.accessibility.addService}
+        >
+          <MaterialCommunityIcons name="plus-circle-outline" size={18} color={colors.accent} />
+          <Text style={{ color: colors.accent, fontWeight: "700" }}>{copy.buttons.addService}</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.actions}>
+        <Pressable
+          onPress={() => {
+            if (!saving) onCancel?.();
+          }}
+          disabled={saving}
+          style={[styles.actionButton, { borderColor: colors.border }, saving && { opacity: 0.6 }]}
+          accessibilityRole="button"
+          accessibilityLabel={copy.accessibility.cancel}
+        >
+          <Text style={{ color: colors.subtext, fontWeight: "700" }}>{copy.buttons.cancel}</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleSubmit}
+          disabled={!valid}
+          style={[
+            styles.actionButton,
+            {
+              borderColor: colors.accent,
+              backgroundColor: valid ? "rgba(37,99,235,0.15)" : "rgba(148,163,184,0.2)",
+            },
+            !valid && { opacity: 0.6 },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={isEditMode ? copy.accessibility.submitEdit : copy.accessibility.submitCreate}
+        >
+          <Text style={{ color: colors.accent, fontWeight: "700" }}>
+            {saving ? copy.buttons.saving : isEditMode ? copy.buttons.edit : copy.buttons.create}
+          </Text>
+        </Pressable>
+      </View>
+
+      <Modal transparent visible={pickerVisible} animationType="fade" onRequestClose={handleCancelPicker}>
+        <View style={styles.modalBackdrop}>
+          <View style={[styles.modalCard, { borderColor: colors.border, backgroundColor: colors.surface }]}> 
+            <Text style={[styles.modalTitle, { color: colors.text }]}>{copy.fields.servicesLabel}</Text>
+            <ScrollView style={{ maxHeight: 320 }}>
+              {services.map((svc) => (
+                <Pressable
+                  key={svc.id}
+                  onPress={() => handleSelectService(svc.id)}
+                  style={[
+                    styles.modalOption,
+                    {
+                      borderColor:
+                        pickerItem?.serviceId === svc.id ? colors.accent : colors.border,
+                      backgroundColor:
+                        pickerItem?.serviceId === svc.id ? "rgba(96,165,250,0.15)" : "transparent",
+                    },
+                  ]}
+                >
+                  <MaterialCommunityIcons name={svc.icon} size={20} color={colors.text} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ color: colors.text, fontWeight: "700" }}>{svc.name}</Text>
+                    <Text style={{ color: colors.subtext, fontSize: 12 }}>
+                      {svc.estimated_minutes} min • {formatPrice(svc.price_cents)}
+                    </Text>
+                  </View>
+                </Pressable>
+              ))}
+              {services.length === 0 ? (
+                <Text style={{ color: colors.subtext, textAlign: "center", paddingVertical: 16 }}>
+                  {copy.fields.servicesEmpty}
+                </Text>
+              ) : null}
+            </ScrollView>
+            <Pressable
+              onPress={handleCancelPicker}
+              style={[styles.actionButton, { borderColor: colors.border, alignSelf: "flex-end" }]}
+              accessibilityRole="button"
+              accessibilityLabel={copy.buttons.cancel}
+            >
+              <Text style={{ color: colors.subtext, fontWeight: "700" }}>{copy.buttons.cancel}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+type FormFieldProps = React.ComponentProps<typeof TextInput> & {
+  label: string;
+  error?: string;
+  colors: FormCardColors;
+  containerStyle?: any;
+};
+
+function FormField({ label, error, colors, containerStyle, style, ...rest }: FormFieldProps) {
+  return (
+    <View style={[{ marginBottom: 12 }, containerStyle]}>
+      <Text style={[styles.label, { color: colors.subtext }]}>{label}</Text>
+      <TextInput
+        {...rest}
+        style={[
+          styles.input,
+          style,
+          { borderColor: error ? colors.danger : colors.border, color: colors.text },
+        ]}
+        placeholderTextColor="#94a3b8"
+      />
+      {error ? <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: 16,
+    gap: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  subtitle: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  helper: {
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: "rgba(15,23,42,0.35)",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  errorText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  row: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  packageRow: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    gap: 10,
+  },
+  serviceSelector: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  removeButton: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+  },
+  addButton: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "flex-end",
+  },
+  actionButton: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(15,23,42,0.65)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  modalCard: {
+    width: "100%",
+    maxWidth: 420,
+    borderWidth: 1,
+    borderRadius: 18,
+    padding: 18,
+    gap: 16,
+  },
+  modalTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+  },
+  modalOption: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 8,
+  },
+});

--- a/src/hooks/useServicePackageForm.ts
+++ b/src/hooks/useServicePackageForm.ts
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { Service, ServicePackage } from "../lib/domain";
+import {
+  createServicePackage,
+  updateServicePackage,
+  type ServicePackageInput,
+} from "../lib/packages";
+import type { ServicePackageFormCopy } from "../locales/types";
+import { centsToInput, parsePrice } from "./useServiceForm";
+
+export type ServicePackageFormMode = "create" | "edit";
+
+type PackageItemState = {
+  key: string;
+  serviceId: string | null;
+  quantityText: string;
+};
+
+type PackageItemErrors = {
+  service?: string;
+  quantity?: string;
+};
+
+export type UseServicePackageFormOptions = {
+  mode: ServicePackageFormMode;
+  servicePackage: ServicePackage | null | undefined;
+  services: Service[];
+  copy: ServicePackageFormCopy;
+  onCreated?: (value: ServicePackage) => void;
+  onUpdated?: (value: ServicePackage) => void;
+};
+
+type SubmitStatus = "invalid" | "created" | "updated";
+
+export type ServicePackageFormState = {
+  isEditMode: boolean;
+  name: string;
+  setName: (value: string) => void;
+  description: string;
+  setDescription: (value: string) => void;
+  regularPriceText: string;
+  handleRegularPriceChange: (value: string) => void;
+  packagePriceText: string;
+  handlePackagePriceChange: (value: string) => void;
+  items: PackageItemState[];
+  itemErrors: Record<string, PackageItemErrors>;
+  addItem: () => void;
+  removeItem: (key: string) => void;
+  updateItemService: (key: string, serviceId: string | null) => void;
+  updateItemQuantity: (key: string, value: string) => void;
+  canAddService: boolean;
+  errors: Record<string, string>;
+  valid: boolean;
+  saving: boolean;
+  submit: () => Promise<{ status: SubmitStatus; servicePackage?: ServicePackage }>;
+};
+
+const makeItemKey = () => `pkg_item_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+
+export function useServicePackageForm({
+  mode,
+  servicePackage = null,
+  services,
+  copy,
+  onCreated,
+  onUpdated,
+}: UseServicePackageFormOptions): ServicePackageFormState {
+  const isEditMode = mode === "edit";
+
+  const [name, setName] = useState(() => (isEditMode && servicePackage ? servicePackage.name : ""));
+  const [description, setDescription] = useState(() =>
+    isEditMode && servicePackage && servicePackage.description ? servicePackage.description : "",
+  );
+  const [regularPriceText, setRegularPriceText] = useState(() =>
+    isEditMode && servicePackage
+      ? centsToInput(servicePackage.regular_price_cents)
+      : copy.fields.regularPricePlaceholder.replace(/[^0-9.,]/g, ""),
+  );
+  const [packagePriceText, setPackagePriceText] = useState(() =>
+    isEditMode && servicePackage
+      ? centsToInput(servicePackage.price_cents)
+      : copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""),
+  );
+  const [items, setItems] = useState<PackageItemState[]>(() => {
+    if (isEditMode && servicePackage) {
+      return servicePackage.items.map((item) => ({
+        key: makeItemKey(),
+        serviceId: item.service_id,
+        quantityText: String(item.quantity),
+      }));
+    }
+    const defaultServiceId = services[0]?.id ?? null;
+    return [
+      {
+        key: makeItemKey(),
+        serviceId: defaultServiceId,
+        quantityText: copy.fields.quantityPlaceholder.replace(/[^0-9]/g, "") || "1",
+      },
+    ];
+  });
+  const [saving, setSaving] = useState(false);
+
+  const setFromPackage = useCallback(
+    (pkg: ServicePackage | null) => {
+      if (pkg) {
+        setName(pkg.name);
+        setDescription(pkg.description ?? "");
+        setRegularPriceText(centsToInput(pkg.regular_price_cents));
+        setPackagePriceText(centsToInput(pkg.price_cents));
+        setItems(
+          pkg.items.length
+            ? pkg.items.map((item) => ({
+                key: makeItemKey(),
+                serviceId: item.service_id,
+                quantityText: String(item.quantity),
+              }))
+            : [
+                {
+                  key: makeItemKey(),
+                  serviceId: services[0]?.id ?? null,
+                  quantityText: copy.fields.quantityPlaceholder.replace(/[^0-9]/g, "") || "1",
+                },
+              ],
+        );
+      } else {
+        setName("");
+        setDescription("");
+        setRegularPriceText(copy.fields.regularPricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setPackagePriceText(copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setItems([
+          {
+            key: makeItemKey(),
+            serviceId: services[0]?.id ?? null,
+            quantityText: copy.fields.quantityPlaceholder.replace(/[^0-9]/g, "") || "1",
+          },
+        ]);
+      }
+    },
+    [copy.fields.pricePlaceholder, copy.fields.quantityPlaceholder, copy.fields.regularPricePlaceholder, services],
+  );
+
+  useEffect(() => {
+    if (isEditMode && servicePackage) {
+      setFromPackage(servicePackage);
+    } else if (!isEditMode) {
+      setFromPackage(null);
+    }
+  }, [isEditMode, servicePackage, setFromPackage]);
+
+  useEffect(() => {
+    setItems((current) => {
+      if (!services.length) {
+        return current.map((item) => ({ ...item, serviceId: null }));
+      }
+      const firstService = services[0].id;
+      return current.map((item) =>
+        item.serviceId && services.some((svc) => svc.id === item.serviceId)
+          ? item
+          : { ...item, serviceId: firstService },
+      );
+    });
+  }, [services]);
+
+  const handleRegularPriceChange = useCallback((value: string) => {
+    setRegularPriceText(value.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const handlePackagePriceChange = useCallback((value: string) => {
+    setPackagePriceText(value.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const addItem = useCallback(() => {
+    setItems((current) => [
+      ...current,
+      {
+        key: makeItemKey(),
+        serviceId: services[0]?.id ?? null,
+        quantityText: copy.fields.quantityPlaceholder.replace(/[^0-9]/g, "") || "1",
+      },
+    ]);
+  }, [copy.fields.quantityPlaceholder, services]);
+
+  const removeItem = useCallback((key: string) => {
+    setItems((current) => {
+      if (current.length <= 1) {
+        return [
+          {
+            key: makeItemKey(),
+            serviceId: services[0]?.id ?? null,
+            quantityText: copy.fields.quantityPlaceholder.replace(/[^0-9]/g, "") || "1",
+          },
+        ];
+      }
+      return current.filter((item) => item.key !== key);
+    });
+  }, [copy.fields.quantityPlaceholder, services]);
+
+  const updateItemService = useCallback((key: string, serviceId: string | null) => {
+    setItems((current) =>
+      current.map((item) => (item.key === key ? { ...item, serviceId } : item)),
+    );
+  }, []);
+
+  const updateItemQuantity = useCallback((key: string, value: string) => {
+    setItems((current) =>
+      current.map((item) =>
+        item.key === key
+          ? { ...item, quantityText: value.replace(/[^0-9]/g, "") }
+          : item,
+      ),
+    );
+  }, []);
+
+  const regularPriceCents = useMemo(() => parsePrice(regularPriceText), [regularPriceText]);
+  const packagePriceCents = useMemo(() => parsePrice(packagePriceText), [packagePriceText]);
+
+  const itemErrors = useMemo(() => {
+    const map: Record<string, PackageItemErrors> = {};
+    items.forEach((item) => {
+      const errs: PackageItemErrors = {};
+      if (!item.serviceId) {
+        errs.service = copy.fields.servicesEmpty;
+      }
+      const quantity = Number(item.quantityText);
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        errs.quantity = copy.fields.quantityError;
+      }
+      if (Object.keys(errs).length > 0) {
+        map[item.key] = errs;
+      }
+    });
+    return map;
+  }, [copy.fields.quantityError, copy.fields.servicesEmpty, items]);
+
+  const baseErrors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = copy.fields.nameError;
+    if (!Number.isFinite(regularPriceCents) || regularPriceCents < 0)
+      errs.regularPrice = copy.fields.regularPriceError;
+    if (!Number.isFinite(packagePriceCents) || packagePriceCents < 0)
+      errs.packagePrice = copy.fields.priceError;
+    if (Number.isFinite(regularPriceCents) && Number.isFinite(packagePriceCents)) {
+      if ((regularPriceCents ?? 0) < (packagePriceCents ?? 0)) {
+        errs.packagePrice = copy.fields.priceError;
+      }
+    }
+    if (!items.length) {
+      errs.items = copy.fields.servicesEmpty;
+    }
+    return errs;
+  }, [
+    copy.fields.nameError,
+    copy.fields.priceError,
+    copy.fields.regularPriceError,
+    copy.fields.servicesEmpty,
+    items.length,
+    name,
+    packagePriceCents,
+    regularPriceCents,
+  ]);
+
+  const readyToSubmit = useMemo(() => {
+    if (Object.keys(baseErrors).length > 0) return false;
+    if (Object.keys(itemErrors).length > 0) return false;
+    if (isEditMode && !servicePackage) return false;
+    return true;
+  }, [baseErrors, itemErrors, isEditMode, servicePackage]);
+
+  const canAddService = services.length > 0;
+
+  const submit = useCallback(async () => {
+    if (!readyToSubmit || saving) {
+      return { status: "invalid" as const };
+    }
+
+    setSaving(true);
+    try {
+      const payload: ServicePackageInput = {
+        name: name.trim(),
+        description: description.trim() || null,
+        regular_price_cents: regularPriceCents,
+        price_cents: packagePriceCents,
+        items: items.map((item) => ({
+          service_id: item.serviceId ?? "",
+          quantity: Number(item.quantityText),
+        })),
+      };
+
+      if (isEditMode && servicePackage) {
+        const updated = await updateServicePackage(servicePackage.id, payload);
+        setFromPackage(updated);
+        onUpdated?.(updated);
+        return { status: "updated" as const, servicePackage: updated };
+      }
+
+      const created = await createServicePackage(payload);
+      setFromPackage(null);
+      onCreated?.(created);
+      return { status: "created" as const, servicePackage: created };
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    description,
+    isEditMode,
+    items,
+    name,
+    onCreated,
+    onUpdated,
+    packagePriceCents,
+    readyToSubmit,
+    regularPriceCents,
+    saving,
+    servicePackage,
+    setFromPackage,
+  ]);
+
+  return {
+    isEditMode,
+    name,
+    setName,
+    description,
+    setDescription,
+    regularPriceText,
+    handleRegularPriceChange,
+    packagePriceText,
+    handlePackagePriceChange,
+    items,
+    itemErrors,
+    addItem,
+    removeItem,
+    updateItemService,
+    updateItemQuantity,
+    canAddService,
+    errors: baseErrors,
+    valid: readyToSubmit && !saving,
+    saving,
+    submit,
+  };
+}

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -23,6 +23,22 @@ export type Product = {
   updated_at?: string | null;
 };
 
+export type ServicePackageId = string;
+export type ServicePackageItem = {
+  service_id: ServiceId;
+  quantity: number;
+};
+export type ServicePackage = {
+  id: ServicePackageId;
+  name: string;
+  description?: string | null;
+  regular_price_cents: number;
+  price_cents: number;
+  items: ServicePackageItem[];
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
 export type BarberId = "joao" | "maria" | "carlos";
 export type Barber = {
   id: BarberId;

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -1,0 +1,253 @@
+import type { PostgrestSingleResponse } from "@supabase/supabase-js";
+
+import type { ServicePackage, ServicePackageItem } from "./domain";
+import { hasSupabaseCredentials, supabase } from "./supabase";
+
+export type ServicePackageInput = {
+  name: string;
+  description?: string | null;
+  regular_price_cents: number;
+  price_cents: number;
+  items: ServicePackageItem[];
+};
+
+type NormalizedPackageInput = {
+  name: string;
+  description: string | null;
+  regular_price_cents: number;
+  price_cents: number;
+  items: ServicePackageItem[];
+};
+
+type SupabasePackageRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  regular_price_cents: number;
+  price_cents: number;
+  items: ServicePackageItem[];
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+const PACKAGE_COLUMNS =
+  "id,name,description,regular_price_cents,price_cents,items,created_at,updated_at";
+
+const useMemoryStore = !hasSupabaseCredentials;
+
+const nowIso = () => new Date().toISOString();
+const clone = (pkg: ServicePackage): ServicePackage => ({
+  ...pkg,
+  items: pkg.items.map((item) => ({ ...item })),
+});
+
+const generateId = () => `pkg_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+
+let memoryPackages: ServicePackage[] = [
+  {
+    id: "pkg-haircut-shave-10",
+    name: "10× Haircut + Shave",
+    description: "Perfect for loyal clients who want a fresh cut and shave every visit.",
+    regular_price_cents: 120000,
+    price_cents: 99000,
+    items: [
+      { service_id: "svc-haircut", quantity: 10 },
+      { service_id: "svc-shave", quantity: 10 },
+    ],
+    created_at: nowIso(),
+    updated_at: nowIso(),
+  },
+  {
+    id: "pkg-haircut-5",
+    name: "5× Haircut",
+    description: "Bundle of five signature haircuts with a loyal customer discount.",
+    regular_price_cents: 60000,
+    price_cents: 52000,
+    items: [{ service_id: "svc-haircut", quantity: 5 }],
+    created_at: nowIso(),
+    updated_at: nowIso(),
+  },
+];
+
+function normalizeInput(payload: ServicePackageInput): NormalizedPackageInput {
+  const name = payload.name?.trim();
+  const regularPrice = Number(payload.regular_price_cents);
+  const price = Number(payload.price_cents);
+  const items = Array.isArray(payload.items) ? payload.items : [];
+
+  if (!name) {
+    throw new Error("Name is required");
+  }
+  if (!Number.isFinite(regularPrice) || regularPrice < 0) {
+    throw new Error("Regular price must be 0 or more");
+  }
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error("Package price must be 0 or more");
+  }
+  if (!items.length) {
+    throw new Error("Include at least one service in the package");
+  }
+
+  const normalizedItems = items.map((item) => {
+    const serviceId = item.service_id?.trim();
+    const quantity = Number(item.quantity);
+    if (!serviceId) {
+      throw new Error("Service ID is required for each package item");
+    }
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new Error("Item quantity must be greater than zero");
+    }
+    return { service_id: serviceId, quantity: Math.round(quantity) };
+  });
+
+  return {
+    name,
+    description: payload.description?.trim() || null,
+    regular_price_cents: Math.round(regularPrice),
+    price_cents: Math.round(price),
+    items: normalizedItems,
+  };
+}
+
+function mapPackage(row: SupabasePackageRow): ServicePackage {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    regular_price_cents: row.regular_price_cents,
+    price_cents: row.price_cents,
+    items: Array.isArray(row.items)
+      ? row.items.map((item) => ({
+          service_id: item.service_id,
+          quantity: item.quantity,
+        }))
+      : [],
+    created_at: row.created_at ?? undefined,
+    updated_at: row.updated_at ?? undefined,
+  };
+}
+
+async function listPackagesFromMemory(): Promise<ServicePackage[]> {
+  return memoryPackages.map(clone);
+}
+
+async function createPackageInMemory(input: NormalizedPackageInput): Promise<ServicePackage> {
+  const now = nowIso();
+  const pkg: ServicePackage = {
+    id: generateId(),
+    ...input,
+    created_at: now,
+    updated_at: now,
+  };
+  memoryPackages = [...memoryPackages, pkg];
+  return clone(pkg);
+}
+
+async function updatePackageInMemory(id: string, input: NormalizedPackageInput): Promise<ServicePackage> {
+  const index = memoryPackages.findIndex((item) => item.id === id);
+  if (index === -1) {
+    throw new Error("Package not found");
+  }
+
+  const now = nowIso();
+  const current = memoryPackages[index];
+  const updated: ServicePackage = {
+    ...current,
+    ...input,
+    updated_at: now,
+  };
+
+  memoryPackages = [
+    ...memoryPackages.slice(0, index),
+    updated,
+    ...memoryPackages.slice(index + 1),
+  ];
+
+  return clone(updated);
+}
+
+async function deletePackageFromMemory(id: string): Promise<void> {
+  memoryPackages = memoryPackages.filter((pkg) => pkg.id !== id);
+}
+
+function ensureId(id: string) {
+  if (!id) {
+    throw new Error("Package ID is required");
+  }
+}
+
+export async function listServicePackages(): Promise<ServicePackage[]> {
+  if (useMemoryStore) {
+    return listPackagesFromMemory();
+  }
+
+  const { data, error } = await supabase
+    .from("service_packages")
+    .select(PACKAGE_COLUMNS)
+    .order("name");
+  if (error) throw error;
+  const rows = (data ?? []) as SupabasePackageRow[];
+  return rows.map(mapPackage);
+}
+
+export async function createServicePackage(payload: ServicePackageInput): Promise<ServicePackage> {
+  const input = normalizeInput(payload);
+  if (useMemoryStore) {
+    return createPackageInMemory(input);
+  }
+
+  const response: PostgrestSingleResponse<SupabasePackageRow> = await supabase
+    .from("service_packages")
+    .insert({
+      name: input.name,
+      description: input.description,
+      regular_price_cents: input.regular_price_cents,
+      price_cents: input.price_cents,
+      items: input.items,
+    })
+    .select(PACKAGE_COLUMNS)
+    .single();
+
+  if (response.error) throw response.error;
+  if (!response.data) throw new Error("Failed to create service package");
+  return mapPackage(response.data);
+}
+
+export async function updateServicePackage(
+  id: string,
+  payload: ServicePackageInput,
+): Promise<ServicePackage> {
+  ensureId(id);
+  const input = normalizeInput(payload);
+  if (useMemoryStore) {
+    return updatePackageInMemory(id, input);
+  }
+
+  const response: PostgrestSingleResponse<SupabasePackageRow> = await supabase
+    .from("service_packages")
+    .update({
+      name: input.name,
+      description: input.description,
+      regular_price_cents: input.regular_price_cents,
+      price_cents: input.price_cents,
+      items: input.items,
+    })
+    .eq("id", id)
+    .select(PACKAGE_COLUMNS)
+    .single();
+
+  if (response.error) throw response.error;
+  if (!response.data) throw new Error("Service package not found");
+  return mapPackage(response.data);
+}
+
+export async function deleteServicePackage(id: string): Promise<void> {
+  ensureId(id);
+  if (useMemoryStore) {
+    await deletePackageFromMemory(id);
+    return;
+  }
+
+  const { error } = await supabase.from("service_packages").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -5,6 +5,7 @@ import type {
   RecurrenceModalCopy,
   ServiceFormCopy,
   ProductFormCopy,
+  ServicePackageFormCopy,
   UserFormCopy,
 } from "./types";
 
@@ -15,6 +16,7 @@ type ComponentCopy = {
   imageAssistant: ImageAssistantCopy;
   serviceForm: ServiceFormCopy;
   productForm: ProductFormCopy;
+  servicePackageForm: ServicePackageFormCopy;
   userForm: UserFormCopy;
   recurrenceModal: RecurrenceModalCopy;
   occurrencePreview: OccurrencePreviewCopy;
@@ -179,6 +181,55 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, stock: number) => `${name} (${stock} in stock)`,
         createErrorTitle: "Create product failed",
         updateErrorTitle: "Update product failed",
+      },
+    },
+    servicePackageForm: {
+      createTitle: "Register a service package",
+      editTitle: "Edit service package",
+      createSubtitle: "Bundle multiple services and offer a loyal-client discount.",
+      editSubtitle: "Update the included services or pricing for this package.",
+      fields: {
+        nameLabel: "Package name",
+        namePlaceholder: "10 haircuts + 10 shaves",
+        nameError: "Name is required",
+        descriptionLabel: "Description",
+        descriptionPlaceholder: "Details about when to recommend this bundle.",
+        regularPriceLabel: "Regular price",
+        regularPricePlaceholder: "1200.00",
+        regularPriceError: "Enter the total regular price",
+        priceLabel: "Package price",
+        pricePlaceholder: "990.00",
+        priceError: "Enter the discounted package price",
+        servicesLabel: "Included services",
+        servicesHelper: "Select services and set how many credits are included.",
+        servicesEmpty: "Add at least one service to the package.",
+        quantityLabel: "Quantity",
+        quantityPlaceholder: "1",
+        quantityError: "Enter a quantity greater than zero",
+      },
+      buttons: {
+        addService: "Add service",
+        removeService: "Remove",
+        create: "Save package",
+        edit: "Save changes",
+        saving: "Saving…",
+        cancel: "Cancel",
+      },
+      accessibility: {
+        submitCreate: "Save service package",
+        submitEdit: "Save service package changes",
+        cancel: "Cancel service package form",
+        addService: "Add service to package",
+        removeService: (name: string) => `Remove ${name} from package`,
+        selectService: "Select service",
+      },
+      alerts: {
+        createdTitle: "Package saved",
+        createdMessage: (name: string) => `${name}`,
+        updatedTitle: "Package updated",
+        updatedMessage: (name: string) => `${name}`,
+        createErrorTitle: "Create package failed",
+        updateErrorTitle: "Update package failed",
       },
     },
     userForm: {
@@ -425,6 +476,55 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, stock: number) => `${name} (${stock} em estoque)`,
         createErrorTitle: "Falha ao criar produto",
         updateErrorTitle: "Falha ao atualizar produto",
+      },
+    },
+    servicePackageForm: {
+      createTitle: "Cadastrar pacote de serviços",
+      editTitle: "Editar pacote de serviços",
+      createSubtitle: "Combine atendimentos e ofereça descontos para clientes fiéis.",
+      editSubtitle: "Atualize os serviços incluídos ou o valor promocional do pacote.",
+      fields: {
+        nameLabel: "Nome do pacote",
+        namePlaceholder: "10 cortes + 10 barbas",
+        nameError: "Informe um nome",
+        descriptionLabel: "Descrição",
+        descriptionPlaceholder: "Quando indicar este pacote para o cliente.",
+        regularPriceLabel: "Preço sem desconto",
+        regularPricePlaceholder: "1200,00",
+        regularPriceError: "Informe o preço de tabela",
+        priceLabel: "Preço do pacote",
+        pricePlaceholder: "990,00",
+        priceError: "Informe o valor com desconto",
+        servicesLabel: "Serviços inclusos",
+        servicesHelper: "Selecione os serviços e quantos créditos cada um possui.",
+        servicesEmpty: "Adicione pelo menos um serviço ao pacote.",
+        quantityLabel: "Quantidade",
+        quantityPlaceholder: "1",
+        quantityError: "Informe uma quantidade maior que zero",
+      },
+      buttons: {
+        addService: "Adicionar serviço",
+        removeService: "Remover",
+        create: "Salvar pacote",
+        edit: "Salvar alterações",
+        saving: "Salvando…",
+        cancel: "Cancelar",
+      },
+      accessibility: {
+        submitCreate: "Salvar pacote de serviços",
+        submitEdit: "Salvar alterações do pacote",
+        cancel: "Cancelar formulário de pacote",
+        addService: "Adicionar serviço ao pacote",
+        removeService: (name: string) => `Remover ${name} do pacote`,
+        selectService: "Selecionar serviço",
+      },
+      alerts: {
+        createdTitle: "Pacote salvo",
+        createdMessage: (name: string) => `${name}`,
+        updatedTitle: "Pacote atualizado",
+        updatedMessage: (name: string) => `${name}`,
+        createErrorTitle: "Falha ao criar pacote",
+        updateErrorTitle: "Falha ao atualizar pacote",
       },
     },
     userForm: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -118,6 +118,56 @@ export type ProductFormCopy = {
   };
 };
 
+export type ServicePackageFormCopy = {
+  createTitle: string;
+  editTitle: string;
+  createSubtitle: string;
+  editSubtitle: string;
+  fields: {
+    nameLabel: string;
+    namePlaceholder: string;
+    nameError: string;
+    descriptionLabel: string;
+    descriptionPlaceholder: string;
+    regularPriceLabel: string;
+    regularPricePlaceholder: string;
+    regularPriceError: string;
+    priceLabel: string;
+    pricePlaceholder: string;
+    priceError: string;
+    servicesLabel: string;
+    servicesHelper: string;
+    servicesEmpty: string;
+    quantityLabel: string;
+    quantityPlaceholder: string;
+    quantityError: string;
+  };
+  buttons: {
+    addService: string;
+    removeService: string;
+    create: string;
+    edit: string;
+    saving: string;
+    cancel: string;
+  };
+  accessibility: {
+    submitCreate: string;
+    submitEdit: string;
+    cancel: string;
+    addService: string;
+    removeService: (serviceName: string) => string;
+    selectService: string;
+  };
+  alerts: {
+    createdTitle: string;
+    createdMessage: (name: string) => string;
+    updatedTitle: string;
+    updatedMessage: (name: string) => string;
+    createErrorTitle: string;
+    updateErrorTitle: string;
+  };
+};
+
 export type ImageAssistantCopy = {
   title: string;
   subtitle: { before: string; highlight: string; after: string };


### PR DESCRIPTION
## Summary
- add domain types, data layer, and localization strings for service packages
- implement a form and hook to create and edit discounted service bundles
- add a packages management screen with navigation entry and CRUD actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e82a02edd083278d7336a7332e0b9c