### PR TITLE
Add settings API status indicators

### DIFF
--- a/api/chat/index.js
+++ b/api/chat/index.js
@@ -9,6 +9,88 @@ function getProvidedToken(req) {
 }
 
 module.exports = async function (context, req) {
+  const method = (req?.method || "GET").toUpperCase();
+  const providedToken = getProvidedToken(req);
+
+  if (method === "GET") {
+    if (!OPENAI_API_KEY) {
+      context.log.warn("Missing OPENAI_API_KEY environment variable.");
+      context.res = {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "The OpenAI API key is not configured on the server.",
+          },
+        },
+      };
+      return;
+    }
+
+    if (!OPENAI_PROXY_TOKEN) {
+      context.log.error("Missing OPENAI_PROXY_TOKEN configuration.");
+      context.res = {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "Server misconfiguration: missing OpenAI proxy token.",
+          },
+        },
+      };
+      return;
+    }
+
+    if (!providedToken || providedToken !== OPENAI_PROXY_TOKEN) {
+      context.res = {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "Unauthorized request.",
+          },
+        },
+      };
+      return;
+    }
+
+    context.res = {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        ok: true,
+        message: "Chat completion proxy is ready.",
+      },
+    };
+    return;
+  }
+
+  if (method !== "POST") {
+    context.res = {
+      status: 405,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        error: {
+          message: "Method not allowed.",
+        },
+      },
+    };
+    return;
+  }
+
   if (!OPENAI_API_KEY) {
     context.log.warn("Missing OPENAI_API_KEY environment variable.");
     context.res = {
@@ -41,7 +123,6 @@ module.exports = async function (context, req) {
     return;
   }
 
-  const providedToken = getProvidedToken(req);
   if (!providedToken || providedToken !== OPENAI_PROXY_TOKEN) {
     context.res = {
       status: 401,

--- a/api/transcribe/index.js
+++ b/api/transcribe/index.js
@@ -9,6 +9,88 @@ function getProvidedToken(req) {
 }
 
 module.exports = async function (context, req) {
+  const method = (req?.method || "GET").toUpperCase();
+  const providedToken = getProvidedToken(req);
+
+  if (method === "GET") {
+    if (!OPENAI_API_KEY) {
+      context.log.warn("Missing OPENAI_API_KEY environment variable.");
+      context.res = {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "The OpenAI API key is not configured on the server.",
+          },
+        },
+      };
+      return;
+    }
+
+    if (!OPENAI_PROXY_TOKEN) {
+      context.log.error("Missing OPENAI_PROXY_TOKEN configuration.");
+      context.res = {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "Server misconfiguration: missing OpenAI proxy token.",
+          },
+        },
+      };
+      return;
+    }
+
+    if (!providedToken || providedToken !== OPENAI_PROXY_TOKEN) {
+      context.res = {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          ok: false,
+          error: {
+            message: "Unauthorized request.",
+          },
+        },
+      };
+      return;
+    }
+
+    context.res = {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        ok: true,
+        message: "Transcription proxy is ready.",
+      },
+    };
+    return;
+  }
+
+  if (method !== "POST") {
+    context.res = {
+      status: 405,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        error: {
+          message: "Method not allowed.",
+        },
+      },
+    };
+    return;
+  }
+
   if (!OPENAI_API_KEY) {
     context.log.warn("Missing OPENAI_API_KEY environment variable.");
     context.res = {
@@ -41,7 +123,6 @@ module.exports = async function (context, req) {
     return;
   }
 
-  const providedToken = getProvidedToken(req);
   if (!providedToken || providedToken !== OPENAI_PROXY_TOKEN) {
     context.res = {
       status: 401,

--- a/src/lib/apiStatus.ts
+++ b/src/lib/apiStatus.ts
@@ -1,0 +1,127 @@
+import { IMAGE_API_AUTH_TOKEN, IMAGE_API_ENDPOINT } from "./imageApi";
+import {
+  OPENAI_CHAT_ENDPOINT,
+  OPENAI_PROXY_AUTH_TOKEN,
+  OPENAI_TRANSCRIPTION_ENDPOINT,
+} from "./openai";
+
+export type ApiServiceName = "chat" | "transcribe" | "image";
+export type ApiStatusState = "available" | "unavailable" | "unauthorized";
+
+export type ApiServiceStatus = {
+  service: ApiServiceName;
+  state: ApiStatusState;
+  ok: boolean;
+  message: string | null;
+  statusCode?: number;
+};
+
+type ServiceConfig = {
+  service: ApiServiceName;
+  url?: string | null;
+  token?: string | null | undefined;
+};
+
+const SERVICE_CONFIGS: ServiceConfig[] = [
+  { service: "chat", url: OPENAI_CHAT_ENDPOINT, token: OPENAI_PROXY_AUTH_TOKEN },
+  { service: "transcribe", url: OPENAI_TRANSCRIPTION_ENDPOINT, token: OPENAI_PROXY_AUTH_TOKEN },
+  { service: "image", url: IMAGE_API_ENDPOINT, token: IMAGE_API_AUTH_TOKEN },
+];
+
+function normalizeMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  if ("message" in value && typeof (value as any).message === "string") {
+    return (value as any).message;
+  }
+  if ("error" in value) {
+    const error = (value as any).error;
+    if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+      return error.message;
+    }
+  }
+  return null;
+}
+
+async function checkService(config: ServiceConfig): Promise<ApiServiceStatus> {
+  if (!config.url) {
+    return {
+      service: config.service,
+      state: "unavailable",
+      ok: false,
+      message: "Service endpoint is not configured.",
+    };
+  }
+
+  if (!config.token) {
+    return {
+      service: config.service,
+      state: "unauthorized",
+      ok: false,
+      message: "Client access token is not configured.",
+    };
+  }
+
+  try {
+    const response = await fetch(config.url, {
+      method: "GET",
+      headers: {
+        "x-api-key": config.token,
+      },
+    });
+
+    let body: unknown = null;
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.toLowerCase().includes("application/json")) {
+      try {
+        body = await response.json();
+      } catch {
+        body = null;
+      }
+    }
+
+    if (response.status === 401) {
+      return {
+        service: config.service,
+        state: "unauthorized",
+        ok: false,
+        message: normalizeMessage(body) ?? "Unauthorized request.",
+        statusCode: response.status,
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        service: config.service,
+        state: "unavailable",
+        ok: false,
+        message:
+          normalizeMessage(body) ?? `Request failed with status ${response.status}.`,
+        statusCode: response.status,
+      };
+    }
+
+    const normalizedMessage = normalizeMessage(body);
+    const bodyOk =
+      body && typeof body === "object" && "ok" in body ? Boolean((body as any).ok) : true;
+
+    return {
+      service: config.service,
+      state: bodyOk ? "available" : "unavailable",
+      ok: bodyOk,
+      message: normalizedMessage,
+      statusCode: response.status,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to contact the service.";
+    return {
+      service: config.service,
+      state: "unavailable",
+      ok: false,
+      message,
+    };
+  }
+}
+
+export async function checkApiStatuses(): Promise<ApiServiceStatus[]> {
+  return Promise.all(SERVICE_CONFIGS.map((config) => checkService(config)));
+}

--- a/src/lib/imageApi.ts
+++ b/src/lib/imageApi.ts
@@ -95,3 +95,6 @@ export async function generateImage(options: GenerateImageOptions): Promise<Gene
 
   return body as GenerateImageResponse;
 }
+
+export const IMAGE_API_ENDPOINT = API_ROUTE;
+export const IMAGE_API_AUTH_TOKEN = IMAGE_API_TOKEN;

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -231,6 +231,10 @@ export function createOpenAIClient(config: OpenAIClientConfig): OpenAIClient {
   };
 }
 
+export const OPENAI_CHAT_ENDPOINT = CHAT_API_URL;
+export const OPENAI_TRANSCRIPTION_ENDPOINT = AUDIO_TRANSCRIPTION_URL;
+export const OPENAI_PROXY_AUTH_TOKEN = OPENAI_PROXY_TOKEN;
+
 const defaultClient = createOpenAIClient({});
 
 export const isOpenAiConfigured = defaultClient.isConfigured;


### PR DESCRIPTION
## Summary
- add lightweight GET handlers to the chat, transcription, and image Azure Functions so they can report readiness without invoking OpenAI
- create a shared client helper that checks each AI endpoint with the configured proxy tokens
- surface localized AI service availability statuses (with refresh control and styling) on the settings page

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68edb42ac91c832795baec1855d724b9