### PR TITLE
Add collapsible left navigation for new barbershop content pages

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,146 @@
-import React from "react";
-import { Slot } from "expo-router";
+import React, { useMemo, useState } from "react";
+import { Slot, Link, usePathname } from "expo-router";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { AuthGate } from "../src/components/AuthGate";
 
+type NavigationItem = {
+  href: string;
+  label: string;
+};
+
+const NAVIGATION_ITEMS: NavigationItem[] = [
+  {
+    href: "/barbershop-online-products",
+    label: "Barbershop online products",
+  },
+  {
+    href: "/barbershop-news",
+    label: "Barbershop news",
+  },
+];
+
 export default function RootLayout(): React.ReactElement {
+  const pathname = usePathname();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const items = useMemo(
+    () =>
+      NAVIGATION_ITEMS.map((item) => ({
+        ...item,
+        isActive:
+          pathname === item.href ||
+          (!!pathname && pathname.startsWith(`${item.href}/`)),
+      })),
+    [pathname],
+  );
+
   return (
     <AuthGate>
-      <Slot />
+      <View style={styles.container}>
+        <View style={[styles.sidebar, isCollapsed && styles.sidebarCollapsed]}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              isCollapsed ? "Open auxiliary navigation menu" : "Close auxiliary navigation menu"
+            }
+            onPress={() => setIsCollapsed((prev) => !prev)}
+            style={styles.toggleButton}
+          >
+            <Text style={styles.toggleButtonText}>{
+              isCollapsed ? "☰" : "⨯"
+            }</Text>
+          </Pressable>
+          {!isCollapsed && (
+            <View style={styles.navigationContainer}>
+              <Text style={styles.navigationHeader}>Explore</Text>
+              {items.map((item) => (
+                <Link key={item.href} href={item.href} asChild>
+                  <Pressable
+                    accessibilityRole="button"
+                    style={[styles.navigationItem, item.isActive && styles.navigationItemActive]}
+                  >
+                    <Text
+                      style={[styles.navigationText, item.isActive && styles.navigationTextActive]}
+                    >
+                      {item.label}
+                    </Text>
+                  </Pressable>
+                </Link>
+              ))}
+            </View>
+          )}
+        </View>
+        <View style={styles.content}>
+          <Slot />
+        </View>
+      </View>
     </AuthGate>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: "row",
+    backgroundColor: "#f6f6f6",
+  },
+  sidebar: {
+    width: 260,
+    backgroundColor: "#ffffff",
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: "#e0e0e0",
+    paddingTop: 16,
+    paddingHorizontal: 12,
+  },
+  sidebarCollapsed: {
+    width: 54,
+    paddingHorizontal: 0,
+    alignItems: "center",
+  },
+  toggleButton: {
+    alignSelf: "flex-end",
+    borderRadius: 20,
+    height: 36,
+    width: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#f0f0f0",
+  },
+  toggleButtonText: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  navigationContainer: {
+    marginTop: 24,
+  },
+  navigationHeader: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#555555",
+    marginBottom: 8,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  navigationItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    marginBottom: 8,
+  },
+  navigationItemActive: {
+    backgroundColor: "#0a7cff10",
+  },
+  navigationText: {
+    fontSize: 15,
+    color: "#222222",
+  },
+  navigationTextActive: {
+    fontWeight: "600",
+    color: "#0a7cff",
+  },
+  content: {
+    flex: 1,
+    backgroundColor: "#ffffff",
+  },
+});

--- a/app/barbershop-news.tsx
+++ b/app/barbershop-news.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+export default function BarbershopNews(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Barbershop news</Text>
+        <Text style={styles.description}>
+          Share updates, campaigns, and announcements with your customers. This
+          screen prepares the experience for future content tools that will live
+          in the revamped navigation structure.
+        </Text>
+        <Text style={styles.helper}>
+          Use this area to plan how news posts will integrate with the rest of
+          the dashboard once the migration is complete.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 24,
+    backgroundColor: "#f5f7fa",
+  },
+  card: {
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 16,
+    color: "#374151",
+    lineHeight: 24,
+    marginBottom: 8,
+  },
+  helper: {
+    fontSize: 14,
+    color: "#6b7280",
+    marginTop: 8,
+  },
+});

--- a/app/barbershop-online-products.tsx
+++ b/app/barbershop-online-products.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+export default function BarbershopOnlineProducts(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Barbershop online products</Text>
+        <Text style={styles.description}>
+          Organize the catalog that will appear in the online experience of your
+          barbershop. This is a placeholder space for upcoming product management
+          tools that will live in the new navigation menu.
+        </Text>
+        <Text style={styles.helper}>
+          We will migrate additional controls to this page as part of the
+          refactoring roadmap.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 24,
+    backgroundColor: "#f5f7fa",
+  },
+  card: {
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 16,
+    color: "#374151",
+    lineHeight: 24,
+    marginBottom: 8,
+  },
+  helper: {
+    fontSize: 14,
+    color: "#6b7280",
+    marginTop: 8,
+  },
+});


### PR DESCRIPTION
## Summary
- add a collapsible left-hand navigation layout that wraps the authenticated app and surfaces links managed by Expo Router
- include new placeholder pages for barbershop online products and barbershop news to populate the menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa5395ebd883279ca503b0d5fc5258