### PR TITLE
Fix service package reload race condition

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import {
   View,
   Text,
@@ -1324,6 +1324,7 @@ export default function App() {
   const [serviceBeingEdited, setServiceBeingEdited] = useState<Service | null>(null);
   const [servicePackages, setServicePackages] = useState<ServicePackage[]>([]);
   const [servicePackagesLoading, setServicePackagesLoading] = useState(false);
+  const servicePackagesRequestId = useRef(0);
   const [packageFormVisible, setPackageFormVisible] = useState(false);
   const [packageFormMode, setPackageFormMode] = useState<"create" | "edit">("create");
   const [packageBeingEdited, setPackageBeingEdited] = useState<ServicePackage | null>(null);
@@ -1485,16 +1486,23 @@ export default function App() {
   useEffect(() => { loadServices(); }, [loadServices]);
 
   const loadServicePackages = useCallback(async () => {
+    const requestId = ++servicePackagesRequestId.current;
     setServicePackagesLoading(true);
     try {
       const rows = await listServicePackages();
-      setServicePackages(rows);
+      if (servicePackagesRequestId.current === requestId) {
+        setServicePackages(rows);
+      }
     } catch (e: any) {
       console.error(e);
-      Alert.alert(packagesCopy.alerts.loadTitle, e?.message ?? String(e));
-      setServicePackages([]);
+      if (servicePackagesRequestId.current === requestId) {
+        Alert.alert(packagesCopy.alerts.loadTitle, e?.message ?? String(e));
+        setServicePackages([]);
+      }
     } finally {
-      setServicePackagesLoading(false);
+      if (servicePackagesRequestId.current === requestId) {
+        setServicePackagesLoading(false);
+      }
     }
   }, [packagesCopy.alerts.loadTitle]);
 


### PR DESCRIPTION
## Summary
- prevent stale service package fetches from overwriting newer results by tracking request ids
- only update list, loading state, and error alerts when the latest fetch resolves

## Testing
- ⚠️ `npm install` *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c6c5e9f08327af31d09956b0d32a