### PR TITLE
Add freeze mode for recurring schedule slots

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -533,6 +533,8 @@ const LANGUAGE_COPY = {
     userForm: COMPONENT_COPY.en.userForm,
     recurrenceModal: COMPONENT_COPY.en.recurrenceModal,
     occurrencePreview: COMPONENT_COPY.en.occurrencePreview,
+    freezeModal: COMPONENT_COPY.en.freezeModal,
+    freezePreview: COMPONENT_COPY.en.freezePreview,
     weekTitle: "This week",
     overviewSubtitle: (range?: string | null) =>
       `Overview of bookings scheduled for ${range?.trim() ? range : "the current week"}.`,
@@ -728,20 +730,36 @@ const LANGUAGE_COPY = {
         cancelFailureTitle: "Cancel failed",
         customerErrorTitle: "Customers",
         recurrence: {
-          noPreviewTitle: "Nothing to preview",
-          noPreviewMessage: "Check the start date, time, and occurrence count.",
-          previewFailureTitle: "Preview failed",
-          noCreateTitle: "Nothing to create",
-          noCreateMessage: "All occurrences were skipped.",
-          createSuccessTitle: "Created",
-          createSuccessMessage: (count: number, barberName: string, skipped: number) =>
-            `Added ${count} with ${barberName}${skipped ? ` • Skipped ${skipped}` : ""}`,
-          createFailureTitle: "Create failed",
+          booking: {
+            noPreviewTitle: "Nothing to preview",
+            noPreviewMessage: "Check the start date, time, and occurrence count.",
+            previewFailureTitle: "Preview failed",
+            noCreateTitle: "Nothing to create",
+            noCreateMessage: "All occurrences were skipped.",
+            createSuccessTitle: "Created",
+            createSuccessMessage: (count: number, barberName: string, skipped: number) =>
+              `Added ${count} with ${barberName}${skipped ? ` • Skipped ${skipped}` : ""}`,
+            createFailureTitle: "Create failed",
+          },
+          freeze: {
+            noPreviewTitle: "Nothing to freeze",
+            noPreviewMessage: "Check the start date, time, and occurrence count.",
+            previewFailureTitle: "Freeze preview failed",
+            noCreateTitle: "Nothing to freeze",
+            noCreateMessage: "All occurrences were skipped.",
+            createSuccessTitle: "Schedule frozen",
+            createSuccessMessage: (count: number, barberName: string, skipped: number) =>
+              `Frozen ${count} slot${count === 1 ? "" : "s"} for ${barberName}${
+                skipped ? ` • Skipped ${skipped}` : ""
+              }`,
+            createFailureTitle: "Freeze failed",
+          },
         },
       },
       actions: {
         book: { label: "Book service", accessibility: "Book service" },
         repeat: { label: "Repeat…", accessibility: "Open recurrence" },
+        freeze: { label: "Freeze…", accessibility: "Freeze recurring slots" },
       },
       bookingsList: {
         title: "Your bookings",
@@ -1012,6 +1030,8 @@ const LANGUAGE_COPY = {
     userForm: COMPONENT_COPY.pt.userForm,
     recurrenceModal: COMPONENT_COPY.pt.recurrenceModal,
     occurrencePreview: COMPONENT_COPY.pt.occurrencePreview,
+    freezeModal: COMPONENT_COPY.pt.freezeModal,
+    freezePreview: COMPONENT_COPY.pt.freezePreview,
     weekTitle: "Esta semana",
     overviewSubtitle: (range?: string | null) =>
       `Visão geral dos agendamentos marcados para ${range?.trim() ? range : "a semana atual"}.`,
@@ -1208,20 +1228,36 @@ const LANGUAGE_COPY = {
         cancelFailureTitle: "Falha ao cancelar",
         customerErrorTitle: "Clientes",
         recurrence: {
-          noPreviewTitle: "Nada para pré-visualizar",
-          noPreviewMessage: "Verifique a data inicial, o horário e a quantidade de ocorrências.",
-          previewFailureTitle: "Erro na pré-visualização",
-          noCreateTitle: "Nada para criar",
-          noCreateMessage: "Todas as ocorrências foram ignoradas.",
-          createSuccessTitle: "Criado",
-          createSuccessMessage: (count: number, barberName: string, skipped: number) =>
-            `Adicionados ${count} com ${barberName}${skipped ? ` • Ignorados ${skipped}` : ""}`,
-          createFailureTitle: "Falha ao criar",
+          booking: {
+            noPreviewTitle: "Nada para pré-visualizar",
+            noPreviewMessage: "Verifique a data inicial, o horário e a quantidade de ocorrências.",
+            previewFailureTitle: "Erro na pré-visualização",
+            noCreateTitle: "Nada para criar",
+            noCreateMessage: "Todas as ocorrências foram ignoradas.",
+            createSuccessTitle: "Criado",
+            createSuccessMessage: (count: number, barberName: string, skipped: number) =>
+              `Adicionados ${count} com ${barberName}${skipped ? ` • Ignorados ${skipped}` : ""}`,
+            createFailureTitle: "Falha ao criar",
+          },
+          freeze: {
+            noPreviewTitle: "Nada para bloquear",
+            noPreviewMessage: "Verifique a data inicial, o horário e a quantidade de ocorrências.",
+            previewFailureTitle: "Erro na prévia de bloqueio",
+            noCreateTitle: "Nada para bloquear",
+            noCreateMessage: "Todas as ocorrências foram ignoradas.",
+            createSuccessTitle: "Horários bloqueados",
+            createSuccessMessage: (count: number, barberName: string, skipped: number) =>
+              `Bloqueado${count === 1 ? "" : "s"} ${count} horário${count === 1 ? "" : "s"} para ${barberName}${
+                skipped ? ` • Ignorados ${skipped}` : ""
+              }`,
+            createFailureTitle: "Falha ao bloquear",
+          },
         },
       },
       actions: {
         book: { label: "Agendar serviço", accessibility: "Agendar serviço" },
         repeat: { label: "Repetir…", accessibility: "Abrir recorrência" },
+        freeze: { label: "Bloquear…", accessibility: "Bloquear horários recorrentes" },
       },
       bookingsList: {
         title: "Seus agendamentos",
@@ -1405,6 +1441,8 @@ export default function App() {
   const [bookingFilterEndTime, setBookingFilterEndTime] = useState("");
 
   const [recurrenceOpen, setRecurrenceOpen] = useState(false);
+  const [recurrenceMode, setRecurrenceMode] = useState<"booking" | "freeze">("booking");
+  const [previewMode, setPreviewMode] = useState<"booking" | "freeze">("booking");
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewItems, setPreviewItems] = useState<PreviewItem[]>([]);
 
@@ -2257,13 +2295,18 @@ export default function App() {
     startFrom: Date;
     frequency: RecurrenceFrequency;
   }) {
-    if (!selectedCustomer) {
-      Alert.alert(bookServiceCopy.alerts.selectClient.title, bookServiceCopy.alerts.selectClient.message);
-      return;
-    }
+    const isFreeze = recurrenceMode === "freeze";
+    const recurrenceAlerts = isFreeze
+      ? bookServiceCopy.alerts.recurrence.freeze
+      : bookServiceCopy.alerts.recurrence.booking;
 
     if (!selectedService) {
       Alert.alert(bookServiceCopy.alerts.selectService.title, bookServiceCopy.alerts.selectService.message);
+      return;
+    }
+
+    if (!selectedCustomer && !isFreeze) {
+      Alert.alert(bookServiceCopy.alerts.selectClient.title, bookServiceCopy.alerts.selectClient.message);
       return;
     }
 
@@ -2306,10 +2349,7 @@ export default function App() {
     });
 
     if (raw.length === 0) {
-      Alert.alert(
-        bookServiceCopy.alerts.recurrence.noPreviewTitle,
-        bookServiceCopy.alerts.recurrence.noPreviewMessage,
-      );
+      Alert.alert(recurrenceAlerts.noPreviewTitle, recurrenceAlerts.noPreviewMessage);
       return;
     }
 
@@ -2333,25 +2373,31 @@ export default function App() {
 
       setPreviewItems(out);
       setRecurrenceOpen(false);
+      setPreviewMode(recurrenceMode);
       setPreviewOpen(true);
     } catch (e: any) {
       console.error(e);
-      Alert.alert(bookServiceCopy.alerts.recurrence.previewFailureTitle, e?.message ?? String(e));
+      Alert.alert(recurrenceAlerts.previewFailureTitle, e?.message ?? String(e));
     } finally {
       setLoading(false);
     }
   }
 
   async function confirmPreviewInsert() {
-    if (!selectedCustomer) {
-      setPreviewOpen(false);
-      Alert.alert(bookServiceCopy.alerts.selectClient.title, bookServiceCopy.alerts.selectClient.message);
-      return;
-    }
+    const isFreeze = previewMode === "freeze";
+    const recurrenceAlerts = isFreeze
+      ? bookServiceCopy.alerts.recurrence.freeze
+      : bookServiceCopy.alerts.recurrence.booking;
 
     if (!selectedService) {
       setPreviewOpen(false);
       Alert.alert(bookServiceCopy.alerts.selectService.title, bookServiceCopy.alerts.selectService.message);
+      return;
+    }
+
+    if (!selectedCustomer && !isFreeze) {
+      setPreviewOpen(false);
+      Alert.alert(bookServiceCopy.alerts.selectClient.title, bookServiceCopy.alerts.selectClient.message);
       return;
     }
 
@@ -2363,36 +2409,36 @@ export default function App() {
         end: i.end,
         service_id: selectedService.id,
         barber: selectedBarber.id,
-        customer_id: selectedCustomer.id,
+        customer_id: isFreeze ? null : selectedCustomer?.id ?? null,
+        note: isFreeze ? "Schedule freeze" : null,
       }));
 
     if (toInsert.length === 0) {
       setPreviewOpen(false);
-      Alert.alert(
-        bookServiceCopy.alerts.recurrence.noCreateTitle,
-        bookServiceCopy.alerts.recurrence.noCreateMessage,
-      );
+      Alert.alert(recurrenceAlerts.noCreateTitle, recurrenceAlerts.noCreateMessage);
       return;
     }
     try {
       setLoading(true);
       await createBookingsBulk(toInsert);
-      const displayServiceName = selectedLocalizedService?.name ?? selectedService.name;
-      try {
-        const entry = await recordServiceSale({
-          serviceId: selectedService.id,
-          serviceName: displayServiceName,
-          unitPriceCents: selectedService.price_cents,
-          quantity: toInsert.length,
-          referenceId: null,
-        });
-        appendCashEntry(entry);
-      } catch (registerError: any) {
-        console.error(registerError);
-        Alert.alert(
-          cashRegisterCopy.alerts.recordSaleFailedTitle,
-          cashRegisterCopy.alerts.recordSaleFailedMessage(displayServiceName),
-        );
+      if (!isFreeze) {
+        const displayServiceName = selectedLocalizedService?.name ?? selectedService.name;
+        try {
+          const entry = await recordServiceSale({
+            serviceId: selectedService.id,
+            serviceName: displayServiceName,
+            unitPriceCents: selectedService.price_cents,
+            quantity: toInsert.length,
+            referenceId: null,
+          });
+          appendCashEntry(entry);
+        } catch (registerError: any) {
+          console.error(registerError);
+          Alert.alert(
+            cashRegisterCopy.alerts.recordSaleFailedTitle,
+            cashRegisterCopy.alerts.recordSaleFailedMessage(displayServiceName),
+          );
+        }
       }
       setPreviewOpen(false);
       await load();
@@ -2400,12 +2446,12 @@ export default function App() {
       const skipped = previewItems.length - toInsert.length;
       const barberName = BARBER_MAP[selectedBarber.id]?.name ?? selectedBarber.id;
       Alert.alert(
-        bookServiceCopy.alerts.recurrence.createSuccessTitle,
-        bookServiceCopy.alerts.recurrence.createSuccessMessage(toInsert.length, barberName, skipped),
+        recurrenceAlerts.createSuccessTitle,
+        recurrenceAlerts.createSuccessMessage(toInsert.length, barberName, skipped),
       );
     } catch (e: any) {
       console.error(e);
-      Alert.alert(bookServiceCopy.alerts.recurrence.createFailureTitle, e?.message ?? String(e));
+      Alert.alert(recurrenceAlerts.createFailureTitle, e?.message ?? String(e));
     } finally {
       setLoading(false);
     }
@@ -3266,6 +3312,7 @@ export default function App() {
                     );
                     return;
                   }
+                  setRecurrenceMode("booking");
                   setRecurrenceOpen(true);
                 }}
                 style={[styles.bookBtn, (!selectedSlot || loading || !selectedCustomer) && styles.bookBtnDisabled, { flexDirection: "row", alignItems: "center" }]}
