### PR TITLE
Add timezone support across barbershop experience

### DIFF
--- a/docs/supabase/authentication.sql
+++ b/docs/supabase/authentication.sql
@@ -17,7 +17,7 @@ create table if not exists public.barbershops (
   id uuid primary key default gen_random_uuid(),
   name text not null check (char_length(name) between 1 and 160),
   slug text,
-  timezone text not null default 'UTC',
+  timezone text not null default 'America/Sao_Paulo',
   owner_id uuid not null references auth.users(id) on delete cascade,
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now())

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -33,6 +33,7 @@ type AssistantChatProps = {
   onBookingsMutated?: () => Promise<void> | void;
   services: Service[];
   copy?: AssistantChatCopy;
+  timeZone: string;
 };
 
 export default function AssistantChat({
@@ -42,6 +43,7 @@ export default function AssistantChat({
   onBookingsMutated,
   services,
   copy = defaultComponentCopy.assistantChat,
+  timeZone,
 }: AssistantChatProps) {
   const scrollRef = useRef<ScrollView>(null);
 
@@ -69,6 +71,7 @@ export default function AssistantChat({
     services,
     copy,
     onBookingsMutated,
+    timeZone,
   });
 
   useEffect(() => {

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -19,6 +19,7 @@ import {
   registerBarbershopAdministrator,
 } from "../lib/auth";
 import { hasSupabaseCredentials, supabase } from "../lib/supabase";
+import { DEFAULT_TIMEZONE } from "../lib/timezone";
 import { clearCurrentBarbershopCache } from "../lib/activeBarbershop";
 import { formCardColors, palette } from "../theme/colors";
 
@@ -157,10 +158,14 @@ export function AuthGate({ children }: AuthGateProps) {
 
   const timezone = useMemo(() => {
     try {
-      return Localization.getCalendars()?.[0]?.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return (
+        Localization.getCalendars()?.[0]?.timeZone ??
+        Intl.DateTimeFormat().resolvedOptions().timeZone ??
+        DEFAULT_TIMEZONE
+      );
     } catch (error) {
       console.warn("Unable to detect timezone", error);
-      return "UTC";
+      return DEFAULT_TIMEZONE;
     }
   }, []);
 

--- a/src/components/RecurrenceModal.tsx
+++ b/src/components/RecurrenceModal.tsx
@@ -19,6 +19,7 @@ type Props = {
   fixedTime: string;   // horário selecionado na tela principal (HH:MM)
   fixedService: string; // serviço atual (ex.: "Cut")
   fixedBarber: string;  // barbeiro atual (ex.: "João")
+  timeZone: string;
   colors?: ModalColors;
   copy?: RecurrenceModalCopy;
 };
@@ -33,6 +34,7 @@ export default function RecurrenceModal({
   fixedTime,
   fixedService,
   fixedBarber,
+  timeZone,
   colors = modalColors,
   copy = defaultComponentCopy.recurrenceModal,
 }: Props) {
@@ -63,7 +65,12 @@ export default function RecurrenceModal({
   };
 
   const humanDate = (d: Date) =>
-    d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+    d.toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      timeZone,
+    });
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>

--- a/src/hooks/useAssistantChat.ts
+++ b/src/hooks/useAssistantChat.ts
@@ -18,6 +18,7 @@ export type AgentRunnerArgs = {
   conversation: DisplayMessage[];
   onBookingsMutated?: () => Promise<void> | void;
   services: Service[];
+  timeZone: string;
 };
 
 export type AgentRunner = (options: AgentRunnerArgs) => Promise<string>;
@@ -33,6 +34,7 @@ const defaultAgentRunner: AgentRunner = ({
   conversation,
   onBookingsMutated,
   services,
+  timeZone,
 }) =>
   runBookingAgent({
     systemPrompt,
@@ -40,6 +42,7 @@ const defaultAgentRunner: AgentRunner = ({
     conversation,
     onBookingsMutated,
     services,
+    timezone: timeZone,
   });
 
 const defaultQuickReplyFactory: QuickReplyFactory = ({ services, copy }) => {
@@ -66,6 +69,7 @@ type UseAssistantChatOptions = {
   onBookingsMutated?: () => Promise<void> | void;
   agentRunner?: AgentRunner;
   quickReplyFactory?: QuickReplyFactory;
+  timeZone: string;
 };
 
 type UseAssistantChatResult = {
@@ -96,6 +100,7 @@ export function useAssistantChat({
   onBookingsMutated,
   agentRunner,
   quickReplyFactory,
+  timeZone,
 }: UseAssistantChatOptions): UseAssistantChatResult {
   const [messages, setMessages] = useState<DisplayMessage[]>([
     { role: "assistant", content: copy.initialMessage },
@@ -308,6 +313,7 @@ export function useAssistantChat({
           conversation: nextMessages,
           onBookingsMutated,
           services,
+          timeZone,
         });
         setMessages((prev) => [...prev, { role: "assistant", content: reply }]);
       } catch (e: any) {
@@ -325,6 +331,7 @@ export function useAssistantChat({
       pending,
       services,
       systemPrompt,
+      timeZone,
     ],
   );
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import type { Session } from "@supabase/supabase-js";
 
 import { supabase } from "./supabase";
+import { DEFAULT_TIMEZONE } from "./timezone";
 import type { StaffRole } from "./users";
 
 export type RegistrationPayload = {
@@ -84,7 +85,7 @@ export async function registerBarbershopAdministrator(
   const email = payload.email.trim().toLowerCase();
   const password = payload.password;
   const phone = payload.phone?.trim() || null;
-  const timezone = payload.timezone?.trim() || "UTC";
+  const timezone = payload.timezone?.trim() || DEFAULT_TIMEZONE;
 
   if (!name) {
     throw new Error("Barbershop name is required.");
@@ -186,7 +187,7 @@ function getPendingRegistrationFromMetadata(session: Session): PendingBarbershop
     timezone: storedTimezone,
   } = metadata as Partial<PendingBarbershopRegistration>;
 
-  const timezone = storedTimezone || "UTC";
+  const timezone = storedTimezone || DEFAULT_TIMEZONE;
 
   if (!barbershopName || !adminFirstName || !adminLastName || !email) {
     return null;

--- a/src/lib/barbershops.ts
+++ b/src/lib/barbershops.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClientLike } from "./supabase";
 import { supabase } from "./supabase";
+import { DEFAULT_TIMEZONE } from "./timezone";
 
 const BARBERSHOPS_TABLE = "barbershops";
 
@@ -32,7 +33,7 @@ function normalizeBarbershop(row: BarbershopRow): Barbershop {
     id: row.id,
     name: row.name,
     slug: row.slug ?? null,
-    timezone: row.timezone ?? "UTC",
+    timezone: row.timezone ?? DEFAULT_TIMEZONE,
     created_at: row.created_at ?? null,
     updated_at: row.updated_at ?? null,
   };

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,5 +1,7 @@
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
+import { DEFAULT_TIMEZONE, formatDateKey, formatDateLabel } from "./timezone";
+
 export type ServiceId = string;
 export type Service = {
   id: ServiceId;
@@ -70,8 +72,8 @@ export function formatPrice(cents: number) {
   });
 }
 
-export function toDateKey(d: Date) {
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+export function toDateKey(d: Date, timeZone: string = DEFAULT_TIMEZONE) {
+  return formatDateKey(d, timeZone);
 }
 
 export function minutesToTime(mins: number) {
@@ -97,11 +99,15 @@ export function overlap(aS: string, aE: string, bS: string, bE: string) {
   return Math.max(as, bs) < Math.min(ae, be);
 }
 
-export function humanDate(dk: string, locale?: string) {
-  const d = new Date(`${dk}T00:00:00`);
-  return d.toLocaleDateString(locale ?? undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
+export function humanDate(dk: string, locale?: string, timeZone: string = DEFAULT_TIMEZONE) {
+  return formatDateLabel(
+    dk,
+    {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    },
+    locale,
+    timeZone,
+  );
 }

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,190 @@
+const FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+const WEEKDAY_FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+export const DEFAULT_TIMEZONE = "America/Sao_Paulo";
+
+type ZonedDateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function pad(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+  const key = timeZone || DEFAULT_TIMEZONE;
+  let formatter = FORMATTER_CACHE.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: key,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    FORMATTER_CACHE.set(key, formatter);
+  }
+  return formatter;
+}
+
+function getWeekdayFormatter(timeZone: string): Intl.DateTimeFormat {
+  const key = timeZone || DEFAULT_TIMEZONE;
+  let formatter = WEEKDAY_FORMATTER_CACHE.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: key,
+      weekday: "short",
+    });
+    WEEKDAY_FORMATTER_CACHE.set(key, formatter);
+  }
+  return formatter;
+}
+
+function parseDateKey(dateKey: string): [number, number, number] {
+  const [yearStr, monthStr, dayStr] = (dateKey ?? "").split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    throw new Error(`Invalid date key: ${dateKey}`);
+  }
+  return [year, month, day];
+}
+
+function formatDateKeyFromUtc(date: Date): string {
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+
+function createUtcDate(parts: ZonedDateParts): Date {
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, 0));
+}
+
+function getZonedDateParts(date: Date, timeZone: string): ZonedDateParts {
+  const formatter = getFormatter(timeZone);
+  const formattedParts = formatter.formatToParts(date);
+  const pick = (type: string) => formattedParts.find((part) => part.type === type)?.value ?? "0";
+  return {
+    year: Number(pick("year")),
+    month: Number(pick("month")),
+    day: Number(pick("day")),
+    hour: Number(pick("hour")),
+    minute: Number(pick("minute")),
+    second: Number(pick("second")),
+  };
+}
+
+function resolveZonedDateTime(parts: ZonedDateParts, timeZone: string): Date {
+  const utcGuess = createUtcDate(parts);
+  const guessParts = getZonedDateParts(utcGuess, timeZone);
+  const guessUtc = createUtcDate(guessParts).getTime();
+  const targetUtc = utcGuess.getTime() - (guessUtc - utcGuess.getTime());
+  return new Date(targetUtc);
+}
+
+export function getCurrentZonedDate(timeZone: string = DEFAULT_TIMEZONE): Date {
+  const nowParts = getZonedDateParts(new Date(), timeZone);
+  return resolveZonedDateTime(nowParts, timeZone);
+}
+
+export function formatDateKey(date: Date, timeZone: string = DEFAULT_TIMEZONE): string {
+  const parts = getZonedDateParts(date, timeZone);
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
+}
+
+export function getCurrentDateKey(timeZone: string = DEFAULT_TIMEZONE): string {
+  return formatDateKey(new Date(), timeZone);
+}
+
+export function getDateFromKey(dateKey: string, timeZone: string = DEFAULT_TIMEZONE): Date {
+  const [year, month, day] = parseDateKey(dateKey);
+  const parts: ZonedDateParts = { year, month, day, hour: 0, minute: 0, second: 0 };
+  return resolveZonedDateTime(parts, timeZone);
+}
+
+export function addDaysToDateKey(dateKey: string, amount: number): string {
+  const [year, month, day] = parseDateKey(dateKey);
+  const base = new Date(Date.UTC(year, month - 1, day + amount));
+  return formatDateKeyFromUtc(base);
+}
+
+export function differenceInDays(startKey: string, endKey: string): number {
+  const [sYear, sMonth, sDay] = parseDateKey(startKey);
+  const [eYear, eMonth, eDay] = parseDateKey(endKey);
+  const start = Date.UTC(sYear, sMonth - 1, sDay, 0, 0, 0);
+  const end = Date.UTC(eYear, eMonth - 1, eDay, 0, 0, 0);
+  return Math.round((end - start) / DAY);
+}
+
+export function getWeekdayIndex(dateKey: string, timeZone: string = DEFAULT_TIMEZONE): number {
+  const date = getDateFromKey(dateKey, timeZone);
+  const formatter = getWeekdayFormatter(timeZone);
+  const label = formatter.format(date).toLowerCase().slice(0, 3);
+  return WEEKDAY_INDEX[label] ?? 0;
+}
+
+export function getWeekStartDateKey(dateKey: string, timeZone: string = DEFAULT_TIMEZONE): string {
+  const weekday = getWeekdayIndex(dateKey, timeZone);
+  const diff = (weekday + 6) % 7;
+  return addDaysToDateKey(dateKey, -diff);
+}
+
+export function getWeekDateKeys(dateKey: string, timeZone: string = DEFAULT_TIMEZONE): string[] {
+  const startKey = getWeekStartDateKey(dateKey, timeZone);
+  return Array.from({ length: 7 }, (_, index) => addDaysToDateKey(startKey, index));
+}
+
+export function makeZonedDateTime(
+  dateKey: string,
+  time: string,
+  timeZone: string = DEFAULT_TIMEZONE,
+): Date {
+  const [year, month, day] = parseDateKey(dateKey);
+  const [hourStr = "0", minuteStr = "0", secondStr = "0"] = time.split(":");
+  const hour = Number(hourStr);
+  const minute = Number(minuteStr);
+  const second = Number(secondStr);
+  const parts: ZonedDateParts = { year, month, day, hour, minute, second };
+  return resolveZonedDateTime(parts, timeZone);
+}
+
+export function formatDateLabel(
+  dateKey: string,
+  options: Intl.DateTimeFormatOptions,
+  locale: string | undefined,
+  timeZone: string = DEFAULT_TIMEZONE,
+): string {
+  const date = getDateFromKey(dateKey, timeZone);
+  return date.toLocaleDateString(locale ?? undefined, { ...options, timeZone });
+}
+
+export function formatDateRangePart(
+  date: Date,
+  locale: string,
+  timeZone: string = DEFAULT_TIMEZONE,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  return date.toLocaleDateString(locale, { ...options, timeZone });
+}


### PR DESCRIPTION
## Summary
- add timezone utilities and default configuration for America/Sao_Paulo
- persist barbershop timezone settings and propagate the value through the app and booking agent
- update booking flows to operate on timezone-aware date keys and formatting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f90df4d8688327b67987f1d95a0893