### PR TITLE
Integrate Expo Router navigation and modularize cash register screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,12 +1,1 @@
-import React from "react";
-
-import { AuthGate } from "./src/components/AuthGate";
-import AuthenticatedApp from "./src/app/AuthenticatedApp";
-
-export default function App() {
-  return (
-    <AuthGate>
-      <AuthenticatedApp />
-    </AuthGate>
-  );
-}
+export { default } from "expo-router/entry";

--- a/app.json
+++ b/app.json
@@ -24,6 +24,7 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": ["expo-router"]
   }
 }

--- a/app/[screen].tsx
+++ b/app/[screen].tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
+
+import AuthenticatedApp, { SCREEN_ROUTES, type ScreenName } from "../src/app/AuthenticatedApp";
+
+const SCREEN_SET = new Set<ScreenName>(SCREEN_ROUTES);
+const DEFAULT_SCREEN: ScreenName = SCREEN_ROUTES[0];
+
+const isScreenName = (value: string | null | undefined): value is ScreenName =>
+  typeof value === "string" && SCREEN_SET.has(value as ScreenName);
+
+export default function ScreenRoute() {
+  const params = useLocalSearchParams<{ screen?: string | string[] }>();
+  const router = useRouter();
+  const rawScreen = params.screen;
+  const screenParam = Array.isArray(rawScreen) ? rawScreen[0] : rawScreen;
+
+  if (!isScreenName(screenParam)) {
+    return <Redirect href={`/${DEFAULT_SCREEN}`} />;
+  }
+
+  return (
+    <AuthenticatedApp
+      routeScreen={screenParam}
+      onNavigate={(next) => {
+        if (next !== screenParam) {
+          router.replace(`/${next}`);
+        }
+      }}
+    />
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Slot } from "expo-router";
+
+import { AuthGate } from "../src/components/AuthGate";
+
+export default function RootLayout() {
+  return (
+    <AuthGate>
+      <Slot />
+    </AuthGate>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { Redirect } from "expo-router";
+
+export default function Index() {
+  return <Redirect href="/home" />;
+}

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,1 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+import "expo-router/entry";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aibarber",
   "version": "1.0.0",
-  "main": "index.ts",
+  "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
     "web-build": "expo export -p web",
@@ -16,6 +16,7 @@
     "expo": "~54.0.13",
     "expo-status-bar": "~3.0.8",
     "expo-localization": "~17.0.7",
+    "expo-router": "~4.0.12",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.6",

--- a/src/app/AuthenticatedApp.tsx
+++ b/src/app/AuthenticatedApp.tsx
@@ -100,6 +100,7 @@ import ProductForm from "../components/ProductForm";
 import FilterToggle from "../components/FilterToggle";
 import DateTimeInput from "../components/DateTimeInput";
 import { DonutChart } from "../components/DonutChart";
+import CashRegisterScreen from "./screens/CashRegisterScreen";
 
 /* Novo: formulário de usuário (com date_of_birth e salvando no Supabase) */
 import UserForm from "../components/UserForm";
@@ -1322,17 +1323,19 @@ const LANGUAGE_COPY = {
   },
 } as const;
 
-type SupportedLanguage = keyof typeof LANGUAGE_COPY;
+export type SupportedLanguage = keyof typeof LANGUAGE_COPY;
 
 const LANGUAGE_OPTIONS: { code: SupportedLanguage; label: string }[] = [
   { code: "en", label: "English (US)" },
   { code: "pt", label: "Português (BR)" },
 ];
 
+export type CashRegisterCopy = (typeof LANGUAGE_COPY)[SupportedLanguage]["cashRegisterPage"];
+
 type ThemeName = "dark" | "light";
 type ThemePreference = "system" | ThemeName;
 
-type ThemeColors = {
+export type ThemeColors = {
   bg: string;
   surface: string;
   sidebarBg: string;
@@ -1392,21 +1395,29 @@ function getInitialLanguage(): SupportedLanguage {
 }
 
 /** ========== App ========== */
-type ScreenName =
-  | "home"
-  | "bookings"
-  | "bookService"
-  | "services"
-  | "packages"
-  | "products"
-  | "cashRegister"
-  | "assistant"
-  | "support"
-  | "team"
-  | "settings"
-  | "barbershopSettings";
+export const SCREEN_ROUTES = [
+  "home",
+  "bookings",
+  "bookService",
+  "services",
+  "packages",
+  "products",
+  "cashRegister",
+  "assistant",
+  "support",
+  "team",
+  "settings",
+  "barbershopSettings",
+] as const;
 
-function AuthenticatedApp() {
+export type ScreenName = (typeof SCREEN_ROUTES)[number];
+
+type AuthenticatedAppProps = {
+  routeScreen?: ScreenName;
+  onNavigate?: (screen: ScreenName) => void;
+};
+
+function AuthenticatedApp({ routeScreen, onNavigate }: AuthenticatedAppProps) {
   const [services, setServices] = useState<Service[]>([]);
   const [servicesLoading, setServicesLoading] = useState(false);
   const [selectedServiceId, setSelectedServiceId] = useState<string | null>(null);
@@ -1444,7 +1455,7 @@ function AuthenticatedApp() {
   const [apiStatusLoading, setApiStatusLoading] = useState(false);
   const [apiStatusError, setApiStatusError] = useState<string | null>(null);
   const apiStatusRequestId = useRef(0);
-  const [activeScreen, setActiveScreen] = useState<ScreenName>("home");
+  const [activeScreenState, setActiveScreenState] = useState<ScreenName>(routeScreen ?? "home");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
@@ -1453,6 +1464,12 @@ function AuthenticatedApp() {
   const [resentConfirmation, setResentConfirmation] = useState(false);
   const [resendConfirmationError, setResendConfirmationError] = useState<string | null>(null);
   const [language, setLanguage] = useState<SupportedLanguage>(() => getInitialLanguage());
+  const activeScreen = routeScreen ?? activeScreenState;
+
+  useEffect(() => {
+    if (!routeScreen) return;
+    setActiveScreenState((previous) => (previous === routeScreen ? previous : routeScreen));
+  }, [routeScreen]);
   const copy = useMemo(() => LANGUAGE_COPY[language], [language]);
   const locale = language === "pt" ? "pt-BR" : "en-US";
   const bookServiceCopy = copy.bookService;
@@ -1475,6 +1492,13 @@ function AuthenticatedApp() {
   const resolvedTheme = themePreference === "system" ? (colorScheme === "dark" ? "dark" : "light") : themePreference;
   const colors = useMemo(() => THEMES[resolvedTheme], [resolvedTheme]);
   const styles = useMemo(() => createStyles(colors), [colors]);
+  const setActiveScreen = useCallback(
+    (screen: ScreenName) => {
+      setActiveScreenState(screen);
+      onNavigate?.(screen);
+    },
+    [onNavigate],
+  );
   const emailConfirmationCopy = copy.settingsPage.emailConfirmation;
   const [barbershop, setBarbershop] = useState<Barbershop | null>(null);
   const [barbershopForm, setBarbershopForm] = useState<{ name: string; slug: string; timezone: string }>(() => ({
@@ -3272,11 +3296,12 @@ function AuthenticatedApp() {
 
   const bookingsNavActive = activeScreen === "bookings" || activeScreen === "bookService";
 
-  const handleNavigate = useCallback((screen: ScreenName) => {
+  const handleNavigate = useCallback(
+    (screen: ScreenName) => {
       setActiveScreen(screen);
       setSidebarOpen(false);
     },
-    [],
+    [setActiveScreen],
   );
 
   const handleLogout = useCallback(async () => {
@@ -4877,244 +4902,30 @@ function AuthenticatedApp() {
         </View>
       </ScrollView>
     ) : activeScreen === "cashRegister" ? (
-      <>
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
-          refreshControl={<RefreshControl refreshing={cashLoading} onRefresh={loadCashRegister} />}
-        >
-        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-          <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
-            <View style={{ flex: 1, gap: 4 }}>
-              <Text style={[styles.title, { color: colors.text }]}>{cashRegisterCopy.title}</Text>
-              <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
-                {cashRegisterCopy.subtitle}
-              </Text>
-            </View>
-            <View
-              style={[
-                styles.cashHeaderActions,
-                isCompactLayout && styles.cashHeaderActionsCompact,
-              ]}
-            >
-              <Pressable
-                onPress={handleOpenAdjustmentModal}
-                style={[styles.secondaryCta, isCompactLayout && styles.fullWidthButton]}
-                accessibilityRole="button"
-                accessibilityLabel={cashRegisterCopy.adjustmentCta.accessibility}
-              >
-                <Text style={styles.secondaryCtaText}>{cashRegisterCopy.adjustmentCta.label}</Text>
-              </Pressable>
-              <Pressable
-                onPress={loadCashRegister}
-                style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
-                accessibilityRole="button"
-                accessibilityLabel={cashRegisterCopy.refreshAccessibility}
-              >
-                <Text style={styles.defaultCtaText}>{cashRegisterCopy.refresh}</Text>
-              </Pressable>
-            </View>
-          </View>
-        </View>
-
-        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 16 }]}>
-          <Text style={[styles.title, { color: colors.text, fontSize: 18 }]}>
-            {cashRegisterCopy.summaryTitle}
-          </Text>
-          <View style={styles.cashSummaryGrid}>
-            {[
-              { key: "total", label: cashRegisterCopy.summary.total, amount: cashSummary.total_cents },
-              {
-                key: "services",
-                label: cashRegisterCopy.summary.services,
-                amount: cashSummary.service_sales_cents,
-              },
-              {
-                key: "products",
-                label: cashRegisterCopy.summary.products,
-                amount: cashSummary.product_sales_cents,
-              },
-              {
-                key: "adjustments",
-                label: cashRegisterCopy.summary.adjustments,
-                amount: cashSummary.adjustments_cents,
-              },
-            ].map((item) => (
-              <View key={item.key} style={[styles.cashSummaryItem, { borderColor: colors.border }]}>
-                <Text style={styles.cashSummaryLabel}>{item.label}</Text>
-                <Text
-                  style={[
-                    styles.cashSummaryValue,
-                    item.amount < 0 ? styles.cashAmountNegative : styles.cashAmountPositive,
-                  ]}
-                >
-                  {formatPrice(item.amount)}
-                </Text>
-              </View>
-            ))}
-          </View>
-        </View>
-
-        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-          <Text style={[styles.title, { color: colors.text }]}>{cashRegisterCopy.ledgerTitle}</Text>
-          {cashEntries.length === 0 ? (
-            <Text style={[styles.empty, { marginVertical: 8 }]}>{cashRegisterCopy.empty}</Text>
-          ) : (
-            cashEntries.map((entry) => {
-              const amountStyle = entry.amount_cents < 0 ? styles.cashAmountNegative : styles.cashAmountPositive;
-              const sourceName = entry.source_name?.trim()
-                ? entry.source_name
-                : cashEntryTypeLabels[entry.type];
-              const created = entry.created_at ? new Date(entry.created_at) : null;
-              const dateLabel =
-                created && !Number.isNaN(created.getTime())
-                  ? created.toLocaleString(locale, { dateStyle: "short", timeStyle: "short" })
-                  : entry.created_at;
-              const quantityLabel =
-                entry.quantity > 1 ? cashRegisterCopy.entryMeta.quantity(entry.quantity) : null;
-              const unitLabel =
-                entry.unit_amount_cents !== null
-                  ? cashRegisterCopy.entryMeta.unitPrice(formatPrice(entry.unit_amount_cents))
-                  : null;
-              const referenceLabel = entry.reference_id
-                ? cashRegisterCopy.entryMeta.reference(entry.reference_id)
-                : null;
-              return (
-                <View key={entry.id} style={[styles.cashEntryRow, { borderColor: colors.border }]}>
-                  <View style={styles.cashEntryHeader}>
-                    <View style={styles.cashEntryInfo}>
-                      <Text style={styles.cashEntryType}>{cashEntryTypeLabels[entry.type]}</Text>
-                      <Text style={styles.cashEntrySource}>{sourceName}</Text>
-                    </View>
-                    <Text style={[styles.cashAmount, amountStyle]}>{formatPrice(entry.amount_cents)}</Text>
-                  </View>
-                  <View style={styles.cashEntryMetaRow}>
-                    <Text style={styles.cashEntryMeta}>{dateLabel}</Text>
-                    {quantityLabel ? <Text style={styles.cashEntryMeta}>{quantityLabel}</Text> : null}
-                    {unitLabel ? <Text style={styles.cashEntryMeta}>{unitLabel}</Text> : null}
-                    {referenceLabel ? <Text style={styles.cashEntryMeta}>{referenceLabel}</Text> : null}
-                  </View>
-                  {entry.note ? (
-                    <Text style={styles.cashEntryNote}>{cashRegisterCopy.entryMeta.note(entry.note)}</Text>
-                  ) : null}
-                </View>
-              );
-            })
-          )}
-        </View>
-        </ScrollView>
-
-        <Modal
-          visible={adjustmentModalOpen}
-          transparent
-          animationType="fade"
-          onRequestClose={handleCloseAdjustmentModal}
-        >
-          <View style={styles.adjustmentModalBackdrop}>
-            <View
-              style={[
-                styles.adjustmentModalCard,
-                { borderColor: colors.border, backgroundColor: colors.sidebarBg },
-              ]}
-            >
-              <Text style={[styles.adjustmentModalTitle, { color: colors.text }]}>
-                {cashRegisterCopy.adjustmentModal.title}
-              </Text>
-              <Text style={[styles.adjustmentModalSubtitle, { color: colors.subtext }]}>
-                {cashRegisterCopy.adjustmentModal.subtitle}
-              </Text>
-
-              <View style={{ gap: 6 }}>
-                <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
-                  {cashRegisterCopy.adjustmentModal.amountLabel}
-                </Text>
-                <TextInput
-                  value={adjustmentAmountText}
-                  onChangeText={handleAdjustmentAmountChange}
-                  keyboardType="decimal-pad"
-                  placeholder={cashRegisterCopy.adjustmentModal.amountPlaceholder}
-                  placeholderTextColor="#94a3b8"
-                  style={[styles.adjustmentTextInput, { borderColor: colors.border, color: colors.text }]}
-                />
-                <Text style={[styles.adjustmentHelperText, { color: colors.subtext }]}>
-                  {cashRegisterCopy.adjustmentModal.amountHelp}
-                </Text>
-                {adjustmentError ? (
-                  <Text style={[styles.adjustmentErrorText, { color: colors.danger }]}>
-                    {adjustmentError}
-                  </Text>
-                ) : null}
-              </View>
-
-              <View style={{ gap: 6 }}>
-                <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
-                  {cashRegisterCopy.adjustmentModal.noteLabel}
-                </Text>
-                <TextInput
-                  value={adjustmentNote}
-                  onChangeText={handleAdjustmentNoteChange}
-                  multiline
-                  numberOfLines={3}
-                  placeholder={cashRegisterCopy.adjustmentModal.noteLabel}
-                  placeholderTextColor="#94a3b8"
-                  style={[styles.adjustmentTextArea, { borderColor: colors.border, color: colors.text }]}
-                  textAlignVertical="top"
-                />
-              </View>
-
-              <View style={{ gap: 6 }}>
-                <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
-                  {cashRegisterCopy.adjustmentModal.referenceLabel}
-                </Text>
-                <TextInput
-                  value={adjustmentReference}
-                  onChangeText={handleAdjustmentReferenceChange}
-                  placeholder={cashRegisterCopy.adjustmentModal.referenceLabel}
-                  placeholderTextColor="#94a3b8"
-                  style={[styles.adjustmentTextInput, { borderColor: colors.border, color: colors.text }]}
-                />
-              </View>
-
-              <View style={styles.adjustmentModalActions}>
-                <Pressable
-                  onPress={handleCloseAdjustmentModal}
-                  disabled={adjustmentSaving}
-                  style={[styles.smallBtn, { borderColor: colors.border }, adjustmentSaving && styles.smallBtnDisabled]}
-                  accessibilityRole="button"
-                  accessibilityLabel={cashRegisterCopy.adjustmentModal.cancel}
-                >
-                  <Text style={{ color: colors.subtext, fontWeight: "800" }}>
-                    {cashRegisterCopy.adjustmentModal.cancel}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={handleConfirmAdjustment}
-                  disabled={adjustmentSaving}
-                  style={[
-                    styles.smallBtn,
-                    {
-                      borderColor: colors.accent,
-                      backgroundColor: adjustmentSaving
-                        ? "rgba(255,255,255,0.08)"
-                        : "rgba(37,99,235,0.12)",
-                    },
-                    adjustmentSaving && styles.smallBtnDisabled,
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel={cashRegisterCopy.adjustmentModal.confirm}
-                >
-                  <Text style={{ color: colors.accent, fontWeight: "800" }}>
-                    {adjustmentSaving
-                      ? cashRegisterCopy.adjustmentModal.saving
-                      : cashRegisterCopy.adjustmentModal.confirm}
-                  </Text>
-                </Pressable>
-              </View>
-            </View>
-          </View>
-        </Modal>
-
-      </>
+      <CashRegisterScreen
+        isCompactLayout={isCompactLayout}
+        cashLoading={cashLoading}
+        onRefresh={loadCashRegister}
+        styles={styles}
+        colors={colors}
+        copy={cashRegisterCopy}
+        cashSummary={cashSummary}
+        cashEntries={cashEntries}
+        cashEntryTypeLabels={cashEntryTypeLabels}
+        locale={locale}
+        adjustmentModalOpen={adjustmentModalOpen}
+        onOpenAdjustmentModal={handleOpenAdjustmentModal}
+        onCloseAdjustmentModal={handleCloseAdjustmentModal}
+        adjustmentAmountText={adjustmentAmountText}
+        onAdjustmentAmountChange={handleAdjustmentAmountChange}
+        adjustmentError={adjustmentError}
+        adjustmentNote={adjustmentNote}
+        onAdjustmentNoteChange={handleAdjustmentNoteChange}
+        adjustmentReference={adjustmentReference}
+        onAdjustmentReferenceChange={handleAdjustmentReferenceChange}
+        adjustmentSaving={adjustmentSaving}
+        onConfirmAdjustment={handleConfirmAdjustment}
+      />
     ) : activeScreen === "services" ? (
       <ScrollView
         style={{ flex: 1 }}
@@ -7250,5 +7061,7 @@ const createStyles = (colors: ThemeColors) => StyleSheet.create({
   teamListInfo: { flex: 1, gap: 6 },
   teamRoleBadge: { borderWidth: 1, borderRadius: 999, paddingHorizontal: 8, paddingVertical: 2 },
 });
+
+export type AuthenticatedAppStyles = ReturnType<typeof createStyles>;
 
 export default AuthenticatedApp;

--- a/src/app/screens/CashRegisterScreen.tsx
+++ b/src/app/screens/CashRegisterScreen.tsx
@@ -1,0 +1,293 @@
+import React from "react";
+import {
+  Modal,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { formatPrice } from "../../lib/domain";
+import type { CashEntry, CashRegisterSummary } from "../../lib/cashRegister";
+import type {
+  AuthenticatedAppStyles,
+  CashRegisterCopy,
+  ThemeColors,
+} from "../AuthenticatedApp";
+
+export type CashEntryTypeLabels = Record<CashEntry["type"], string>;
+
+type CashRegisterScreenProps = {
+  isCompactLayout: boolean;
+  cashLoading: boolean;
+  onRefresh: () => void;
+  styles: AuthenticatedAppStyles;
+  colors: ThemeColors;
+  copy: CashRegisterCopy;
+  cashSummary: CashRegisterSummary;
+  cashEntries: CashEntry[];
+  cashEntryTypeLabels: CashEntryTypeLabels;
+  locale: string;
+  adjustmentModalOpen: boolean;
+  onOpenAdjustmentModal: () => void;
+  onCloseAdjustmentModal: () => void;
+  adjustmentAmountText: string;
+  onAdjustmentAmountChange: (value: string) => void;
+  adjustmentError: string | null;
+  adjustmentNote: string;
+  onAdjustmentNoteChange: (value: string) => void;
+  adjustmentReference: string;
+  onAdjustmentReferenceChange: (value: string) => void;
+  adjustmentSaving: boolean;
+  onConfirmAdjustment: () => void;
+};
+
+export default function CashRegisterScreen({
+  isCompactLayout,
+  cashLoading,
+  onRefresh,
+  styles,
+  colors,
+  copy,
+  cashSummary,
+  cashEntries,
+  cashEntryTypeLabels,
+  locale,
+  adjustmentModalOpen,
+  onOpenAdjustmentModal,
+  onCloseAdjustmentModal,
+  adjustmentAmountText,
+  onAdjustmentAmountChange,
+  adjustmentError,
+  adjustmentNote,
+  onAdjustmentNoteChange,
+  adjustmentReference,
+  onAdjustmentReferenceChange,
+  adjustmentSaving,
+  onConfirmAdjustment,
+}: CashRegisterScreenProps) {
+  return (
+    <>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
+        refreshControl={<RefreshControl refreshing={cashLoading} onRefresh={onRefresh} />}
+      >
+        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+          <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
+            <View style={{ flex: 1, gap: 4 }}>
+              <Text style={[styles.title, { color: colors.text }]}>{copy.title}</Text>
+              <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
+                {copy.subtitle}
+              </Text>
+            </View>
+            <View
+              style={[
+                styles.cashHeaderActions,
+                isCompactLayout && styles.cashHeaderActionsCompact,
+              ]}
+            >
+              <Pressable
+                onPress={onOpenAdjustmentModal}
+                style={[styles.secondaryCta, isCompactLayout && styles.fullWidthButton]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.adjustmentCta.accessibility}
+              >
+                <Text style={styles.secondaryCtaText}>{copy.adjustmentCta.label}</Text>
+              </Pressable>
+              <Pressable
+                onPress={onRefresh}
+                style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.refreshAccessibility}
+              >
+                <Text style={styles.defaultCtaText}>{copy.refresh}</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+
+        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 16 }]}>
+          <Text style={[styles.title, { color: colors.text, fontSize: 18 }]}>{copy.summaryTitle}</Text>
+          <View style={styles.cashSummaryGrid}>
+            {[
+              { key: "total", label: copy.summary.total, amount: cashSummary.total_cents },
+              { key: "services", label: copy.summary.services, amount: cashSummary.service_sales_cents },
+              { key: "products", label: copy.summary.products, amount: cashSummary.product_sales_cents },
+              { key: "adjustments", label: copy.summary.adjustments, amount: cashSummary.adjustments_cents },
+            ].map((item) => (
+              <View key={item.key} style={[styles.cashSummaryItem, { borderColor: colors.border }]}>
+                <Text style={styles.cashSummaryLabel}>{item.label}</Text>
+                <Text
+                  style={[
+                    styles.cashSummaryValue,
+                    item.amount < 0 ? styles.cashAmountNegative : styles.cashAmountPositive,
+                  ]}
+                >
+                  {formatPrice(item.amount)}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+          <Text style={[styles.title, { color: colors.text }]}>{copy.ledgerTitle}</Text>
+          {cashEntries.length === 0 ? (
+            <Text style={[styles.empty, { marginVertical: 8 }]}>{copy.empty}</Text>
+          ) : (
+            cashEntries.map((entry) => {
+              const amountStyle =
+                entry.amount_cents < 0 ? styles.cashAmountNegative : styles.cashAmountPositive;
+              const sourceName = entry.source_name?.trim()
+                ? entry.source_name
+                : cashEntryTypeLabels[entry.type];
+              const created = entry.created_at ? new Date(entry.created_at) : null;
+              const dateLabel =
+                created && !Number.isNaN(created.getTime())
+                  ? created.toLocaleString(locale, { dateStyle: "short", timeStyle: "short" })
+                  : entry.created_at;
+              const quantityLabel = entry.quantity > 1 ? copy.entryMeta.quantity(entry.quantity) : null;
+              const unitLabel =
+                entry.unit_amount_cents !== null
+                  ? copy.entryMeta.unitPrice(formatPrice(entry.unit_amount_cents))
+                  : null;
+              const referenceLabel = entry.reference_id
+                ? copy.entryMeta.reference(entry.reference_id)
+                : null;
+
+              return (
+                <View key={entry.id} style={[styles.cashEntryRow, { borderColor: colors.border }]}>
+                  <View style={styles.cashEntryHeader}>
+                    <View style={styles.cashEntryInfo}>
+                      <Text style={styles.cashEntryType}>{cashEntryTypeLabels[entry.type]}</Text>
+                      <Text style={styles.cashEntrySource}>{sourceName}</Text>
+                    </View>
+                    <Text style={[styles.cashAmount, amountStyle]}>{formatPrice(entry.amount_cents)}</Text>
+                  </View>
+                  <View style={styles.cashEntryMetaRow}>
+                    <Text style={styles.cashEntryMeta}>{dateLabel}</Text>
+                    {quantityLabel ? <Text style={styles.cashEntryMeta}>{quantityLabel}</Text> : null}
+                    {unitLabel ? <Text style={styles.cashEntryMeta}>{unitLabel}</Text> : null}
+                    {referenceLabel ? <Text style={styles.cashEntryMeta}>{referenceLabel}</Text> : null}
+                  </View>
+                  {entry.note ? (
+                    <Text style={styles.cashEntryNote}>{copy.entryMeta.note(entry.note)}</Text>
+                  ) : null}
+                </View>
+              );
+            })
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={adjustmentModalOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={onCloseAdjustmentModal}
+      >
+        <View style={styles.adjustmentModalBackdrop}>
+          <View
+            style={[
+              styles.adjustmentModalCard,
+              { borderColor: colors.border, backgroundColor: colors.sidebarBg },
+            ]}
+          >
+            <Text style={[styles.adjustmentModalTitle, { color: colors.text }]}>
+              {copy.adjustmentModal.title}
+            </Text>
+            <Text style={[styles.adjustmentModalSubtitle, { color: colors.subtext }]}>
+              {copy.adjustmentModal.subtitle}
+            </Text>
+
+            <View style={{ gap: 6 }}>
+              <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
+                {copy.adjustmentModal.amountLabel}
+              </Text>
+              <TextInput
+                value={adjustmentAmountText}
+                onChangeText={onAdjustmentAmountChange}
+                keyboardType="decimal-pad"
+                placeholder={copy.adjustmentModal.amountPlaceholder}
+                placeholderTextColor="#94a3b8"
+                style={[styles.adjustmentTextInput, { borderColor: colors.border, color: colors.text }]}
+              />
+              <Text style={[styles.adjustmentHelperText, { color: colors.subtext }]}>
+                {copy.adjustmentModal.amountHelp}
+              </Text>
+              {adjustmentError ? (
+                <Text style={[styles.adjustmentErrorText, { color: colors.danger }]}>{adjustmentError}</Text>
+              ) : null}
+            </View>
+
+            <View style={{ gap: 6 }}>
+              <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
+                {copy.adjustmentModal.noteLabel}
+              </Text>
+              <TextInput
+                value={adjustmentNote}
+                onChangeText={onAdjustmentNoteChange}
+                multiline
+                numberOfLines={3}
+                placeholder={copy.adjustmentModal.noteLabel}
+                placeholderTextColor="#94a3b8"
+                style={[styles.adjustmentTextArea, { borderColor: colors.border, color: colors.text }]}
+                textAlignVertical="top"
+              />
+            </View>
+
+            <View style={{ gap: 6 }}>
+              <Text style={[styles.adjustmentModalLabel, { color: colors.subtext }]}>
+                {copy.adjustmentModal.referenceLabel}
+              </Text>
+              <TextInput
+                value={adjustmentReference}
+                onChangeText={onAdjustmentReferenceChange}
+                placeholder={copy.adjustmentModal.referenceLabel}
+                placeholderTextColor="#94a3b8"
+                style={[styles.adjustmentTextInput, { borderColor: colors.border, color: colors.text }]}
+              />
+            </View>
+
+            <View style={styles.adjustmentModalActions}>
+              <Pressable
+                onPress={onCloseAdjustmentModal}
+                disabled={adjustmentSaving}
+                style={[styles.smallBtn, { borderColor: colors.border }, adjustmentSaving && styles.smallBtnDisabled]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.adjustmentModal.cancel}
+              >
+                <Text style={{ color: colors.subtext, fontWeight: "800" }}>
+                  {copy.adjustmentModal.cancel}
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={onConfirmAdjustment}
+                disabled={adjustmentSaving}
+                style={[
+                  styles.smallBtn,
+                  {
+                    borderColor: colors.accent,
+                    backgroundColor: adjustmentSaving
+                      ? "rgba(255,255,255,0.08)"
+                      : "rgba(37,99,235,0.12)",
+                  },
+                  adjustmentSaving && styles.smallBtnDisabled,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={copy.adjustmentModal.confirm}
+              >
+                <Text style={{ color: colors.accent, fontWeight: "800" }}>
+                  {adjustmentSaving ? copy.adjustmentModal.saving : copy.adjustmentModal.confirm}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "types": ["expo-router/types"],
+    "typeRoots": ["./types", "./node_modules/@types"]
   }
 }

--- a/types/expo-router/index.d.ts
+++ b/types/expo-router/index.d.ts
@@ -1,0 +1,12 @@
+declare module "expo-router" {
+  import * as React from "react";
+
+  export const Slot: React.ComponentType<{ children?: React.ReactNode }>;
+  export const Redirect: React.ComponentType<{ href: string }>;
+  export function useRouter(): {
+    replace: (href: string) => void;
+    push: (href: string) => void;
+    back: () => void;
+  };
+  export function useLocalSearchParams<T extends Record<string, string | string[] | undefined>>(): T;
+}

--- a/types/expo-router/types.d.ts
+++ b/types/expo-router/types.d.ts
@@ -1,0 +1,1 @@
+declare module "expo-router/types" {}


### PR DESCRIPTION
## Summary
- wire up Expo Router as the application entry point with root and dynamic routes for dashboard screens
- expose navigation props on `AuthenticatedApp` and render the cash register content via a new `CashRegisterScreen` component
- add the Expo Router dependency, configuration, and temporary local type stubs so TypeScript succeeds until the package can be installed

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f94b41c5dc83278f8da503ad17abf7