### PR TITLE
Extract products and services screens from AuthenticatedApp

### DIFF
--- a/app/assistant.tsx
+++ b/app/assistant.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Assistant(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Assistant(): React.ReactElement {
       initialScreen="assistant"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/barbershop-settings.tsx
+++ b/app/barbershop-settings.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function BarbershopSettings(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function BarbershopSettings(): React.ReactElement {
       initialScreen="barbershopSettings"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/book-service.tsx
+++ b/app/book-service.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function BookService(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function BookService(): React.ReactElement {
       initialScreen="bookService"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/bookings.tsx
+++ b/app/bookings.tsx
@@ -21,6 +21,8 @@ import { applyAlpha } from "../src/utils/color";
 import FilterToggle from "../src/components/FilterToggle";
 import DateTimeInput from "../src/components/DateTimeInput";
 import { cashRegisterRenderer } from "./cash-register";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 const WHATSAPP_BRAND_COLOR = "#25D366";
 
@@ -548,6 +550,8 @@ export default function Bookings(): React.ReactElement {
       initialScreen="bookings"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/cash-register.tsx
+++ b/app/cash-register.tsx
@@ -6,6 +6,8 @@ import AuthenticatedApp, {
   type CashRegisterScreenRenderer,
 } from "../src/app/AuthenticatedApp";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 import { formatPrice } from "../src/lib/domain";
 
 export function CashRegisterScreen({
@@ -296,6 +298,8 @@ export default function CashRegister(): React.ReactElement {
       initialScreen="cashRegister"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Index(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Index(): React.ReactElement {
       initialScreen="home"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/packages.tsx
+++ b/app/packages.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Packages(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Packages(): React.ReactElement {
       initialScreen="packages"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/products.tsx
+++ b/app/products.tsx
@@ -1,8 +1,373 @@
 import React from "react";
+import { Modal, Pressable, RefreshControl, ScrollView, Text, TextInput, View } from "react-native";
 
-import AuthenticatedApp from "../src/app/AuthenticatedApp";
+import AuthenticatedApp, {
+  type ProductsScreenProps,
+  type ProductsScreenRenderer,
+} from "../src/app/AuthenticatedApp";
+import ProductForm from "../src/components/ProductForm";
+import { formatPrice } from "../src/lib/domain";
+import { applyAlpha, mixHexColor } from "../src/utils/color";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { servicesRenderer } from "./services";
+
+export function ProductsScreen({
+  isCompactLayout,
+  colors,
+  styles,
+  productsCopy,
+  productsLoading,
+  loadProducts,
+  handleOpenCreateProduct,
+  productFormVisible,
+  productFormMode,
+  productBeingEdited,
+  handleProductCreated,
+  handleProductUpdated,
+  handleProductFormClose,
+  productFormCopy,
+  localizedProducts,
+  productMap,
+  resolvedTheme,
+  handleOpenSellProduct,
+  handleOpenRestockProduct,
+  handleOpenEditProduct,
+  handleDeleteProduct,
+  stockModalProduct,
+  stockModalDisplayProduct,
+  stockModalMode,
+  stockQuantityText,
+  handleStockQuantityChange,
+  handleCloseStockModal,
+  handleConfirmStockModal,
+  stockSaving,
+}: ProductsScreenProps): React.ReactElement {
+  return (
+    <>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
+        refreshControl={<RefreshControl refreshing={productsLoading} onRefresh={loadProducts} />}
+      >
+        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+          <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
+            <View style={{ flex: 1, gap: 4 }}>
+              <Text style={[styles.title, { color: colors.text }]}>{productsCopy.title}</Text>
+              <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
+                {productsCopy.subtitle}
+              </Text>
+            </View>
+            <Pressable
+              onPress={handleOpenCreateProduct}
+              style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
+              accessibilityRole="button"
+              accessibilityLabel={productsCopy.createCta.accessibility}
+            >
+              <Text style={styles.defaultCtaText}>{productsCopy.createCta.label}</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {productFormVisible ? (
+          <ProductForm
+            mode={productFormMode}
+            product={productFormMode === "edit" ? productBeingEdited : null}
+            onCreated={handleProductCreated}
+            onUpdated={handleProductUpdated}
+            onCancel={handleProductFormClose}
+            colors={{
+              text: colors.text,
+              subtext: colors.subtext,
+              border: colors.border,
+              surface: colors.surface,
+              accent: colors.accent,
+              accentFgOn: colors.accentFgOn,
+              danger: colors.danger,
+            }}
+            copy={productFormCopy}
+          />
+        ) : null}
+
+        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+          <Text style={[styles.title, { color: colors.text }]}>{productsCopy.listTitle}</Text>
+          {localizedProducts.length === 0 ? (
+            <Text style={[styles.empty, { marginVertical: 8 }]}>{productsCopy.empty}</Text>
+          ) : (
+            localizedProducts.map((product) => {
+              const original = productMap.get(product.id) ?? product;
+              const disableSell = original.stock_quantity <= 0;
+              const isLowStock = original.stock_quantity <= 5;
+              const stockBorderColor = mixHexColor(
+                colors.border,
+                isLowStock ? colors.danger : colors.accent,
+                0.45,
+              );
+              const stockBackgroundColor = applyAlpha(
+                isLowStock ? colors.danger : colors.accent,
+                resolvedTheme === "dark" ? 0.28 : 0.12,
+              );
+              const stockLabelColor = isLowStock ? colors.danger : colors.accent;
+              return (
+                <View
+                  key={product.id}
+                  style={[
+                    styles.productCard,
+                    {
+                      borderColor: mixHexColor(colors.border, colors.accent, 0.25),
+                      backgroundColor: mixHexColor(
+                        colors.surface,
+                        colors.accent,
+                        resolvedTheme === "dark" ? 0.14 : 0.06,
+                      ),
+                    },
+                    isCompactLayout && styles.productCardCompact,
+                  ]}
+                >
+                  <View style={styles.productHeader}>
+                    <Text style={[styles.productName, { color: colors.text }]}>{product.name}</Text>
+                    {original.sku ? (
+                      <View
+                        style={[
+                          styles.productChip,
+                          styles.productSkuChip,
+                          {
+                            borderColor: mixHexColor(colors.border, colors.surface, 0.45),
+                            backgroundColor: mixHexColor(
+                              colors.surface,
+                              colors.border,
+                              resolvedTheme === "dark" ? 0.38 : 0.18,
+                            ),
+                          },
+                        ]}
+                      >
+                        <Text style={[styles.productChipLabel, { color: colors.subtext }]}>
+                          {productsCopy.skuLabel}
+                        </Text>
+                        <Text style={[styles.productChipValue, { color: colors.subtext }]}>
+                          {original.sku}
+                        </Text>
+                      </View>
+                    ) : null}
+                  </View>
+
+                  <View style={styles.productChipRow}>
+                    <View
+                      style={[
+                        styles.productChip,
+                        {
+                          borderColor: mixHexColor(colors.border, colors.accent, 0.35),
+                          backgroundColor: applyAlpha(
+                            colors.accent,
+                            resolvedTheme === "dark" ? 0.25 : 0.1,
+                          ),
+                        },
+                      ]}
+                    >
+                      <Text style={[styles.productChipLabel, { color: colors.accent }]}>
+                        {productsCopy.priceLabel}
+                      </Text>
+                      <Text style={[styles.productChipValue, { color: colors.text }]}>
+                        {formatPrice(original.price_cents)}
+                      </Text>
+                    </View>
+                    <View
+                      style={[
+                        styles.productChip,
+                        {
+                          borderColor: stockBorderColor,
+                          backgroundColor: stockBackgroundColor,
+                        },
+                      ]}
+                    >
+                      <Text style={[styles.productChipLabel, { color: stockLabelColor }]}>
+                        {productsCopy.stockLabel}
+                      </Text>
+                      <Text style={[styles.productChipValue, { color: colors.text }]}>
+                        {productsCopy.stockValue(original.stock_quantity)}
+                      </Text>
+                    </View>
+                  </View>
+
+                  {original.description ? (
+                    <View style={styles.productDescriptionBlock}>
+                      <Text style={[styles.productChipLabel, { color: colors.subtext }]}>
+                        {productsCopy.descriptionLabel}
+                      </Text>
+                      <Text style={[styles.productDescription, { color: colors.subtext }]}>
+                        {original.description}
+                      </Text>
+                    </View>
+                  ) : null}
+
+                  <View
+                    style={[
+                      styles.productActionsContainer,
+                      isCompactLayout && styles.productActionsContainerStacked,
+                    ]}
+                  >
+                    <Pressable
+                      onPress={() => handleOpenSellProduct(original)}
+                      disabled={disableSell}
+                      style={[
+                        styles.productActionButton,
+                        styles.productPrimaryAction,
+                        disableSell && styles.productActionDisabled,
+                        isCompactLayout && styles.productActionButtonFullWidth,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel={productsCopy.actions.sell.accessibility(product.name)}
+                    >
+                      <Text
+                        style={[
+                          styles.productActionLabel,
+                          styles.productActionPrimaryLabel,
+                          disableSell && styles.productActionDisabledLabel,
+                        ]}
+                      >
+                        {productsCopy.actions.sell.label}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleOpenRestockProduct(original)}
+                      style={[
+                        styles.productActionButton,
+                        styles.productPrimaryAction,
+                        isCompactLayout && styles.productActionButtonFullWidth,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel={productsCopy.actions.restock.accessibility(product.name)}
+                    >
+                      <Text style={[styles.productActionLabel, styles.productActionPrimaryLabel]}>
+                        {productsCopy.actions.restock.label}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleOpenEditProduct(original)}
+                      style={[
+                        styles.productActionButton,
+                        styles.productSecondaryAction,
+                        isCompactLayout && styles.productActionButtonFullWidth,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel={productsCopy.actions.edit.accessibility(product.name)}
+                    >
+                      <Text style={[styles.productActionLabel, styles.productActionSecondaryLabel]}>
+                        {productsCopy.actions.edit.label}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleDeleteProduct(original)}
+                      style={[
+                        styles.productActionButton,
+                        styles.productDangerAction,
+                        isCompactLayout && styles.productActionButtonFullWidth,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel={productsCopy.actions.delete.accessibility(product.name)}
+                    >
+                      <Text style={[styles.productActionLabel, styles.productActionDangerLabel]}>
+                        {productsCopy.actions.delete.label}
+                      </Text>
+                    </Pressable>
+                  </View>
+                </View>
+              );
+            })
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={!!stockModalProduct}
+        transparent
+        animationType="fade"
+        onRequestClose={handleCloseStockModal}
+      >
+        <View style={styles.stockModalBackdrop}>
+          <View
+            style={[
+              styles.stockModalCard,
+              { borderColor: colors.border, backgroundColor: colors.sidebarBg },
+            ]}
+          >
+            <Text style={[styles.stockModalTitle, { color: colors.text }]}>
+              {stockModalProduct
+                ? stockModalMode === "sell"
+                  ? productsCopy.stockModal.sellTitle(
+                      stockModalDisplayProduct?.name ?? stockModalProduct.name,
+                    )
+                  : productsCopy.stockModal.restockTitle(
+                      stockModalDisplayProduct?.name ?? stockModalProduct.name,
+                    )
+                : ""}
+            </Text>
+            <Text style={[styles.stockModalSubtitle, { color: colors.subtext }]}>
+              {stockModalProduct
+                ? stockModalMode === "sell"
+                  ? productsCopy.stockModal.sellSubtitle(stockModalProduct.stock_quantity)
+                  : productsCopy.stockModal.restockSubtitle
+                : ""}
+            </Text>
+            <Text style={[styles.stockModalLabel, { color: colors.subtext }]}>
+              {productsCopy.stockModal.quantityLabel}
+            </Text>
+            <TextInput
+              value={stockQuantityText}
+              onChangeText={handleStockQuantityChange}
+              keyboardType="number-pad"
+              placeholder={productsCopy.stockModal.quantityPlaceholder}
+              placeholderTextColor="#94a3b8"
+              style={[styles.stockQuantityInput, { borderColor: colors.border, color: colors.text }]}
+            />
+            <View style={styles.stockModalActions}>
+              <Pressable
+                onPress={handleCloseStockModal}
+                style={[styles.smallBtn, { borderColor: colors.border }]}
+                accessibilityRole="button"
+                accessibilityLabel={productsCopy.stockModal.cancel}
+              >
+                <Text style={{ color: colors.subtext, fontWeight: "800" }}>
+                  {productsCopy.stockModal.cancel}
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={handleConfirmStockModal}
+                disabled={stockSaving}
+                style={[
+                  styles.smallBtn,
+                  {
+                    borderColor: colors.accent,
+                    backgroundColor: stockSaving
+                      ? "rgba(255,255,255,0.08)"
+                      : "rgba(37,99,235,0.12)",
+                  },
+                  stockSaving && styles.smallBtnDisabled,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  stockModalMode === "sell"
+                    ? productsCopy.stockModal.confirmSell
+                    : productsCopy.stockModal.confirmRestock
+                }
+              >
+                <Text style={{ color: colors.accent, fontWeight: "800" }}>
+                  {stockSaving
+                    ? productFormCopy.buttons.saving
+                    : stockModalMode === "sell"
+                      ? productsCopy.stockModal.confirmSell
+                      : productsCopy.stockModal.confirmRestock}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+export const productsRenderer: ProductsScreenRenderer = (props) => <ProductsScreen {...props} />;
 
 export default function Products(): React.ReactElement {
   return (
@@ -10,6 +375,8 @@ export default function Products(): React.ReactElement {
       initialScreen="products"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/services.tsx
+++ b/app/services.tsx
@@ -1,8 +1,140 @@
 import React from "react";
+import { Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 
-import AuthenticatedApp from "../src/app/AuthenticatedApp";
+import AuthenticatedApp, {
+  type ServicesScreenProps,
+  type ServicesScreenRenderer,
+} from "../src/app/AuthenticatedApp";
+import ServiceForm from "../src/components/ServiceForm";
+import { formatPrice } from "../src/lib/domain";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+
+export function ServicesScreen({
+  isCompactLayout,
+  colors,
+  styles,
+  servicesCopy,
+  servicesLoading,
+  loadServices,
+  handleOpenCreateService,
+  serviceFormVisible,
+  serviceFormMode,
+  serviceBeingEdited,
+  handleServiceCreated,
+  handleServiceUpdated,
+  handleServiceFormClose,
+  serviceFormCopy,
+  services,
+  localizedServiceMap,
+  handleOpenEditService,
+  handleDeleteService,
+}: ServicesScreenProps): React.ReactElement {
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
+      refreshControl={<RefreshControl refreshing={servicesLoading} onRefresh={loadServices} />}
+    >
+      <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+        <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
+          <View style={{ flex: 1, gap: 4 }}>
+            <Text style={[styles.title, { color: colors.text }]}>{servicesCopy.title}</Text>
+            <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
+              {servicesCopy.subtitle}
+            </Text>
+          </View>
+          <Pressable
+            onPress={handleOpenCreateService}
+            style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
+            accessibilityRole="button"
+            accessibilityLabel={servicesCopy.createCta.accessibility}
+          >
+            <Text style={styles.defaultCtaText}>{servicesCopy.createCta.label}</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {serviceFormVisible ? (
+        <ServiceForm
+          mode={serviceFormMode}
+          service={serviceFormMode === "edit" ? serviceBeingEdited : null}
+          onCreated={handleServiceCreated}
+          onUpdated={handleServiceUpdated}
+          onCancel={handleServiceFormClose}
+          colors={{
+            text: colors.text,
+            subtext: colors.subtext,
+            border: colors.border,
+            surface: colors.surface,
+            accent: colors.accent,
+            accentFgOn: colors.accentFgOn,
+            danger: colors.danger,
+          }}
+          copy={serviceFormCopy}
+        />
+      ) : null}
+
+      <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
+        <Text style={[styles.title, { color: colors.text }]}>{servicesCopy.listTitle}</Text>
+        {services.length === 0 ? (
+          <Text style={[styles.empty, { marginVertical: 8 }]}>{servicesCopy.empty}</Text>
+        ) : (
+          services.map((svc) => {
+            const localized = localizedServiceMap.get(svc.id) ?? svc;
+            return (
+              <View key={svc.id} style={styles.serviceRow}>
+                <View
+                  style={{ flexDirection: "row", alignItems: "center", gap: 10, flex: 1, flexWrap: "wrap" }}
+                >
+                  <MaterialCommunityIcons name={svc.icon} size={22} color={colors.accent} />
+                  <View>
+                    <Text style={{ color: colors.text, fontWeight: "800" }}>{localized.name}</Text>
+                    <Text style={{ color: colors.subtext, fontSize: 12 }}>
+                      {servicesCopy.serviceMeta(svc.estimated_minutes, formatPrice(svc.price_cents))}
+                    </Text>
+                  </View>
+                </View>
+                <View style={styles.serviceActions}>
+                  <Pressable
+                    onPress={() => handleOpenEditService(svc)}
+                    style={[styles.smallBtn, { borderColor: colors.border }]}
+                    accessibilityRole="button"
+                    accessibilityLabel={servicesCopy.actions.edit.accessibility(localized.name)}
+                  >
+                    <Text style={{ color: colors.subtext, fontWeight: "800" }}>
+                      {servicesCopy.actions.edit.label}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => handleDeleteService(svc)}
+                    style={[
+                      styles.smallBtn,
+                      {
+                        borderColor: colors.danger,
+                        backgroundColor: "rgba(239,68,68,0.1)",
+                      },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={servicesCopy.actions.delete.accessibility(localized.name)}
+                  >
+                    <Text style={{ color: colors.danger, fontWeight: "800" }}>
+                      {servicesCopy.actions.delete.label}
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            );
+          })
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+export const servicesRenderer: ServicesScreenRenderer = (props) => <ServicesScreen {...props} />;
 
 export default function Services(): React.ReactElement {
   return (
@@ -10,6 +142,8 @@ export default function Services(): React.ReactElement {
       initialScreen="services"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Settings(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Settings(): React.ReactElement {
       initialScreen="settings"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/support.tsx
+++ b/app/support.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Support(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Support(): React.ReactElement {
       initialScreen="support"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/app/team.tsx
+++ b/app/team.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import AuthenticatedApp from "../src/app/AuthenticatedApp";
 import { cashRegisterRenderer } from "./cash-register";
 import { bookingsRenderer } from "./bookings";
+import { productsRenderer } from "./products";
+import { servicesRenderer } from "./services";
 
 export default function Team(): React.ReactElement {
   return (
@@ -10,6 +12,8 @@ export default function Team(): React.ReactElement {
       initialScreen="team"
       renderBookings={bookingsRenderer}
       renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
     />
   );
 }

--- a/src/app/AuthenticatedApp.tsx
+++ b/src/app/AuthenticatedApp.tsx
@@ -95,8 +95,6 @@ import BarberSelector, { Barber } from "../components/BarberSelector";
 import AssistantChat from "../components/AssistantChat";
 import SupportChat from "../components/SupportChat";
 import ServicePackageForm from "../components/ServicePackageForm";
-import ServiceForm from "../components/ServiceForm";
-import ProductForm from "../components/ProductForm";
 import FilterToggle from "../components/FilterToggle";
 import DateTimeInput from "../components/DateTimeInput";
 import { DonutChart } from "../components/DonutChart";
@@ -1437,6 +1435,67 @@ export type CashRegisterScreenRenderer = (
   props: CashRegisterScreenProps,
 ) => React.ReactElement | null;
 
+export type ProductsScreenProps = {
+  isCompactLayout: boolean;
+  colors: ThemeColors;
+  styles: ReturnType<typeof createStyles>;
+  productsCopy: (typeof LANGUAGE_COPY)[SupportedLanguage]["productsPage"];
+  productsLoading: boolean;
+  loadProducts: () => Promise<void>;
+  handleOpenCreateProduct: () => void;
+  productFormVisible: boolean;
+  productFormMode: "create" | "edit";
+  productBeingEdited: Product | null;
+  handleProductCreated: (product: Product) => void;
+  handleProductUpdated: (product: Product) => void;
+  handleProductFormClose: () => void;
+  productFormCopy: (typeof LANGUAGE_COPY)[SupportedLanguage]["productForm"];
+  localizedProducts: Product[];
+  productMap: Map<string, Product>;
+  resolvedTheme: "light" | "dark";
+  handleOpenSellProduct: (product: Product) => void;
+  handleOpenRestockProduct: (product: Product) => void;
+  handleOpenEditProduct: (product: Product) => void;
+  handleDeleteProduct: (product: Product) => void;
+  stockModalProduct: Product | null;
+  stockModalDisplayProduct: Product | null;
+  stockModalMode: "sell" | "restock";
+  stockQuantityText: string;
+  handleStockQuantityChange: (text: string) => void;
+  handleCloseStockModal: () => void;
+  handleConfirmStockModal: () => Promise<void>;
+  stockSaving: boolean;
+};
+
+export type ProductsScreenRenderer = (
+  props: ProductsScreenProps,
+) => React.ReactElement | null;
+
+export type ServicesScreenProps = {
+  isCompactLayout: boolean;
+  colors: ThemeColors;
+  styles: ReturnType<typeof createStyles>;
+  servicesCopy: (typeof LANGUAGE_COPY)[SupportedLanguage]["servicesPage"];
+  servicesLoading: boolean;
+  loadServices: () => Promise<void>;
+  handleOpenCreateService: () => void;
+  serviceFormVisible: boolean;
+  serviceFormMode: "create" | "edit";
+  serviceBeingEdited: Service | null;
+  handleServiceCreated: (service: Service) => void;
+  handleServiceUpdated: (service: Service) => void;
+  handleServiceFormClose: () => void;
+  serviceFormCopy: (typeof LANGUAGE_COPY)[SupportedLanguage]["serviceForm"];
+  services: Service[];
+  localizedServiceMap: Map<string, Service>;
+  handleOpenEditService: (service: Service) => void;
+  handleDeleteService: (service: Service) => void;
+};
+
+export type ServicesScreenRenderer = (
+  props: ServicesScreenProps,
+) => React.ReactElement | null;
+
 export type BookingsScreenProps = {
   isCompactLayout: boolean;
   isUltraCompactLayout: boolean;
@@ -1486,6 +1545,8 @@ type AuthenticatedAppProps = {
   onNavigate?: (screen: ScreenName) => void;
   renderCashRegister?: CashRegisterScreenRenderer;
   renderBookings?: BookingsScreenRenderer;
+  renderProducts?: ProductsScreenRenderer;
+  renderServices?: ServicesScreenRenderer;
 };
 
 function AuthenticatedApp({
@@ -1493,6 +1554,8 @@ function AuthenticatedApp({
   onNavigate,
   renderCashRegister,
   renderBookings,
+  renderProducts,
+  renderServices,
 }: AuthenticatedAppProps) {
   const [services, setServices] = useState<Service[]>([]);
   const [servicesLoading, setServicesLoading] = useState(false);
@@ -1547,9 +1610,11 @@ function AuthenticatedApp({
   const assistantCopy = copy.assistant;
   const supportCopy = copy.support;
   const productsCopy = copy.productsPage;
+  const servicesCopy = copy.servicesPage;
   const packagesCopy = copy.packagesPage;
   const cashRegisterCopy = copy.cashRegisterPage;
   const productFormCopy = copy.productForm;
+  const serviceFormCopy = copy.serviceForm;
   const teamCopy = copy.teamPage;
   const settingsBarbershopCopy = copy.settingsPage.barbershop;
   const barbershopPageCopy = copy.barbershopPage;
@@ -4084,332 +4149,39 @@ function AuthenticatedApp({
           })
         : null
     ) : activeScreen === "products" ? (
-      <>
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
-          refreshControl={<RefreshControl refreshing={productsLoading} onRefresh={loadProducts} />}
-        >
-          <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-            <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
-              <View style={{ flex: 1, gap: 4 }}>
-                <Text style={[styles.title, { color: colors.text }]}>{productsCopy.title}</Text>
-                <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
-                  {productsCopy.subtitle}
-                </Text>
-              </View>
-              <Pressable
-                onPress={handleOpenCreateProduct}
-                style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
-                accessibilityRole="button"
-                accessibilityLabel={productsCopy.createCta.accessibility}
-              >
-                <Text style={styles.defaultCtaText}>{productsCopy.createCta.label}</Text>
-              </Pressable>
-            </View>
-          </View>
-
-          {productFormVisible ? (
-            <ProductForm
-              mode={productFormMode}
-              product={productFormMode === "edit" ? productBeingEdited : null}
-              onCreated={handleProductCreated}
-              onUpdated={handleProductUpdated}
-              onCancel={handleProductFormClose}
-              colors={{
-                text: colors.text,
-                subtext: colors.subtext,
-                border: colors.border,
-                surface: colors.surface,
-                accent: colors.accent,
-                accentFgOn: colors.accentFgOn,
-                danger: colors.danger,
-              }}
-              copy={productFormCopy}
-            />
-          ) : null}
-
-          <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-            <Text style={[styles.title, { color: colors.text }]}>{productsCopy.listTitle}</Text>
-            {localizedProducts.length === 0 ? (
-              <Text style={[styles.empty, { marginVertical: 8 }]}>{productsCopy.empty}</Text>
-            ) : (
-              localizedProducts.map((product) => {
-                const original = productMap.get(product.id) ?? product;
-                const disableSell = original.stock_quantity <= 0;
-                const isLowStock = original.stock_quantity <= 5;
-                const stockBorderColor = mixHexColor(
-                  colors.border,
-                  isLowStock ? colors.danger : colors.accent,
-                  0.45,
-                );
-                const stockBackgroundColor = applyAlpha(
-                  isLowStock ? colors.danger : colors.accent,
-                  resolvedTheme === "dark" ? 0.28 : 0.12,
-                );
-                const stockLabelColor = isLowStock ? colors.danger : colors.accent;
-                return (
-                  <View
-                    key={product.id}
-                    style={[
-                      styles.productCard,
-                      {
-                        borderColor: mixHexColor(colors.border, colors.accent, 0.25),
-                        backgroundColor: mixHexColor(
-                          colors.surface,
-                          colors.accent,
-                          resolvedTheme === "dark" ? 0.14 : 0.06,
-                        ),
-                      },
-                      isCompactLayout && styles.productCardCompact,
-                    ]}
-                  >
-                    <View style={styles.productHeader}>
-                      <Text style={[styles.productName, { color: colors.text }]}>{product.name}</Text>
-                      {original.sku ? (
-                        <View
-                          style={[
-                            styles.productChip,
-                            styles.productSkuChip,
-                            {
-                              borderColor: mixHexColor(colors.border, colors.surface, 0.45),
-                              backgroundColor: mixHexColor(
-                                colors.surface,
-                                colors.border,
-                                resolvedTheme === "dark" ? 0.38 : 0.18,
-                              ),
-                            },
-                          ]}
-                        >
-                          <Text style={[styles.productChipLabel, { color: colors.subtext }]}>
-                            {productsCopy.skuLabel}
-                          </Text>
-                          <Text style={[styles.productChipValue, { color: colors.subtext }]}>
-                            {original.sku}
-                          </Text>
-                        </View>
-                      ) : null}
-                    </View>
-
-                    <View style={styles.productChipRow}>
-                      <View
-                        style={[
-                          styles.productChip,
-                          {
-                            borderColor: mixHexColor(colors.border, colors.accent, 0.35),
-                            backgroundColor: applyAlpha(
-                              colors.accent,
-                              resolvedTheme === "dark" ? 0.25 : 0.1,
-                            ),
-                          },
-                        ]}
-                      >
-                        <Text style={[styles.productChipLabel, { color: colors.accent }]}>
-                          {productsCopy.priceLabel}
-                        </Text>
-                        <Text style={[styles.productChipValue, { color: colors.text }]}>
-                          {formatPrice(original.price_cents)}
-                        </Text>
-                      </View>
-                      <View
-                        style={[
-                          styles.productChip,
-                          {
-                            borderColor: stockBorderColor,
-                            backgroundColor: stockBackgroundColor,
-                          },
-                        ]}
-                      >
-                        <Text style={[styles.productChipLabel, { color: stockLabelColor }]}>
-                          {productsCopy.stockLabel}
-                        </Text>
-                        <Text style={[styles.productChipValue, { color: colors.text }]}>
-                          {productsCopy.stockValue(original.stock_quantity)}
-                        </Text>
-                      </View>
-                    </View>
-
-                    {original.description ? (
-                      <View style={styles.productDescriptionBlock}>
-                        <Text style={[styles.productChipLabel, { color: colors.subtext }]}>
-                          {productsCopy.descriptionLabel}
-                        </Text>
-                        <Text style={[styles.productDescription, { color: colors.subtext }]}>
-                          {original.description}
-                        </Text>
-                      </View>
-                    ) : null}
-
-                    <View
-                      style={[
-                        styles.productActionsContainer,
-                        isCompactLayout && styles.productActionsContainerStacked,
-                      ]}
-                    >
-                      <Pressable
-                        onPress={() => handleOpenSellProduct(original)}
-                        disabled={disableSell}
-                        style={[
-                          styles.productActionButton,
-                          styles.productPrimaryAction,
-                          disableSell && styles.productActionDisabled,
-                          isCompactLayout && styles.productActionButtonFullWidth,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={productsCopy.actions.sell.accessibility(product.name)}
-                      >
-                        <Text
-                          style={[
-                            styles.productActionLabel,
-                            styles.productActionPrimaryLabel,
-                            disableSell && styles.productActionDisabledLabel,
-                          ]}
-                        >
-                          {productsCopy.actions.sell.label}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={() => handleOpenRestockProduct(original)}
-                        style={[
-                          styles.productActionButton,
-                          styles.productPrimaryAction,
-                          isCompactLayout && styles.productActionButtonFullWidth,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={productsCopy.actions.restock.accessibility(product.name)}
-                      >
-                        <Text
-                          style={[styles.productActionLabel, styles.productActionPrimaryLabel]}
-                        >
-                          {productsCopy.actions.restock.label}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={() => handleOpenEditProduct(original)}
-                        style={[
-                          styles.productActionButton,
-                          styles.productSecondaryAction,
-                          isCompactLayout && styles.productActionButtonFullWidth,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={productsCopy.actions.edit.accessibility(product.name)}
-                      >
-                        <Text
-                          style={[styles.productActionLabel, styles.productActionSecondaryLabel]}
-                        >
-                          {productsCopy.actions.edit.label}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={() => handleDeleteProduct(original)}
-                        style={[
-                          styles.productActionButton,
-                          styles.productDangerAction,
-                          isCompactLayout && styles.productActionButtonFullWidth,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={productsCopy.actions.delete.accessibility(product.name)}
-                      >
-                        <Text
-                          style={[styles.productActionLabel, styles.productActionDangerLabel]}
-                        >
-                          {productsCopy.actions.delete.label}
-                        </Text>
-                      </Pressable>
-                    </View>
-                  </View>
-                );
-              })
-            )}
-          </View>
-        </ScrollView>
-
-        <Modal
-          visible={!!stockModalProduct}
-          transparent
-          animationType="fade"
-          onRequestClose={handleCloseStockModal}
-        >
-          <View style={styles.stockModalBackdrop}>
-            <View
-              style={[
-                styles.stockModalCard,
-                { borderColor: colors.border, backgroundColor: colors.sidebarBg },
-              ]}
-            >
-              <Text style={[styles.stockModalTitle, { color: colors.text }]}>
-                {stockModalProduct
-                  ? stockModalMode === "sell"
-                    ? productsCopy.stockModal.sellTitle(
-                        stockModalDisplayProduct?.name ?? stockModalProduct.name,
-                      )
-                    : productsCopy.stockModal.restockTitle(
-                        stockModalDisplayProduct?.name ?? stockModalProduct.name,
-                      )
-                  : ""}
-              </Text>
-              <Text style={[styles.stockModalSubtitle, { color: colors.subtext }]}>
-                {stockModalProduct
-                  ? stockModalMode === "sell"
-                    ? productsCopy.stockModal.sellSubtitle(stockModalProduct.stock_quantity)
-                    : productsCopy.stockModal.restockSubtitle
-                  : ""}
-              </Text>
-              <Text style={[styles.stockModalLabel, { color: colors.subtext }]}>
-                {productsCopy.stockModal.quantityLabel}
-              </Text>
-              <TextInput
-                value={stockQuantityText}
-                onChangeText={handleStockQuantityChange}
-                keyboardType="number-pad"
-                placeholder={productsCopy.stockModal.quantityPlaceholder}
-                placeholderTextColor="#94a3b8"
-                style={[styles.stockQuantityInput, { borderColor: colors.border, color: colors.text }]}
-              />
-              <View style={styles.stockModalActions}>
-                <Pressable
-                  onPress={handleCloseStockModal}
-                  style={[styles.smallBtn, { borderColor: colors.border }]}
-                  accessibilityRole="button"
-                  accessibilityLabel={productsCopy.stockModal.cancel}
-                >
-                  <Text style={{ color: colors.subtext, fontWeight: "800" }}>
-                    {productsCopy.stockModal.cancel}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={handleConfirmStockModal}
-                  disabled={stockSaving}
-                  style={[
-                    styles.smallBtn,
-                    {
-                      borderColor: colors.accent,
-                      backgroundColor: stockSaving
-                        ? "rgba(255,255,255,0.08)"
-                        : "rgba(37,99,235,0.12)",
-                    },
-                    stockSaving && styles.smallBtnDisabled,
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    stockModalMode === "sell"
-                      ? productsCopy.stockModal.confirmSell
-                      : productsCopy.stockModal.confirmRestock
-                  }
-                >
-                  <Text style={{ color: colors.accent, fontWeight: "800" }}>
-                    {stockSaving
-                      ? productFormCopy.buttons.saving
-                      : stockModalMode === "sell"
-                        ? productsCopy.stockModal.confirmSell
-                        : productsCopy.stockModal.confirmRestock}
-                  </Text>
-                </Pressable>
-              </View>
-            </View>
-          </View>
-        </Modal>
-      </>
+      renderProducts
+        ? renderProducts({
+            isCompactLayout,
+            colors,
+            styles,
+            productsCopy,
+            productsLoading,
+            loadProducts,
+            handleOpenCreateProduct,
+            productFormVisible,
+            productFormMode,
+            productBeingEdited,
+            handleProductCreated,
+            handleProductUpdated,
+            handleProductFormClose,
+            productFormCopy,
+            localizedProducts,
+            productMap,
+            resolvedTheme,
+            handleOpenSellProduct,
+            handleOpenRestockProduct,
+            handleOpenEditProduct,
+            handleDeleteProduct,
+            stockModalProduct,
+            stockModalDisplayProduct,
+            stockModalMode,
+            stockQuantityText,
+            handleStockQuantityChange,
+            handleCloseStockModal,
+            handleConfirmStockModal,
+            stockSaving,
+          })
+        : null
     ) : activeScreen === "packages" ? (
       <ScrollView
         style={{ flex: 1 }}
@@ -4581,104 +4353,28 @@ function AuthenticatedApp({
           })
         : null
     ) : activeScreen === "services" ? (
-      <ScrollView
-        style={{ flex: 1 }}
-        contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}
-        refreshControl={<RefreshControl refreshing={servicesLoading} onRefresh={loadServices} />}
-      >
-        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-          <View style={[styles.listHeaderRow, isCompactLayout && styles.listHeaderRowCompact]}>
-            <View style={{ flex: 1, gap: 4 }}>
-              <Text style={[styles.title, { color: colors.text }]}>{copy.servicesPage.title}</Text>
-              <Text style={{ color: colors.subtext, fontSize: 13, fontWeight: "600" }}>
-                {copy.servicesPage.subtitle}
-              </Text>
-            </View>
-            <Pressable
-              onPress={handleOpenCreateService}
-              style={[styles.defaultCta, { marginTop: 0 }, isCompactLayout && styles.fullWidthButton]}
-              accessibilityRole="button"
-              accessibilityLabel={copy.servicesPage.createCta.accessibility}
-            >
-              <Text style={styles.defaultCtaText}>{copy.servicesPage.createCta.label}</Text>
-            </Pressable>
-          </View>
-        </View>
-
-        {serviceFormVisible ? (
-          <ServiceForm
-            mode={serviceFormMode}
-            service={serviceFormMode === "edit" ? serviceBeingEdited : null}
-            onCreated={handleServiceCreated}
-            onUpdated={handleServiceUpdated}
-            onCancel={handleServiceFormClose}
-            colors={{
-              text: colors.text,
-              subtext: colors.subtext,
-              border: colors.border,
-              surface: colors.surface,
-              accent: colors.accent,
-              accentFgOn: colors.accentFgOn,
-              danger: colors.danger,
-            }}
-            copy={copy.serviceForm}
-          />
-        ) : null}
-
-        <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface, gap: 12 }]}>
-          <Text style={[styles.title, { color: colors.text }]}>{copy.servicesPage.listTitle}</Text>
-          {services.length === 0 ? (
-            <Text style={[styles.empty, { marginVertical: 8 }]}>{copy.servicesPage.empty}</Text>
-          ) : (
-            services.map((svc) => {
-              const localized = localizedServiceMap.get(svc.id) ?? svc;
-              return (
-                <View key={svc.id} style={styles.serviceRow}>
-                  <View
-                    style={{ flexDirection: "row", alignItems: "center", gap: 10, flex: 1, flexWrap: "wrap" }}
-                  >
-                    <MaterialCommunityIcons name={svc.icon} size={22} color={colors.accent} />
-                    <View>
-                      <Text style={{ color: colors.text, fontWeight: "800" }}>{localized.name}</Text>
-                      <Text style={{ color: colors.subtext, fontSize: 12 }}>
-                        {copy.servicesPage.serviceMeta(svc.estimated_minutes, formatPrice(svc.price_cents))}
-                      </Text>
-                    </View>
-                  </View>
-                  <View style={styles.serviceActions}>
-                    <Pressable
-                      onPress={() => handleOpenEditService(svc)}
-                      style={[styles.smallBtn, { borderColor: colors.border }]}
-                      accessibilityRole="button"
-                      accessibilityLabel={copy.servicesPage.actions.edit.accessibility(localized.name)}
-                    >
-                      <Text style={{ color: colors.subtext, fontWeight: "800" }}>
-                        {copy.servicesPage.actions.edit.label}
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => handleDeleteService(svc)}
-                      style={[
-                        styles.smallBtn,
-                        {
-                          borderColor: colors.danger,
-                          backgroundColor: "rgba(239,68,68,0.1)",
-                        },
-                      ]}
-                      accessibilityRole="button"
-                      accessibilityLabel={copy.servicesPage.actions.delete.accessibility(localized.name)}
-                    >
-                      <Text style={{ color: colors.danger, fontWeight: "800" }}>
-                        {copy.servicesPage.actions.delete.label}
-                      </Text>
-                    </Pressable>
-                  </View>
-                </View>
-              );
-            })
-          )}
-        </View>
-      </ScrollView>
+      renderServices
+        ? renderServices({
+            isCompactLayout,
+            colors,
+            styles,
+            servicesCopy,
+            servicesLoading,
+            loadServices,
+            handleOpenCreateService,
+            serviceFormVisible,
+            serviceFormMode,
+            serviceBeingEdited,
+            handleServiceCreated,
+            handleServiceUpdated,
+            handleServiceFormClose,
+            serviceFormCopy,
+            services,
+            localizedServiceMap,
+            handleOpenEditService,
+            handleDeleteService,
+          })
+        : null
     ) : activeScreen === "assistant" ? (
       <AssistantChat
         colors={{


### PR DESCRIPTION
## Summary
- move the products experience into `app/products.tsx` with a dedicated renderer
- move the services experience into `app/services.tsx` with a dedicated renderer
- teach `AuthenticatedApp` to accept the new renderers and wire them through every entry screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f97fe3572883278a07a5b2822037a6