### PR TITLE
Adjust biweekly recurrence scheduling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2132,7 +2132,7 @@ export default function App() {
         if (opts.frequency === "monthly") {
           occurrenceDate = nextMonthlyOccurrence(occurrenceDate);
         } else {
-          const step = opts.frequency === "every-15-days" ? 15 : 7;
+          const step = opts.frequency === "every-15-days" ? 14 : 7;
           occurrenceDate = addDays(occurrenceDate, step);
         }
       }

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -242,7 +242,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       frequencyOptions: [
         { value: "weekly", label: "Weekly" },
-        { value: "every-15-days", label: "Every 15 days" },
+        { value: "every-15-days", label: "Every two weeks" },
         { value: "monthly", label: "Monthly" },
       ],
       placeholders: {
@@ -495,7 +495,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       frequencyOptions: [
         { value: "weekly", label: "Semanal" },
-        { value: "every-15-days", label: "A cada 15 dias" },
+        { value: "every-15-days", label: "A cada duas semanas" },
         { value: "monthly", label: "Mensal" },
       ],
       placeholders: {


### PR DESCRIPTION
## Summary
- rename the "Every 15 days" recurrence option to "Every two weeks" in both supported languages
- adjust the recurrence generation logic so biweekly bookings always fall on the same weekday as the initial appointment

## Testing
- npm test *(fails: vitest not found before installing dependencies)*
- npm install *(fails: npm registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e954120ec4832780d27db90b15f9ee