### PR TITLE
Clarify POST requirement for image API endpoint

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -109,6 +109,19 @@ if (!response.ok) {
 const data = await response.json();
 ```
 
+> ℹ️ The function only supports `POST` requests. Navigating to
+> `https://<your-app-name>.azurestaticapps.net/api/images/generate` in a
+> browser issues a `GET` and results in a 404. Use a tool such as
+> `curl`, Postman, or your front-end to send a `POST` request with the
+> required headers and JSON body instead:
+
+```bash
+curl -X POST "https://<your-app-name>.azurestaticapps.net/api/images/generate" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $IMAGE_API_TOKEN" \
+  -d '{"prompt":"High-resolution haircut design"}'
+```
+
 Define `VITE_IMAGE_API_TOKEN` (Vite build) or `EXPO_PUBLIC_IMAGE_API_TOKEN` (Expo dev server) as a build-time environment variable for the front-end using the SWA configuration or GitHub Actions if necessary.
 
 ## 8. Verification Checklist


### PR DESCRIPTION
## Summary
- document that the image generation function only responds to POST requests
- add a curl example showing how to call the deployed endpoint with headers

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ea5b937efc83279820b653cfbe23a7