### PR TITLE
Add package summary and improve service picker modal

### DIFF
--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -212,8 +212,13 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         quantityError: "Enter a quantity greater than zero",
       },
       summary: {
-        basePrice: (price: string) => `Regular total ${price}`,
-        discount: (percent: string) => `${percent}% discount`,
+        title: "Package summary",
+        subtitle: (count: number) => `${count} ${count === 1 ? "service" : "services"} included`,
+        packagePriceLabel: "Package price",
+        regularPriceLabel: "Original value",
+        savingsLabel: "You save",
+        noSavings: "No savings",
+        discount: (percent: string) => `${percent}% off`,
       },
       buttons: {
         create: "Save package",
@@ -527,7 +532,13 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         quantityError: "Informe uma quantidade maior que zero",
       },
       summary: {
-        basePrice: (price: string) => `Somando serviços: ${price}`,
+        title: "Resumo do pacote",
+        subtitle: (count: number) =>
+          `${count} ${count === 1 ? "serviço incluído" : "serviços incluídos"}`,
+        packagePriceLabel: "Preço do pacote",
+        regularPriceLabel: "Valor cheio",
+        savingsLabel: "Você economiza",
+        noSavings: "Sem economia",
         discount: (percent: string) => `${percent}% de desconto`,
       },
       buttons: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -147,7 +147,12 @@ export type ServicePackageFormCopy = {
     quantityError: string;
   };
   summary: {
-    basePrice: (price: string) => string;
+    title: string;
+    subtitle: (count: number) => string;
+    packagePriceLabel: string;
+    regularPriceLabel: string;
+    savingsLabel: string;
+    noSavings: string;
     discount: (percent: string) => string;
   };
   buttons: {


### PR DESCRIPTION
## Summary
- add a detailed package summary panel that highlights included sessions, package price, base value, and savings
- compute the derived totals that feed the summary and localization strings for both supported languages
- make the service picker modal opaque so the background no longer shows through

## Testing
- npm test *(fails: vitest not found before dependencies could be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9be7d9b7c8327852eb7dd894e4379