### PR TITLE
Add service package management view

### DIFF
--- a/docs/supabase/service_packages.sql
+++ b/docs/supabase/service_packages.sql
@@ -1,0 +1,90 @@
+-- Service packages tables for Supabase
+-- Run these statements inside the `public` schema after applying booking_management.sql.
+
+create table if not exists public.service_packages (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (char_length(name) between 1 and 160),
+  price_cents integer not null check (price_cents >= 0),
+  original_price_cents integer not null check (original_price_cents >= 0),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  created_by uuid references auth.users(id)
+);
+
+create trigger on_service_packages_updated
+before update on public.service_packages
+for each row
+execute function public.update_updated_at_column();
+
+comment on table public.service_packages is 'Discounted bundles made of multiple services.';
+
+create table if not exists public.service_package_items (
+  id uuid primary key default gen_random_uuid(),
+  package_id uuid not null references public.service_packages(id) on delete cascade,
+  service_id uuid not null references public.services(id) on delete restrict,
+  quantity integer not null check (quantity > 0),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists service_package_items_package_service_idx
+  on public.service_package_items (package_id, service_id);
+
+comment on table public.service_package_items is 'Stores how many times each service appears in a package.';
+
+alter table public.service_packages enable row level security;
+alter table public.service_package_items enable row level security;
+
+create policy if not exists "Authenticated users can read service packages" on public.service_packages
+for select using (
+  auth.role() = 'authenticated'
+  and created_by = auth.uid()
+);
+
+create policy if not exists "Authenticated users can manage service packages" on public.service_packages
+for all using (
+  auth.role() = 'authenticated'
+  and created_by = auth.uid()
+)
+  with check (
+    auth.role() = 'authenticated'
+    and created_by = auth.uid()
+  );
+
+create policy if not exists "Service role can manage service packages" on public.service_packages
+for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy if not exists "Authenticated users can read package items" on public.service_package_items
+for select using (
+  auth.role() = 'authenticated'
+  and exists (
+    select 1
+    from public.service_packages p
+    where p.id = service_package_items.package_id
+      and p.created_by = auth.uid()
+  )
+);
+
+create policy if not exists "Authenticated users can manage package items" on public.service_package_items
+for all using (
+  auth.role() = 'authenticated'
+  and exists (
+    select 1
+    from public.service_packages p
+    where p.id = service_package_items.package_id
+      and p.created_by = auth.uid()
+  )
+)
+  with check (
+    auth.role() = 'authenticated'
+    and exists (
+      select 1
+      from public.service_packages p
+      where p.id = service_package_items.package_id
+        and p.created_by = auth.uid()
+    )
+  );
+
+create policy if not exists "Service role can manage package items" on public.service_package_items
+for all using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');

--- a/src/components/ServicePackageForm.tsx
+++ b/src/components/ServicePackageForm.tsx
@@ -1,0 +1,370 @@
+import React, { useCallback, useMemo } from "react";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import type { Service, ServicePackage } from "../lib/domain";
+import { formatPrice } from "../lib/domain";
+import { useServicePackageForm } from "../hooks/useServicePackageForm";
+import { defaultComponentCopy } from "../locales/componentCopy";
+import type { ServicePackageFormCopy } from "../locales/types";
+import { formCardColors, type FormCardColors } from "../theme/colors";
+
+type Props = {
+  mode?: "create" | "edit";
+  services: Service[];
+  localizedServices: Service[];
+  servicePackage?: ServicePackage | null;
+  onCreated?: (servicePackage: ServicePackage) => void;
+  onUpdated?: (servicePackage: ServicePackage) => void;
+  onCancel?: () => void;
+  colors?: FormCardColors;
+  copy?: ServicePackageFormCopy;
+};
+
+export default function ServicePackageForm({
+  mode = "create",
+  services,
+  localizedServices,
+  servicePackage = null,
+  onCreated,
+  onUpdated,
+  onCancel,
+  colors = formCardColors,
+  copy = defaultComponentCopy.servicePackageForm,
+}: Props) {
+  const {
+    isEditMode,
+    name,
+    setName,
+    priceText,
+    handlePriceChange,
+    quantities,
+    handleQuantityChange,
+    selectedItems,
+    totalUnits,
+    originalPriceCents,
+    packagePriceCents,
+    discountValueCents,
+    discountPercent,
+    errors,
+    valid,
+    saving,
+    submit,
+  } = useServicePackageForm({
+    mode,
+    services,
+    servicePackage,
+    copy,
+    onCreated,
+    onUpdated,
+  });
+
+  const displayServices = useMemo(() => {
+    const baseMap = new Map<string, Service>();
+    services.forEach((svc) => baseMap.set(svc.id, svc));
+    const localizedMap = new Map<string, Service>();
+    localizedServices.forEach((svc) => localizedMap.set(svc.id, svc));
+    const ids = new Set<string>([
+      ...services.map((svc) => svc.id),
+      ...localizedServices.map((svc) => svc.id),
+      ...Object.keys(quantities),
+    ]);
+    return Array.from(ids).map((id) => ({
+      id,
+      base: baseMap.get(id) ?? null,
+      localized: localizedMap.get(id) ?? baseMap.get(id) ?? null,
+    }));
+  }, [localizedServices, quantities, services]);
+
+  const packagePriceDisplay =
+    Number.isFinite(packagePriceCents) && packagePriceCents >= 0 ? formatPrice(packagePriceCents) : "—";
+  const originalPriceDisplay = formatPrice(originalPriceCents);
+  const discountValueDisplay = formatPrice(discountValueCents);
+  const discountPercentDisplay = `${discountPercent}%`;
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      const result = await submit();
+      if (!result || result.status === "invalid" || !result.servicePackage) {
+        return;
+      }
+
+      if (result.status === "created") {
+        Alert.alert(
+          copy.alerts.createdTitle,
+          copy.alerts.createdMessage(result.servicePackage.name, totalUnits),
+        );
+      } else if (result.status === "updated") {
+        Alert.alert(
+          copy.alerts.updatedTitle,
+          copy.alerts.updatedMessage(result.servicePackage.name, totalUnits),
+        );
+      }
+    } catch (err: any) {
+      Alert.alert(
+        isEditMode ? copy.alerts.updateErrorTitle : copy.alerts.createErrorTitle,
+        err?.message ?? String(err),
+      );
+    }
+  }, [copy.alerts, isEditMode, submit, totalUnits]);
+
+  return (
+    <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface }]}> 
+      <Text style={[styles.title, { color: colors.text }]}>
+        {isEditMode ? copy.editTitle : copy.createTitle}
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.subtext }]}>
+        {isEditMode ? copy.editSubtitle : copy.createSubtitle}
+      </Text>
+
+      <FormField
+        label={copy.fields.nameLabel}
+        value={name}
+        onChangeText={setName}
+        placeholder={copy.fields.namePlaceholder}
+        error={errors.name}
+        colors={colors}
+      />
+
+      <FormField
+        label={copy.fields.priceLabel}
+        value={priceText}
+        onChangeText={handlePriceChange}
+        placeholder={copy.fields.pricePlaceholder}
+        error={errors.price}
+        colors={colors}
+        keyboardType="decimal-pad"
+        helper={copy.fields.priceHelper}
+      />
+
+      <View style={{ gap: 6 }}>
+        <Text style={[styles.label, { color: colors.subtext }]}>{copy.fields.servicesLabel}</Text>
+        <Text style={[styles.helper, { color: colors.subtext }]}>{copy.fields.servicesHelper}</Text>
+        <View style={[styles.serviceList, { borderColor: colors.border }]}> 
+          <ScrollView style={{ maxHeight: 280 }} nestedScrollEnabled>
+            <View style={{ gap: 10 }}>
+              {displayServices.map(({ id, base, localized }) => {
+                const quantityText = quantities[id] ?? "";
+                const selected = Number(quantityText) > 0;
+                const iconName = (base?.icon ?? "help-circle") as keyof typeof MaterialCommunityIcons.glyphMap;
+                const priceMeta = base
+                  ? copy.fields.serviceMeta(base.estimated_minutes, formatPrice(base.price_cents))
+                  : copy.fields.missingServicePrice;
+                const label = localized?.name ?? base?.name ?? id;
+                return (
+                  <View
+                    key={id}
+                    style={[
+                      styles.serviceRow,
+                      {
+                        borderColor: selected ? colors.accent : colors.border,
+                        backgroundColor: selected ? "rgba(96,165,250,0.12)" : "rgba(15,23,42,0.35)",
+                      },
+                    ]}
+                  >
+                    <View style={styles.serviceInfo}>
+                      <MaterialCommunityIcons name={iconName} size={22} color={colors.accent} />
+                      <View style={{ flex: 1 }}>
+                        <Text style={[styles.serviceName, { color: colors.text }]} numberOfLines={1}>
+                          {label}
+                        </Text>
+                        <Text style={[styles.serviceMeta, { color: colors.subtext }]}>{priceMeta}</Text>
+                      </View>
+                    </View>
+                    <View style={styles.quantityColumn}>
+                      <Text style={[styles.quantityLabel, { color: colors.subtext }]}>
+                        {copy.fields.quantityLabel}
+                      </Text>
+                      <TextInput
+                        value={quantityText}
+                        onChangeText={(text) => handleQuantityChange(id, text)}
+                        placeholder={copy.fields.quantityPlaceholder}
+                        placeholderTextColor="#94a3b8"
+                        keyboardType="number-pad"
+                        style={[
+                          styles.quantityInput,
+                          { borderColor: selected ? colors.accent : colors.border, color: colors.text },
+                        ]}
+                      />
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          </ScrollView>
+        </View>
+        {errors.items ? <Text style={[styles.errorText, { color: colors.danger }]}>{errors.items}</Text> : null}
+      </View>
+
+      <View style={[styles.summaryCard, { borderColor: colors.border, backgroundColor: "rgba(15,23,42,0.35)" }]}> 
+        <Text style={[styles.summaryTitle, { color: colors.subtext }]}>{copy.summary.title}</Text>
+        {selectedItems.length === 0 ? (
+          <Text style={[styles.summaryEmpty, { color: colors.subtext }]}>{copy.summary.empty}</Text>
+        ) : (
+          <View style={{ gap: 4 }}>
+            <Text style={[styles.summaryValue, { color: colors.text }]}>
+              {copy.summary.totalUnits(totalUnits)}
+            </Text>
+            <Text style={[styles.summaryMeta, { color: colors.subtext }]}>
+              {copy.summary.packagePrice(packagePriceDisplay)}
+            </Text>
+            <Text style={[styles.summaryMeta, { color: colors.subtext }]}>
+              {copy.summary.originalPrice(originalPriceDisplay)}
+            </Text>
+            <Text style={[styles.summaryMeta, { color: colors.subtext }]}>
+              {copy.summary.discountValue(discountValueDisplay)}
+            </Text>
+            <Text style={[styles.summaryMeta, { color: colors.subtext }]}>
+              {copy.summary.discountPercent(discountPercentDisplay)}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <Pressable
+        onPress={handleSubmit}
+        disabled={!valid}
+        style={[
+          styles.button,
+          {
+            backgroundColor: valid ? colors.accent : "rgba(255,255,255,0.08)",
+            borderColor: valid ? colors.accent : colors.border,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={isEditMode ? copy.accessibility.submitEdit : copy.accessibility.submitCreate}
+      >
+        <Text style={[styles.buttonText, { color: valid ? colors.accentFgOn : colors.subtext }]}>
+          {saving
+            ? copy.buttons.saving
+            : isEditMode
+              ? copy.buttons.edit
+              : copy.buttons.create}
+        </Text>
+      </Pressable>
+
+      {onCancel ? (
+        <Pressable
+          onPress={() => {
+            if (!saving) onCancel();
+          }}
+          style={[styles.secondaryButton, { borderColor: colors.border }]}
+          accessibilityRole="button"
+          accessibilityLabel={copy.accessibility.cancel}
+        >
+          <Text style={[styles.secondaryButtonText, { color: colors.subtext }]}>{copy.buttons.cancel}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function FormField({
+  label,
+  error,
+  helper,
+  colors,
+  style,
+  ...rest
+}: {
+  label: string;
+  error?: string;
+  helper?: string;
+  colors: FormCardColors;
+  style?: any;
+} & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={[{ gap: 6 }, style]}>
+      <Text style={[styles.label, { color: colors.subtext }]}>{label}</Text>
+      <TextInput
+        {...rest}
+        placeholderTextColor="#94a3b8"
+        style={[styles.input, { borderColor: error ? colors.danger : colors.border, color: colors.text }]}
+      />
+      {helper ? <Text style={[styles.helper, { color: colors.subtext }]}>{helper}</Text> : null}
+      {error ? <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 16,
+  },
+  title: { fontSize: 18, fontWeight: "800" },
+  subtitle: { fontSize: 13, fontWeight: "600" },
+  label: { fontSize: 12, fontWeight: "700" },
+  helper: { fontSize: 11, fontWeight: "600" },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 16,
+    fontWeight: "700",
+    backgroundColor: "rgba(15,23,42,0.35)",
+  },
+  errorText: { fontSize: 12, fontWeight: "700" },
+  serviceList: {
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 10,
+    backgroundColor: "rgba(15,23,42,0.2)",
+  },
+  serviceRow: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  serviceInfo: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    flex: 1,
+  },
+  serviceName: { fontSize: 14, fontWeight: "800" },
+  serviceMeta: { fontSize: 12, fontWeight: "600" },
+  quantityColumn: { gap: 4, width: 90 },
+  quantityLabel: { fontSize: 11, fontWeight: "700" },
+  quantityInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    fontSize: 14,
+    fontWeight: "700",
+    textAlign: "center",
+    backgroundColor: "rgba(8,15,35,0.45)",
+  },
+  summaryCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    gap: 8,
+  },
+  summaryTitle: { fontSize: 12, fontWeight: "700" },
+  summaryEmpty: { fontSize: 12, fontWeight: "600" },
+  summaryValue: { fontSize: 16, fontWeight: "800" },
+  summaryMeta: { fontSize: 12, fontWeight: "600" },
+  button: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  buttonText: { fontSize: 14, fontWeight: "800" },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  secondaryButtonText: { fontSize: 13, fontWeight: "800" },
+});

--- a/src/hooks/useServicePackageForm.ts
+++ b/src/hooks/useServicePackageForm.ts
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { Service, ServicePackage } from "../lib/domain";
+import { createServicePackage, updateServicePackage } from "../lib/servicePackages";
+import type { ServicePackageFormCopy } from "../locales/types";
+import { centsToInput, parsePrice } from "./useServiceForm";
+
+type ServicePackageFormMode = "create" | "edit";
+
+type UseServicePackageFormOptions = {
+  mode: ServicePackageFormMode;
+  services: Service[];
+  servicePackage: ServicePackage | null | undefined;
+  copy: ServicePackageFormCopy;
+  onCreated?: (servicePackage: ServicePackage) => void;
+  onUpdated?: (servicePackage: ServicePackage) => void;
+};
+
+type SubmitStatus = "invalid" | "created" | "updated";
+
+type SubmitResult = {
+  status: SubmitStatus;
+  servicePackage?: ServicePackage;
+};
+
+type QuantityMap = Record<string, string>;
+
+type UseServicePackageFormReturn = {
+  isEditMode: boolean;
+  name: string;
+  setName: (value: string) => void;
+  priceText: string;
+  handlePriceChange: (text: string) => void;
+  quantities: QuantityMap;
+  handleQuantityChange: (serviceId: string, text: string) => void;
+  selectedItems: ReadonlyArray<{ service_id: string; quantity: number }>;
+  totalUnits: number;
+  originalPriceCents: number;
+  packagePriceCents: number;
+  discountValueCents: number;
+  discountPercent: number;
+  errors: Record<string, string>;
+  valid: boolean;
+  saving: boolean;
+  submit: () => Promise<SubmitResult>;
+};
+
+function sanitizeNumericInput(text: string) {
+  return text.replace(/[^0-9]/g, "");
+}
+
+export function useServicePackageForm({
+  mode,
+  services,
+  servicePackage = null,
+  copy,
+  onCreated,
+  onUpdated,
+}: UseServicePackageFormOptions): UseServicePackageFormReturn {
+  const isEditMode = mode === "edit";
+
+  const [name, setName] = useState(() => (isEditMode && servicePackage ? servicePackage.name : ""));
+  const [priceText, setPriceText] = useState(() =>
+    isEditMode && servicePackage
+      ? centsToInput(servicePackage.price_cents)
+      : copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""),
+  );
+  const [quantities, setQuantities] = useState<QuantityMap>(() => {
+    if (!isEditMode || !servicePackage) return {};
+    const entries: QuantityMap = {};
+    servicePackage.items.forEach((item) => {
+      entries[item.service_id] = String(item.quantity);
+    });
+    return entries;
+  });
+  const [saving, setSaving] = useState(false);
+
+  const setFromPackage = useCallback(
+    (pkg: ServicePackage | null) => {
+      if (pkg) {
+        setName(pkg.name);
+        setPriceText(centsToInput(pkg.price_cents));
+        setQuantities(() => {
+          const next: QuantityMap = {};
+          pkg.items.forEach((item) => {
+            next[item.service_id] = String(item.quantity);
+          });
+          return next;
+        });
+      } else {
+        setName("");
+        setPriceText(copy.fields.pricePlaceholder.replace(/[^0-9.,]/g, ""));
+        setQuantities({});
+      }
+    },
+    [copy.fields.pricePlaceholder],
+  );
+
+  useEffect(() => {
+    if (isEditMode && servicePackage) {
+      setFromPackage(servicePackage);
+    } else if (!isEditMode) {
+      setFromPackage(null);
+    }
+  }, [isEditMode, servicePackage, setFromPackage]);
+
+  const serviceIdOrder = useMemo(() => services.map((svc) => svc.id), [services]);
+  const servicePriceMap = useMemo(() => {
+    const map = new Map<string, number>();
+    services.forEach((svc) => {
+      map.set(svc.id, Number(svc.price_cents) || 0);
+    });
+    return map;
+  }, [services]);
+
+  const packagePriceCents = useMemo(() => parsePrice(priceText), [priceText]);
+
+  const selectedItems = useMemo(() => {
+    const knownIds = new Set(serviceIdOrder);
+    const extras = Object.keys(quantities).filter((id) => !knownIds.has(id));
+    const allIds = [...serviceIdOrder, ...extras];
+
+    const items = allIds
+      .map((id) => {
+        const value = Number(quantities[id]);
+        if (!Number.isFinite(value) || value <= 0) {
+          return null;
+        }
+        return { service_id: id, quantity: Math.round(value) };
+      })
+      .filter((item): item is { service_id: string; quantity: number } => Boolean(item));
+
+    const combined = new Map<string, number>();
+    items.forEach((item) => {
+      const current = combined.get(item.service_id) ?? 0;
+      combined.set(item.service_id, current + item.quantity);
+    });
+
+    return Array.from(combined.entries()).map(([service_id, quantity]) => ({ service_id, quantity }));
+  }, [quantities, serviceIdOrder]);
+
+  const totalUnits = useMemo(
+    () => selectedItems.reduce((total, item) => total + item.quantity, 0),
+    [selectedItems],
+  );
+
+  const originalPriceCents = useMemo(() => {
+    return selectedItems.reduce((total, item) => {
+      const unitPrice = servicePriceMap.get(item.service_id) ?? 0;
+      return total + unitPrice * item.quantity;
+    }, 0);
+  }, [selectedItems, servicePriceMap]);
+
+  const discountValueCents = useMemo(() => {
+    if (!Number.isFinite(packagePriceCents) || packagePriceCents < 0) return 0;
+    const diff = originalPriceCents - packagePriceCents;
+    return diff > 0 ? diff : 0;
+  }, [originalPriceCents, packagePriceCents]);
+
+  const discountPercent = useMemo(() => {
+    if (!originalPriceCents) return 0;
+    return Math.max(0, Math.round((discountValueCents / originalPriceCents) * 100));
+  }, [discountValueCents, originalPriceCents]);
+
+  const errors = useMemo(() => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) {
+      errs.name = copy.fields.nameError;
+    }
+    if (!Number.isFinite(packagePriceCents) || packagePriceCents < 0) {
+      errs.price = copy.fields.priceError;
+    }
+    if (!selectedItems.length) {
+      errs.items = copy.fields.itemsError;
+    }
+    if (
+      selectedItems.length &&
+      Number.isFinite(packagePriceCents) &&
+      packagePriceCents >= originalPriceCents
+    ) {
+      errs.price = copy.fields.priceDiscountError;
+    }
+    return errs;
+  }, [
+    copy.fields.itemsError,
+    copy.fields.nameError,
+    copy.fields.priceDiscountError,
+    copy.fields.priceError,
+    name,
+    originalPriceCents,
+    packagePriceCents,
+    selectedItems,
+  ]);
+
+  const readyToSubmit = useMemo(
+    () => Object.keys(errors).length === 0 && (!isEditMode || !!servicePackage),
+    [errors, isEditMode, servicePackage],
+  );
+
+  const valid = readyToSubmit && !saving;
+
+  const handlePriceChange = useCallback((text: string) => {
+    setPriceText(text.replace(/[^0-9.,]/g, ""));
+  }, []);
+
+  const handleQuantityChange = useCallback((serviceId: string, text: string) => {
+    setQuantities((prev) => ({ ...prev, [serviceId]: sanitizeNumericInput(text) }));
+  }, []);
+
+  const submit = useCallback(async (): Promise<SubmitResult> => {
+    if (!readyToSubmit || saving) {
+      return { status: "invalid" };
+    }
+    setSaving(true);
+    try {
+      if (isEditMode && servicePackage) {
+        const updated = await updateServicePackage(servicePackage.id, {
+          name: name.trim(),
+          price_cents: packagePriceCents,
+          original_price_cents: originalPriceCents,
+          items: selectedItems,
+        });
+        setFromPackage(updated);
+        onUpdated?.(updated);
+        return { status: "updated", servicePackage: updated };
+      }
+
+      const created = await createServicePackage({
+        name: name.trim(),
+        price_cents: packagePriceCents,
+        original_price_cents: originalPriceCents,
+        items: selectedItems,
+      });
+      setFromPackage(null);
+      onCreated?.(created);
+      return { status: "created", servicePackage: created };
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    readyToSubmit,
+    saving,
+    isEditMode,
+    servicePackage,
+    name,
+    packagePriceCents,
+    originalPriceCents,
+    selectedItems,
+    setFromPackage,
+    onUpdated,
+    onCreated,
+  ]);
+
+  return {
+    isEditMode,
+    name,
+    setName,
+    priceText,
+    handlePriceChange,
+    quantities,
+    handleQuantityChange,
+    selectedItems,
+    totalUnits,
+    originalPriceCents,
+    packagePriceCents,
+    discountValueCents,
+    discountPercent,
+    errors,
+    valid,
+    saving,
+    submit,
+  };
+}

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -10,6 +10,25 @@ export type Service = {
   created_at?: string | null;
 };
 
+export type ServicePackageItem = {
+  id?: string;
+  service_id: ServiceId;
+  quantity: number;
+  service?: Service | null;
+};
+
+export type ServicePackageId = string;
+
+export type ServicePackage = {
+  id: ServicePackageId;
+  name: string;
+  price_cents: number;
+  original_price_cents: number;
+  items: ServicePackageItem[];
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
 export type ProductId = string;
 export type Product = {
   id: ProductId;

--- a/src/lib/servicePackages.ts
+++ b/src/lib/servicePackages.ts
@@ -1,0 +1,338 @@
+import type { Service, ServicePackage, ServicePackageItem } from "./domain";
+import { hasSupabaseCredentials, supabase, type SupabaseClientLike } from "./supabase";
+
+export type ServicePackageItemInput = {
+  service_id: string;
+  quantity: number;
+};
+
+export type ServicePackageInput = {
+  name: string;
+  price_cents: number;
+  original_price_cents: number;
+  items: ReadonlyArray<ServicePackageItemInput>;
+};
+
+type NormalizedServicePackageInput = {
+  name: string;
+  price_cents: number;
+  original_price_cents: number;
+  items: ReadonlyArray<{ service_id: string; quantity: number }>;
+};
+
+type DbServicePackageItemRow = {
+  id: string;
+  service_id: string;
+  quantity: number;
+  services: {
+    id: string;
+    name: string;
+    estimated_minutes: number;
+    price_cents: number;
+    icon: string;
+    created_at: string | null;
+  } | null;
+};
+
+type DbServicePackageRow = {
+  id: string;
+  name: string;
+  price_cents: number;
+  original_price_cents: number;
+  created_at: string | null;
+  updated_at: string | null;
+  service_package_items: DbServicePackageItemRow[] | null;
+};
+
+const SERVICE_PACKAGE_COLUMNS =
+  "id,name,price_cents,original_price_cents,created_at,updated_at," +
+  "service_package_items:service_package_items (" +
+  "id,service_id,quantity," +
+  "services:services (id,name,estimated_minutes,price_cents,icon,created_at)" +
+  ")";
+
+const useMemoryStore = !hasSupabaseCredentials;
+
+let memoryPackages: ServicePackage[] = [];
+
+const cloneService = (service: Service): Service => ({ ...service });
+
+const cloneItem = (item: ServicePackageItem): ServicePackageItem => ({
+  ...item,
+  service: item.service ? cloneService(item.service) : item.service ?? undefined,
+});
+
+const clonePackage = (pkg: ServicePackage): ServicePackage => ({
+  ...pkg,
+  items: pkg.items.map(cloneItem),
+});
+
+const generateId = () => `pkg_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+
+const nowIso = () => new Date().toISOString();
+
+function normalizeInput(payload: ServicePackageInput): NormalizedServicePackageInput {
+  const name = payload.name?.trim();
+  if (!name) {
+    throw new Error("Name is required");
+  }
+
+  const price = Number(payload.price_cents);
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error("Price must be 0 or more");
+  }
+
+  const original = Number(payload.original_price_cents);
+  if (!Number.isFinite(original) || original <= 0) {
+    throw new Error("Original price must be greater than 0");
+  }
+
+  const itemMap = new Map<string, number>();
+  payload.items.forEach((item) => {
+    const id = item.service_id?.trim();
+    if (!id) {
+      throw new Error("Service ID is required");
+    }
+    const quantity = Number(item.quantity);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new Error("Quantity must be greater than 0");
+    }
+    const current = itemMap.get(id) ?? 0;
+    itemMap.set(id, current + Math.round(quantity));
+  });
+
+  const items = Array.from(itemMap.entries()).map(([service_id, quantity]) => ({ service_id, quantity }));
+
+  if (items.length === 0) {
+    throw new Error("Select at least one service");
+  }
+
+  if (price >= original) {
+    throw new Error("Price must be lower than the sum of services");
+  }
+
+  return {
+    name,
+    price_cents: Math.round(price),
+    original_price_cents: Math.round(original),
+    items,
+  };
+}
+
+function mapRow(row: DbServicePackageRow): ServicePackage {
+  const items: ServicePackageItem[] = (row.service_package_items ?? []).map((item) => {
+    const serviceRow = item.services;
+    let service: Service | null = null;
+    if (serviceRow) {
+      const minutes = Number(serviceRow.estimated_minutes);
+      const price = Number(serviceRow.price_cents);
+      service = {
+        id: serviceRow.id,
+        name: serviceRow.name,
+        estimated_minutes: Number.isFinite(minutes)
+          ? minutes
+          : Number.parseInt(String(serviceRow.estimated_minutes ?? 0), 10) || 0,
+        price_cents: Number.isFinite(price)
+          ? price
+          : Number.parseInt(String(serviceRow.price_cents ?? 0), 10) || 0,
+        icon: (serviceRow.icon || "content-cut") as Service["icon"],
+        created_at: serviceRow.created_at ?? null,
+      };
+    }
+    return {
+      id: item.id,
+      service_id: item.service_id,
+      quantity: Number(item.quantity) || 0,
+      service,
+    };
+  });
+
+  return {
+    id: row.id,
+    name: row.name,
+    price_cents: Number(row.price_cents) || 0,
+    original_price_cents: Number(row.original_price_cents) || 0,
+    created_at: row.created_at ?? null,
+    updated_at: row.updated_at ?? null,
+    items,
+  };
+}
+
+async function listPackagesFromMemory(): Promise<ServicePackage[]> {
+  return memoryPackages.map(clonePackage);
+}
+
+async function createPackageInMemory(input: NormalizedServicePackageInput): Promise<ServicePackage> {
+  const now = nowIso();
+  const pkg: ServicePackage = {
+    id: generateId(),
+    name: input.name,
+    price_cents: input.price_cents,
+    original_price_cents: input.original_price_cents,
+    created_at: now,
+    updated_at: now,
+    items: input.items.map((item) => ({ service_id: item.service_id, quantity: item.quantity })),
+  };
+  memoryPackages = [...memoryPackages, pkg];
+  return clonePackage(pkg);
+}
+
+async function updatePackageInMemory(id: string, input: NormalizedServicePackageInput): Promise<ServicePackage> {
+  const index = memoryPackages.findIndex((item) => item.id === id);
+  if (index === -1) {
+    throw new Error("Service package not found");
+  }
+  const now = nowIso();
+  const current = memoryPackages[index];
+  const updated: ServicePackage = {
+    ...current,
+    name: input.name,
+    price_cents: input.price_cents,
+    original_price_cents: input.original_price_cents,
+    updated_at: now,
+    items: input.items.map((item) => ({ service_id: item.service_id, quantity: item.quantity })),
+  };
+  memoryPackages = [...memoryPackages.slice(0, index), updated, ...memoryPackages.slice(index + 1)];
+  return clonePackage(updated);
+}
+
+async function deletePackageFromMemory(id: string): Promise<void> {
+  memoryPackages = memoryPackages.filter((item) => item.id !== id);
+}
+
+async function listPackagesFromSupabase(client: SupabaseClientLike): Promise<ServicePackage[]> {
+  const { data, error } = await client.from("service_packages").select(SERVICE_PACKAGE_COLUMNS).order("name");
+  if (error) throw error;
+  return (data ?? []).map((row) => mapRow(row as DbServicePackageRow));
+}
+
+async function fetchPackageById(client: SupabaseClientLike, id: string): Promise<ServicePackage> {
+  const { data, error } = await client
+    .from("service_packages")
+    .select(SERVICE_PACKAGE_COLUMNS)
+    .eq("id", id)
+    .single();
+  if (error) throw error;
+  return mapRow(data as DbServicePackageRow);
+}
+
+async function createPackageInSupabase(
+  client: SupabaseClientLike,
+  input: NormalizedServicePackageInput,
+): Promise<ServicePackage> {
+  const { data, error } = await client
+    .from("service_packages")
+    .insert({
+      name: input.name,
+      price_cents: input.price_cents,
+      original_price_cents: input.original_price_cents,
+    })
+    .select("id")
+    .single();
+
+  if (error) throw error;
+  const createdId = (data as { id: string } | null)?.id;
+  if (!createdId) {
+    throw new Error("Failed to create service package");
+  }
+
+  try {
+    if (input.items.length) {
+      const { error: itemsError } = await client.from("service_package_items").insert(
+        input.items.map((item) => ({
+          package_id: createdId,
+          service_id: item.service_id,
+          quantity: item.quantity,
+        })),
+      );
+      if (itemsError) throw itemsError;
+    }
+  } catch (err) {
+    await client.from("service_packages").delete().eq("id", createdId);
+    throw err;
+  }
+
+  return fetchPackageById(client, createdId);
+}
+
+async function updatePackageInSupabase(
+  client: SupabaseClientLike,
+  id: string,
+  input: NormalizedServicePackageInput,
+): Promise<ServicePackage> {
+  const { error } = await client
+    .from("service_packages")
+    .update({
+      name: input.name,
+      price_cents: input.price_cents,
+      original_price_cents: input.original_price_cents,
+    })
+    .eq("id", id);
+
+  if (error) throw error;
+
+  const { error: deleteError } = await client.from("service_package_items").delete().eq("package_id", id);
+  if (deleteError) throw deleteError;
+
+  if (input.items.length) {
+    const { error: insertError } = await client.from("service_package_items").insert(
+      input.items.map((item) => ({
+        package_id: id,
+        service_id: item.service_id,
+        quantity: item.quantity,
+      })),
+    );
+    if (insertError) throw insertError;
+  }
+
+  return fetchPackageById(client, id);
+}
+
+async function deletePackageInSupabase(client: SupabaseClientLike, id: string): Promise<void> {
+  const { error } = await client.from("service_packages").delete().eq("id", id);
+  if (error) throw error;
+}
+
+export function createServicePackagesRepository(client: SupabaseClientLike) {
+  return {
+    async listServicePackages(): Promise<ServicePackage[]> {
+      if (useMemoryStore) {
+        return listPackagesFromMemory();
+      }
+      return listPackagesFromSupabase(client);
+    },
+
+    async createServicePackage(payload: ServicePackageInput): Promise<ServicePackage> {
+      const input = normalizeInput(payload);
+      if (useMemoryStore) {
+        return createPackageInMemory(input);
+      }
+      return createPackageInSupabase(client, input);
+    },
+
+    async updateServicePackage(id: string, payload: ServicePackageInput): Promise<ServicePackage> {
+      if (!id) throw new Error("Service package ID is required");
+      const input = normalizeInput(payload);
+      if (useMemoryStore) {
+        return updatePackageInMemory(id, input);
+      }
+      return updatePackageInSupabase(client, id, input);
+    },
+
+    async deleteServicePackage(id: string): Promise<void> {
+      if (!id) throw new Error("Service package ID is required");
+      if (useMemoryStore) {
+        await deletePackageFromMemory(id);
+        return;
+      }
+      await deletePackageInSupabase(client, id);
+    },
+  };
+}
+
+const defaultRepository = createServicePackagesRepository(supabase);
+
+export const listServicePackages = defaultRepository.listServicePackages;
+export const createServicePackage = defaultRepository.createServicePackage;
+export const updateServicePackage = defaultRepository.updateServicePackage;
+export const deleteServicePackage = defaultRepository.deleteServicePackage;

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -4,6 +4,7 @@ import type {
   OccurrencePreviewCopy,
   RecurrenceModalCopy,
   ServiceFormCopy,
+  ServicePackageFormCopy,
   ProductFormCopy,
   UserFormCopy,
 } from "./types";
@@ -14,6 +15,7 @@ type ComponentCopy = {
   assistantChat: AssistantChatCopy;
   imageAssistant: ImageAssistantCopy;
   serviceForm: ServiceFormCopy;
+  servicePackageForm: ServicePackageFormCopy;
   productForm: ProductFormCopy;
   userForm: UserFormCopy;
   recurrenceModal: RecurrenceModalCopy;
@@ -137,6 +139,57 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
         createErrorTitle: "Create service failed",
         updateErrorTitle: "Update service failed",
+      },
+    },
+    servicePackageForm: {
+      createTitle: "Register a package",
+      editTitle: "Edit package",
+      createSubtitle: "Combine multiple services into discounted bundles.",
+      editSubtitle: "Update the included services or pricing for this package.",
+      fields: {
+        nameLabel: "Name",
+        namePlaceholder: "10 haircuts bundle",
+        nameError: "Name is required",
+        priceLabel: "Package price",
+        pricePlaceholder: "249.90",
+        priceHelper: "Use the discounted price clients will pay.",
+        priceError: "Enter a valid price",
+        priceDiscountError: "Package price must be lower than the sum of services",
+        servicesLabel: "Included services",
+        servicesHelper: "Enter how many times each service is part of the package.",
+        quantityLabel: "Qty",
+        quantityPlaceholder: "0",
+        itemsError: "Select at least one service",
+        missingServicePrice: "Service unavailable",
+        serviceMeta: (minutes: number, price: string) => `${minutes} min • ${price}`,
+      },
+      summary: {
+        title: "Package summary",
+        empty: "Add quantities to calculate totals.",
+        totalUnits: (units: number) => `${units} service${units === 1 ? "" : "s"} included`,
+        packagePrice: (price: string) => `Package price: ${price}`,
+        originalPrice: (price: string) => `Original value: ${price}`,
+        discountValue: (price: string) => `You save: ${price}`,
+        discountPercent: (percent: string) => `Discount: ${percent}`,
+      },
+      buttons: {
+        create: "Create package",
+        edit: "Save changes",
+        saving: "Saving…",
+        cancel: "Cancel",
+      },
+      accessibility: {
+        submitCreate: "Create package",
+        submitEdit: "Save package changes",
+        cancel: "Cancel package form",
+      },
+      alerts: {
+        createdTitle: "Package created",
+        createdMessage: (name: string, units: number) => `${name} (${units} service${units === 1 ? "" : "s"})`,
+        updatedTitle: "Package updated",
+        updatedMessage: (name: string, units: number) => `${name} (${units} service${units === 1 ? "" : "s"})`,
+        createErrorTitle: "Create package failed",
+        updateErrorTitle: "Update package failed",
       },
     },
     productForm: {
@@ -390,6 +443,57 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         updatedMessage: (name: string, minutes: number) => `${name} (${minutes} min)`,
         createErrorTitle: "Falha ao criar serviço",
         updateErrorTitle: "Falha ao atualizar serviço",
+      },
+    },
+    servicePackageForm: {
+      createTitle: "Cadastrar pacote",
+      editTitle: "Editar pacote",
+      createSubtitle: "Monte combos com vários serviços com desconto.",
+      editSubtitle: "Atualize os serviços incluídos ou o valor deste pacote.",
+      fields: {
+        nameLabel: "Nome",
+        namePlaceholder: "Pacote 10 cortes",
+        nameError: "Informe o nome",
+        priceLabel: "Preço do pacote",
+        pricePlaceholder: "249,90",
+        priceHelper: "Informe o valor com desconto que o cliente pagará.",
+        priceError: "Informe um preço válido",
+        priceDiscountError: "O preço do pacote deve ser menor que a soma dos serviços",
+        servicesLabel: "Serviços incluídos",
+        servicesHelper: "Preencha quantas vezes cada serviço faz parte do pacote.",
+        quantityLabel: "Qtd",
+        quantityPlaceholder: "0",
+        itemsError: "Selecione pelo menos um serviço",
+        missingServicePrice: "Serviço indisponível",
+        serviceMeta: (minutes: number, price: string) => `${minutes} min • ${price}`,
+      },
+      summary: {
+        title: "Resumo do pacote",
+        empty: "Defina as quantidades para calcular os totais.",
+        totalUnits: (units: number) => `${units} serviço${units === 1 ? "" : "s"} incluído${units === 1 ? "" : "s"}`,
+        packagePrice: (price: string) => `Preço do pacote: ${price}`,
+        originalPrice: (price: string) => `Valor somado: ${price}`,
+        discountValue: (price: string) => `Economia: ${price}`,
+        discountPercent: (percent: string) => `Desconto: ${percent}`,
+      },
+      buttons: {
+        create: "Criar pacote",
+        edit: "Salvar alterações",
+        saving: "Salvando…",
+        cancel: "Cancelar",
+      },
+      accessibility: {
+        submitCreate: "Criar pacote",
+        submitEdit: "Salvar alterações do pacote",
+        cancel: "Cancelar formulário de pacote",
+      },
+      alerts: {
+        createdTitle: "Pacote criado",
+        createdMessage: (name: string, units: number) => `${name} (${units} serviço${units === 1 ? "" : "s"})`,
+        updatedTitle: "Pacote atualizado",
+        updatedMessage: (name: string, units: number) => `${name} (${units} serviço${units === 1 ? "" : "s"})`,
+        createErrorTitle: "Erro ao criar pacote",
+        updateErrorTitle: "Erro ao atualizar pacote",
       },
     },
     productForm: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -75,6 +75,58 @@ export type ServiceFormCopy = {
   };
 };
 
+export type ServicePackageFormCopy = {
+  createTitle: string;
+  editTitle: string;
+  createSubtitle: string;
+  editSubtitle: string;
+  fields: {
+    nameLabel: string;
+    namePlaceholder: string;
+    nameError: string;
+    priceLabel: string;
+    pricePlaceholder: string;
+    priceHelper: string;
+    priceError: string;
+    priceDiscountError: string;
+    servicesLabel: string;
+    servicesHelper: string;
+    quantityLabel: string;
+    quantityPlaceholder: string;
+    itemsError: string;
+    missingServicePrice: string;
+    serviceMeta: (minutes: number, price: string) => string;
+  };
+  summary: {
+    title: string;
+    empty: string;
+    totalUnits: (units: number) => string;
+    packagePrice: (price: string) => string;
+    originalPrice: (price: string) => string;
+    discountValue: (price: string) => string;
+    discountPercent: (percent: string) => string;
+  };
+  buttons: {
+    create: string;
+    edit: string;
+    saving: string;
+    cancel: string;
+  };
+  accessibility: {
+    submitCreate: string;
+    submitEdit: string;
+    cancel: string;
+  };
+  alerts: {
+    createdTitle: string;
+    createdMessage: (name: string, units: number) => string;
+    updatedTitle: string;
+    updatedMessage: (name: string, units: number) => string;
+    createErrorTitle: string;
+    updateErrorTitle: string;
+  };
+};
+
 export type ProductFormCopy = {
   createTitle: string;
   editTitle: string;


### PR DESCRIPTION
## Summary
- add service package domain types and Supabase repository logic for discounted bundles
- expose a packages management screen with creation, editing, and deletion flows alongside a dedicated form
- document the required Supabase tables for storing packages and their included services

## Testing
- npm test *(fails: vitest command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e96b0455408327ba0add6bd1e91bf1