@@ -3275,6 +3322,36 @@ export default function App() {
                 <Ionicons name="repeat" size={16} color={colors.accentFgOn} />
                 <Text style={[styles.bookBtnText, { marginLeft: 6 }]}>
                   {bookServiceCopy.actions.repeat.label}
+                </Text>
+              </Pressable>
+
+              <Pressable
+                onPress={() => {
+                  if (!selectedSlot) {
+                    Alert.alert(
+                      bookServiceCopy.alerts.selectSlot.title,
+                      bookServiceCopy.alerts.selectSlot.message,
+                    );
+                    return;
+                  }
+                  if (!selectedService) {
+                    Alert.alert(
+                      bookServiceCopy.alerts.selectService.title,
+                      bookServiceCopy.alerts.selectService.message,
+                    );
+                    return;
+                  }
+                  setRecurrenceMode("freeze");
+                  setRecurrenceOpen(true);
+                }}
+                style={[styles.bookBtn, (!selectedSlot || loading) && styles.bookBtnDisabled, { flexDirection: "row", alignItems: "center" }]}
+                disabled={!selectedSlot || loading}
+                accessibilityRole="button"
+                accessibilityLabel={bookServiceCopy.actions.freeze.accessibility}
+              >
+                <Ionicons name="snow-outline" size={16} color={colors.accentFgOn} />
+                <Text style={[styles.bookBtnText, { marginLeft: 6 }]}>
+                  {bookServiceCopy.actions.freeze.label}
                 </Text>
               </Pressable>
             </View>
@@ -3350,7 +3427,7 @@ export default function App() {
           fixedService={selectedLocalizedService?.name ?? ""}
           fixedBarber={BARBER_MAP[selectedBarber.id]?.name || selectedBarber.id}
           colors={{ text: colors.text, subtext: colors.subtext, surface: colors.surface, border: colors.border, accent: colors.accent, bg: colors.sidebarBg }}
-          copy={copy.recurrenceModal}
+          copy={recurrenceMode === "freeze" ? copy.freezeModal : copy.recurrenceModal}
         />
         <OccurrencePreviewModal
           visible={previewOpen}
@@ -3358,7 +3435,7 @@ export default function App() {
           onClose={() => setPreviewOpen(false)}
           onConfirm={confirmPreviewInsert}
           colors={{ text: colors.text, subtext: colors.subtext, surface: colors.surface, border: colors.border, accent: colors.accent, bg: colors.bg, danger: colors.danger }}
-          copy={copy.occurrencePreview}
+          copy={previewMode === "freeze" ? copy.freezePreview : copy.occurrencePreview}
         />
 
         {/* Modal de clientes (lista + criar via UserForm) */}

--- a/src/lib/bookings.ts
+++ b/src/lib/bookings.ts
@@ -97,12 +97,16 @@ export type BookingInsertPayload = {
   service_id: string;
   barber: string;
   customer_id?: string | null;
+  note?: string | null;
 };
 
 export async function createBooking(payload: BookingInsertPayload) {
   const gateway = getBookingGateway();
   try {
-    const { data, status } = await gateway.insertBooking(payload);
+    const { data, status } = await gateway.insertBooking({
+      ...payload,
+      note: payload.note ?? null,
+    });
     const bookingId = data?.id ?? null;
     logger.info("bookings.createBooking succeeded", { bookingId, status });
     return bookingId;
@@ -117,7 +121,12 @@ export async function createBookingsBulk(payloads: BookingInsertPayload[]): Prom
   if (payloads.length === 0) return;
   const gateway = getBookingGateway();
   try {
-    const { status } = await gateway.insertManyBookings(payloads);
+    const { status } = await gateway.insertManyBookings(
+      payloads.map((payload) => ({
+        ...payload,
+        note: payload.note ?? null,
+      })),
+    );
     logger.info("bookings.createBookingsBulk succeeded", {
       status,
       count: payloads.length,

--- a/src/lib/gateways/bookingGateway.ts
+++ b/src/lib/gateways/bookingGateway.ts
@@ -27,6 +27,7 @@ export interface BookingGateway {
     service_id: string;
     barber: string;
     customer_id?: string | null;
+    note?: string | null;
   }): Promise<GatewayResult<{ id: string | null }>>;
   deleteBooking(id: string): Promise<GatewayResult<{ deleted: number }>>;
   fetchCustomersByIds(ids: readonly string[]): Promise<GatewayResult<Customer[]>>;
@@ -46,6 +47,7 @@ export interface BookingGateway {
     service_id: string;
     barber: string;
     customer_id?: string | null;
+    note?: string | null;
   }[]): Promise<GatewayResult<null>>;
   markBookingPerformed(
     id: string,
@@ -64,7 +66,7 @@ class SupabaseBookingGateway implements BookingGateway {
   async fetchBookingsByDate(date: string): Promise<GatewayResult<DbBooking[]>> {
     const { data, error, status } = await this.client
       .from("bookings")
-      .select('id,date,start,"end",service_id,barber,customer_id,performed_at')
+      .select('id,date,start,"end",service_id,barber,customer_id,note,performed_at')
       .eq("date", date)
       .order("start");
     if (error) this.wrapError(error, "Failed to fetch bookings by date", status);
@@ -74,7 +76,7 @@ class SupabaseBookingGateway implements BookingGateway {
   async fetchBookingsForRange(startDate: string, endDate: string): Promise<GatewayResult<DbBooking[]>> {
     const { data, error, status } = await this.client
       .from("bookings")
-      .select('id,date,start,"end",service_id,barber,customer_id,performed_at')
+      .select('id,date,start,"end",service_id,barber,customer_id,note,performed_at')
       .gte("date", startDate)
       .lte("date", endDate)
       .order("date")
@@ -86,7 +88,7 @@ class SupabaseBookingGateway implements BookingGateway {
   async fetchRecentBookings(limit: number): Promise<GatewayResult<DbBooking[]>> {
     const { data, error, status } = await this.client
       .from("bookings")
-      .select('id,date,start,"end",service_id,barber,customer_id,performed_at')
+      .select('id,date,start,"end",service_id,barber,customer_id,note,performed_at')
       .order("date", { ascending: false })
       .order("start", { ascending: false })
       .limit(limit);
@@ -101,6 +103,7 @@ class SupabaseBookingGateway implements BookingGateway {
     service_id: string;
     barber: string;
     customer_id?: string | null;
+    note?: string | null;
   }): Promise<GatewayResult<{ id: string | null }>> {
     const { data, error, status } = await this.client.from("bookings").insert(payload).select("id").single();
     if (error) this.wrapError(error, "Failed to create booking", status);
@@ -181,7 +184,7 @@ class SupabaseBookingGateway implements BookingGateway {
   async fetchBookingsForDates(dates: readonly string[]): Promise<GatewayResult<DbBooking[]>> {
     const { data, error, status } = await this.client
       .from("bookings")
-      .select('id,date,start,"end",service_id,barber,customer_id,performed_at')
+      .select('id,date,start,"end",service_id,barber,customer_id,note,performed_at')
       .in("date", dates as string[]);
     if (error) this.wrapError(error, "Failed to fetch bookings for dates", status);
     return { data: (data ?? []) as DbBooking[], status: status ?? 200 };
@@ -195,6 +198,7 @@ class SupabaseBookingGateway implements BookingGateway {
       service_id: string;
       barber: string;
       customer_id?: string | null;
+      note?: string | null;
     }[],
   ): Promise<GatewayResult<null>> {
     const { error, status } = await this.client.from("bookings").insert(payload);

--- a/src/lib/types/booking.ts
+++ b/src/lib/types/booking.ts
@@ -6,6 +6,7 @@ export type DbBooking = {
   service_id: string;
   barber: string;
   customer_id?: string | null;
+  note?: string | null;
   performed_at?: string | null;
 };
 

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -20,6 +20,8 @@ type ComponentCopy = {
   userForm: UserFormCopy;
   recurrenceModal: RecurrenceModalCopy;
   occurrencePreview: OccurrencePreviewCopy;
+  freezeModal: RecurrenceModalCopy;
+  freezePreview: OccurrencePreviewCopy;
 };
 
 export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
@@ -341,6 +343,48 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         confirm: (count: number) => `Create ${count}`,
       },
     },
+    freezeModal: {
+      title: "Freeze schedule",
+      labels: {
+        service: "Service",
+        barber: "Barber",
+        startDate: "Start date",
+        time: "Time",
+        frequency: "Frequency",
+        count: "Count (1–10)",
+      },
+      frequencyOptions: [
+        { value: "weekly", label: "Weekly" },
+        { value: "every-15-days", label: "Every two weeks" },
+        { value: "monthly", label: "Monthly" },
+      ],
+      placeholders: {
+        count: "10",
+      },
+      actions: {
+        cancel: "Cancel",
+        preview: "Preview freeze",
+      },
+    },
+    freezePreview: {
+      title: "Preview frozen slots",
+      summary: (frozen: number, skipped: number) =>
+        `${frozen} will be frozen${skipped ? ` • ${skipped} skipped` : ""}`,
+      headers: {
+        date: "Date",
+        time: "Time",
+        status: "Status",
+      },
+      status: {
+        ok: "OK",
+        conflict: "Conflict",
+        outsideHours: "Outside hours",
+      },
+      actions: {
+        back: "Back",
+        confirm: (count: number) => `Freeze ${count}`,
+      },
+    },
   },
   pt: {
     assistantChat: {
@@ -660,6 +704,48 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       actions: {
         back: "Voltar",
         confirm: (count: number) => `Criar ${count}`,
+      },
+    },
+    freezeModal: {
+      title: "Bloquear horário",
+      labels: {
+        service: "Serviço",
+        barber: "Barbeiro",
+        startDate: "Data inicial",
+        time: "Horário",
+        frequency: "Frequência",
+        count: "Quantidade (1–10)",
+      },
+      frequencyOptions: [
+        { value: "weekly", label: "Semanal" },
+        { value: "every-15-days", label: "A cada duas semanas" },
+        { value: "monthly", label: "Mensal" },
+      ],
+      placeholders: {
+        count: "10",
+      },
+      actions: {
+        cancel: "Cancelar",
+        preview: "Pré-visualizar bloqueio",
+      },
+    },
+    freezePreview: {
+      title: "Prévia de bloqueios",
+      summary: (frozen: number, skipped: number) =>
+        `${frozen} serão bloqueados${skipped ? ` • ${skipped} ignorados` : ""}`,
+      headers: {
+        date: "Data",
+        time: "Horário",
+        status: "Status",
+      },
+      status: {
+        ok: "OK",
+        conflict: "Conflito",
+        outsideHours: "Fora do horário",
+      },
+      actions: {
+        back: "Voltar",
+        confirm: (count: number) => `Bloquear ${count}`,
       },
     },
   },

--- a/tests/bookingService/functional/bookingLifecycle.functional.test.ts
+++ b/tests/bookingService/functional/bookingLifecycle.functional.test.ts
@@ -27,6 +27,7 @@ describe("booking service functional flow", () => {
       service_id: "cut",
       barber: "Mina",
       customer_id: customerRecord.id,
+      note: null,
     };
 
     const customersTable = supabaseMock.useTable("customers");
@@ -57,6 +58,7 @@ describe("booking service functional flow", () => {
         service_id: bookingRecord.service_id,
         barber: bookingRecord.barber,
         customer_id: bookingRecord.customer_id,
+        note: null,
       });
       bookingsTable.returns({ data: { id: bookingRecord.id }, error: null, status: 201 });
       return bookingsTable;


### PR DESCRIPTION
## Summary
- add a schedule freeze mode to the booking workflow, including recurrence previews and freeze actions in the UI
- localize freeze-specific modal copy for English and Portuguese experiences
- extend booking payloads to carry optional notes and adjust gateway/tests for the new field

## Testing
- npm test *(fails: vitest binary not found in environment)*
- npm install *(fails: registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea66662c808327b8e9011a69531902