### PR TITLE
Route chat completions through Azure function

### DIFF
--- a/api/functions/chat.js
+++ b/api/functions/chat.js
@@ -1,0 +1,149 @@
+const { app } = require("@azure/functions");
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+function sanitizeRequestPayload(body) {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+
+  const {
+    model = "gpt-4o-mini",
+    messages,
+    temperature = 0.6,
+    max_tokens,
+    top_p,
+    frequency_penalty,
+    presence_penalty,
+    response_format,
+    tools,
+    tool_choice,
+    user,
+  } = body;
+
+  const payload = {
+    model,
+    messages,
+    temperature,
+  };
+
+  if (typeof max_tokens === "number") {
+    payload.max_tokens = max_tokens;
+  }
+
+  if (typeof top_p === "number") {
+    payload.top_p = top_p;
+  }
+
+  if (typeof frequency_penalty === "number") {
+    payload.frequency_penalty = frequency_penalty;
+  }
+
+  if (typeof presence_penalty === "number") {
+    payload.presence_penalty = presence_penalty;
+  }
+
+  if (response_format && typeof response_format === "object") {
+    payload.response_format = response_format;
+  }
+
+  if (Array.isArray(tools)) {
+    payload.tools = tools;
+  }
+
+  if (tool_choice !== undefined) {
+    payload.tool_choice = tool_choice;
+  }
+
+  if (typeof user === "string") {
+    payload.user = user;
+  }
+
+  return payload;
+}
+
+app.http("chat", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  handler: async (request, context) => {
+    if (!OPENAI_API_KEY) {
+      context.warn("Missing OPENAI_API_KEY environment variable.");
+      return {
+        status: 500,
+        jsonBody: {
+          error: {
+            message: "The OpenAI API key is not configured on the server.",
+          },
+        },
+      };
+    }
+
+    let body;
+
+    try {
+      body = await request.json();
+    } catch (error) {
+      context.warn("Failed to parse request body as JSON.", error);
+      return {
+        status: 400,
+        jsonBody: {
+          error: {
+            message: "Invalid JSON payload in request body.",
+          },
+        },
+      };
+    }
+
+    const payload = sanitizeRequestPayload(body);
+    const { messages } = payload;
+
+    if (!Array.isArray(messages)) {
+      return {
+        status: 400,
+        jsonBody: {
+          error: {
+            message: 'The request body must include a "messages" array.',
+          },
+        },
+      };
+    }
+
+    try {
+      const response = await fetch(OPENAI_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        context.warn("OpenAI API returned an error response.", data);
+        return {
+          status: response.status,
+          jsonBody: data,
+        };
+      }
+
+      return {
+        status: 200,
+        jsonBody: data,
+      };
+    } catch (error) {
+      context.error("Unexpected error calling OpenAI API.", error);
+      return {
+        status: 500,
+        jsonBody: {
+          error: {
+            message:
+              "Unable to contact the AI service right now. Please try again later.",
+          },
+        },
+      };
+    }
+  },
+});

--- a/src/hooks/useAssistantChat.ts
+++ b/src/hooks/useAssistantChat.ts
@@ -3,7 +3,11 @@ import { Platform } from "react-native";
 
 import { runBookingAgent } from "../lib/bookingAgent";
 import { BARBERS, type Service } from "../lib/domain";
