### PR TITLE
chore: remove unused code and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@supabase/supabase-js": "^2.75.0",
         "expo": "~54.0.13",
         "expo-localization": "~17.0.7",
-        "expo-status-bar": "~3.0.8",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
@@ -5855,19 +5854,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
-      }
-    },
-    "node_modules/expo-status-bar": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-3.0.8.tgz",
-      "integrity": "sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-native-is-edge-to-edge": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@expo/metro-runtime": "~5.0.4",
     "@supabase/supabase-js": "^2.75.0",
     "expo": "~54.0.13",
-    "expo-status-bar": "~3.0.8",
     "expo-localization": "~17.0.7",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/src/lib/activeBarbershop.ts
+++ b/src/lib/activeBarbershop.ts
@@ -97,11 +97,6 @@ export async function requireCurrentBarbershopId(options?: { refresh?: boolean }
   return id;
 }
 
-export function setCurrentBarbershopId(id: string | null): void {
-  cachedBarbershopId = id;
-  hasResolvedBarbershopId = true;
-}
-
 export function clearCurrentBarbershopCache(): void {
   cachedBarbershopId = null;
   hasResolvedBarbershopId = false;

--- a/src/lib/cashRegister.ts
+++ b/src/lib/cashRegister.ts
@@ -278,7 +278,3 @@ export function summarizeCashEntries(entries: CashEntry[]): CashRegisterSummary 
     { total_cents: 0, service_sales_cents: 0, product_sales_cents: 0, adjustments_cents: 0 },
   );
 }
-
-export function __resetMemoryCashRegister() {
-  memoryEntries = [];
-}

--- a/src/lib/polyglot.ts
+++ b/src/lib/polyglot.ts
@@ -107,13 +107,6 @@ function lookupServiceTranslation(
   return null;
 }
 
-export function polyglotServiceName(
-  service: Pick<Service, "id" | "name">,
-  language: LanguageCode,
-): string {
-  return lookupServiceTranslation(service, language) ?? service.name;
-}
-
 export function polyglotServices(services: Service[], language: LanguageCode): Service[] {
   if (language === "en") return services;
 


### PR DESCRIPTION
## Summary
- remove the unused `expo-status-bar` dependency and sync the lockfile
- drop unused helper exports from the barbershop cache, cash register, and polyglot modules

## Testing
- `npm run test` *(fails: missing tslib dependency in supabase packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f985cbbbe48327ac8f7752fb042d8d