### PR TITLE
Add support assistant chat page

### DIFF
--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -13,7 +13,11 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 
 import type { Service } from "../lib/domain";
-import { useAssistantChat } from "../hooks/useAssistantChat";
+import {
+  useAssistantChat,
+  type AgentRunner,
+  type QuickReplyFactory,
+} from "../hooks/useAssistantChat";
 import { defaultComponentCopy } from "../locales/componentCopy";
 import type { AssistantChatCopy } from "../locales/types";
 
@@ -33,6 +37,8 @@ type AssistantChatProps = {
   onBookingsMutated?: () => Promise<void> | void;
   services: Service[];
   copy?: AssistantChatCopy;
+  agentRunner?: AgentRunner;
+  quickReplyFactory?: QuickReplyFactory;
 };
 
 export default function AssistantChat({
@@ -42,6 +48,8 @@ export default function AssistantChat({
   onBookingsMutated,
   services,
   copy = defaultComponentCopy.assistantChat,
+  agentRunner,
+  quickReplyFactory,
 }: AssistantChatProps) {
   const scrollRef = useRef<ScrollView>(null);
 
@@ -69,6 +77,8 @@ export default function AssistantChat({
     services,
     copy,
     onBookingsMutated,
+    agentRunner,
+    quickReplyFactory,
   });
 
   useEffect(() => {

--- a/src/lib/supportAgent.ts
+++ b/src/lib/supportAgent.ts
@@ -1,0 +1,24 @@
+import type { ConversationMessage } from "./bookingAgent";
+import { fetchAssistantReply } from "./openai";
+
+type SupportAgentOptions = {
+  systemPrompt: string;
+  contextSummary?: string;
+  conversation: ConversationMessage[];
+};
+
+export async function runSupportAgent({
+  systemPrompt,
+  contextSummary = "",
+  conversation,
+}: SupportAgentOptions): Promise<string> {
+  const messages = [
+    { role: "system" as const, content: systemPrompt },
+    ...(contextSummary.trim()
+      ? [{ role: "system" as const, content: contextSummary.trim() }]
+      : []),
+    ...conversation.map((message) => ({ role: message.role, content: message.content })),
+  ];
+
+  return fetchAssistantReply(messages);
+}

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -12,6 +12,7 @@ type SupportedLanguage = "en" | "pt";
 
 type ComponentCopy = {
   assistantChat: AssistantChatCopy;
+  supportChat: AssistantChatCopy;
   serviceForm: ServiceFormCopy;
   productForm: ProductFormCopy;
   servicePackageForm: ServicePackageFormCopy;
@@ -40,6 +41,42 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         barberAvailability: (barberName: string) => `Available hours for ${barberName}`,
       },
       inputPlaceholder: "Ask about bookings...",
+      sendAccessibility: "Send message",
+      typingIndicator: "Typing…",
+      suggestionsAccessibility: {
+        show: "Show quick suggestions",
+        hide: "Hide quick suggestions",
+      },
+      voiceButtonAccessibility: {
+        start: "Start voice input",
+        stop: "Stop voice input",
+      },
+      errors: {
+        generic: "Something went wrong.",
+        missingApiKey: "Configure the backend OPENAI_API_KEY secret to enable voice input.",
+        voiceWebOnly: "Voice capture is currently supported on the web experience only.",
+        voiceUnsupported: "Voice capture is not supported in this browser.",
+        voiceStartFailed: "Unable to start voice recording.",
+        noAudio: "No audio captured. Try again.",
+        processFailed: "Failed to process voice message.",
+      },
+    },
+    supportChat: {
+      initialMessage:
+        "Hi! I'm your AIBarber support assistant. Share compliments, suggestions, or bug reports and I'll make sure they reach the team.",
+      apiKeyWarning: "Configure the backend OPENAI_API_KEY secret to enable the assistant.",
+      contextPrefix: "Support context:",
+      quickRepliesTitle: "Suggested prompts",
+      quickRepliesToggleShow: "Show suggestions",
+      quickRepliesToggleHide: "Hide quick suggestions",
+      quickReplyAccessibility: (suggestion: string) => `Send quick message: ${suggestion}`,
+      quickReplies: {
+        existingBookings: "Share positive feedback",
+        bookService: "I have a suggestion",
+        bookSpecificService: () => "Report a bug",
+        barberAvailability: () => "Follow up on my last report",
+      },
+      inputPlaceholder: "Tell us how we can help...",
       sendAccessibility: "Send message",
       typingIndicator: "Typing…",
       suggestionsAccessibility: {
@@ -360,6 +397,42 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         barberAvailability: (barberName: string) => `Horários disponíveis para ${barberName}`,
       },
       inputPlaceholder: "Pergunte sobre os agendamentos...",
+      sendAccessibility: "Enviar mensagem",
+      typingIndicator: "Digitando…",
+      suggestionsAccessibility: {
+        show: "Mostrar sugestões rápidas",
+        hide: "Ocultar sugestões rápidas",
+      },
+      voiceButtonAccessibility: {
+        start: "Iniciar entrada por voz",
+        stop: "Parar entrada por voz",
+      },
+      errors: {
+        generic: "Algo deu errado.",
+        missingApiKey: "Configure a variável OPENAI_API_KEY no backend para habilitar a entrada por voz.",
+        voiceWebOnly: "A captura de voz está disponível apenas na experiência web no momento.",
+        voiceUnsupported: "A captura de voz não é suportada neste navegador.",
+        voiceStartFailed: "Não foi possível iniciar a gravação de voz.",
+        noAudio: "Nenhum áudio capturado. Tente novamente.",
+        processFailed: "Falha ao processar a mensagem de voz.",
+      },
+    },
+    supportChat: {
+      initialMessage:
+        "Olá! Sou o assistente de suporte AIBarber. Envie elogios, sugestões ou relatos de bugs que eu repasso para o nosso time.",
+      apiKeyWarning: "Configure a variável OPENAI_API_KEY no backend para habilitar o assistente.",
+      contextPrefix: "Contexto de suporte:",
+      quickRepliesTitle: "Prompts sugeridos",
+      quickRepliesToggleShow: "Mostrar sugestões",
+      quickRepliesToggleHide: "Ocultar sugestões rápidas",
+      quickReplyAccessibility: (suggestion: string) => `Enviar mensagem rápida: ${suggestion}`,
+      quickReplies: {
+        existingBookings: "Compartilhar um elogio",
+        bookService: "Tenho uma sugestão",
+        bookSpecificService: () => "Reportar um bug",
+        barberAvailability: () => "Acompanhar meu relatório anterior",
+      },
+      inputPlaceholder: "Conte como podemos ajudar...",
       sendAccessibility: "Enviar mensagem",
       typingIndicator: "Digitando…",
       suggestionsAccessibility: {


### PR DESCRIPTION
## Summary
- add localized navigation labels and copy for a new support chat experience
- reuse the assistant chat UI with configurable runners and quick replies to power a support-focused agent
- call a lightweight support agent that records feedback via the OpenAI client and expose the page in the sidebar

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f297c92430832787e05b6ca771bbb5