-import { isOpenAiConfigured, transcribeAudio } from "../lib/openai";
+import {
+  isOpenAiConfigured,
+  isVoiceTranscriptionConfigured,
+  transcribeAudio,
+} from "../lib/openai";
 import type { AssistantChatCopy } from "../locales/types";
 
 export type DisplayMessage = {
@@ -175,7 +179,7 @@ export function useAssistantChat({
   }, [input, pending, voiceTranscribing]);
 
   const startVoiceRecording = useCallback(async () => {
-    if (!isOpenAiConfigured) {
+    if (!isVoiceTranscriptionConfigured) {
       setError(copy.errors.missingApiKey);
       return;
     }
@@ -214,7 +218,7 @@ export function useAssistantChat({
     copy.errors.voiceStartFailed,
     copy.errors.voiceUnsupported,
     copy.errors.voiceWebOnly,
-    isOpenAiConfigured,
+    isVoiceTranscriptionConfigured,
   ]);
 
   const stopVoiceRecording = useCallback(async () => {
@@ -371,7 +375,11 @@ export function useAssistantChat({
     isRecording,
     voiceTranscribing,
     voiceButtonDisabled:
-      !isOpenAiConfigured || pending || voiceTranscribing || (!voiceSupported && !isRecording),
+      !isOpenAiConfigured ||
+      !isVoiceTranscriptionConfigured ||
+      pending ||
+      voiceTranscribing ||
+      (!voiceSupported && !isRecording),
     handleSend,
     handleQuickReply,
     handleVoicePress,

--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -373,7 +373,7 @@ async function cancelService(
 
 export async function runBookingAgent(options: AgentRunOptions): Promise<string> {
   if (!isOpenAiConfigured) {
-    throw new Error("OpenAI API key is not configured. Set EXPO_PUBLIC_OPENAI_API_KEY in your environment.");
+    throw new Error("The chat assistant API is not configured on the server.");
   }
 
   const { systemPrompt, contextSummary, conversation, onBookingsMutated, services } = options;

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -29,7 +29,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
     assistantChat: {
       initialMessage:
         "Hi! I'm your AIBarber agent. I can check availability, book services, and cancel existing appointments for you.",
-      apiKeyWarning: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable the assistant.",
+      apiKeyWarning: "The AI assistant service is unavailable. Ask an administrator to configure the chat API.",
       contextPrefix: "Booking context:",
       quickRepliesTitle: "Suggested prompts",
       quickRepliesToggleShow: "Show suggestions",
@@ -54,7 +54,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       errors: {
         generic: "Something went wrong.",
-        missingApiKey: "Set EXPO_PUBLIC_OPENAI_API_KEY to enable voice input.",
+        missingApiKey: "Voice input is unavailable because transcription isn't configured on the server.",
         voiceWebOnly: "Voice capture is currently supported on the web experience only.",
         voiceUnsupported: "Voice capture is not supported in this browser.",
         voiceStartFailed: "Unable to start voice recording.",
@@ -390,7 +390,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
     assistantChat: {
       initialMessage:
         "Olá! Sou o seu agente AIBarber. Posso verificar disponibilidade, agendar serviços e cancelar compromissos existentes para você.",
-      apiKeyWarning: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar o assistente.",
+      apiKeyWarning: "O serviço do assistente de IA está indisponível. Peça a um administrador para configurar a API de chat.",
       contextPrefix: "Contexto de agendamentos:",
       quickRepliesTitle: "Prompts sugeridos",
       quickRepliesToggleShow: "Mostrar sugestões",
@@ -415,7 +415,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
       },
       errors: {
         generic: "Algo deu errado.",
-        missingApiKey: "Defina EXPO_PUBLIC_OPENAI_API_KEY para habilitar a entrada por voz.",
+        missingApiKey: "A entrada por voz está indisponível porque a transcrição não está configurada no servidor.",
         voiceWebOnly: "A captura de voz está disponível apenas na experiência web no momento.",
         voiceUnsupported: "A captura de voz não é suportada neste navegador.",
         voiceStartFailed: "Não foi possível iniciar a gravação de voz.",

--- a/tests/openai/openaiClient.test.ts
+++ b/tests/openai/openaiClient.test.ts
@@ -19,7 +19,7 @@ describe("createOpenAIClient", () => {
     }));
 
     const client = createOpenAIClient({
-      apiKey: "test-key",
+      apiUrl: "/api/chat",
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
@@ -28,20 +28,20 @@ describe("createOpenAIClient", () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl).toHaveBeenCalledWith(
-      expect.any(String),
+      "/api/chat",
       expect.objectContaining({
         method: "POST",
-        headers: expect.objectContaining({ Authorization: `Bearer test-key` }),
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
       }),
     );
     expect(response.choices[0]?.message.content).toBe("Hello");
   });
 
-  it("throws a configuration error when the API key is missing", async () => {
-    const client = createOpenAIClient({ apiKey: "" });
+  it("throws a configuration error when the chat API route is missing", async () => {
+    const client = createOpenAIClient({ apiUrl: "" });
     await expect(
       client.callChatCompletion({ messages: [{ role: "user", content: "" }] }),
-    ).rejects.toThrowError(/OpenAI API key is not configured/);
+    ).rejects.toThrowError(/chat assistant API is not configured/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an Azure Function (`chat`) that proxies chat completions with the server-side OpenAI key
- update the front-end OpenAI client to use the new `/api/chat` route and gate voice transcription appropriately
- refresh user-facing copy and tests to reflect the new chat service configuration flow

## Testing
- npm test *(fails: vitest is unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed909cf8f88327827a4ebe4663a895