### PR TITLE
Add collapsible dashboard navigation and placeholder pages

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { Slot } from "expo-router";
 
 import { AuthGate } from "../src/components/AuthGate";
+import { DashboardLayout } from "../src/components/layout/DashboardLayout";
 
 export default function RootLayout(): React.ReactElement {
   return (
     <AuthGate>
-      <Slot />
+      <DashboardLayout>
+        <Slot />
+      </DashboardLayout>
     </AuthGate>
   );
 }

--- a/app/barbershop-news.tsx
+++ b/app/barbershop-news.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View, useColorScheme } from "react-native";
+
+export default function BarbershopNews(): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const backgroundColor = isDark ? "#0f0f0f" : "#f4f4f5";
+
+  return (
+    <ScrollView
+      style={{ backgroundColor }}
+      contentContainerStyle={[styles.container, { backgroundColor }]}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: isDark ? "#f4f4f5" : "#18181b" }]}>Barbershop news</Text>
+        <Text style={[styles.subtitle, { color: isDark ? "#a1a1aa" : "#3f3f46" }]}>
+          Keep your staff and customers informed with curated updates about the barbershop and the
+          broader grooming industry.
+        </Text>
+      </View>
+      <View
+        style={[
+          styles.body,
+          {
+            backgroundColor: isDark ? "#18181b" : "#ffffff",
+            shadowOpacity: isDark ? 0 : 0.05,
+            borderWidth: isDark ? StyleSheet.hairlineWidth : 0,
+            borderColor: isDark ? "#27272a" : "transparent",
+          },
+        ]}
+      >
+        <Text style={[styles.bodyText, { color: isDark ? "#e4e4e7" : "#27272a" }]}>
+          We are designing a newsroom experience where you will be able to publish announcements,
+          create promotional campaigns, and highlight industry insights. These tools will integrate
+          with customer communications and in-store signage.
+        </Text>
+        <Text style={[styles.bodyText, { color: isDark ? "#e4e4e7" : "#27272a" }]}>
+          Until this space is ready, announcements can continue to be shared through your existing
+          communication channels.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    paddingHorizontal: 32,
+    paddingVertical: 40,
+    gap: 24,
+  },
+  header: {
+    gap: 12,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "700",
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  body: {
+    gap: 16,
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  bodyText: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/app/barbershop-online-products.tsx
+++ b/app/barbershop-online-products.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View, useColorScheme } from "react-native";
+
+export default function BarbershopOnlineProducts(): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+
+  const backgroundColor = isDark ? "#0f0f0f" : "#f4f4f5";
+
+  return (
+    <ScrollView
+      style={{ backgroundColor }}
+      contentContainerStyle={[styles.container, { backgroundColor }]}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: isDark ? "#f4f4f5" : "#18181b" }]}>Barbershop online products</Text>
+        <Text style={[styles.subtitle, { color: isDark ? "#a1a1aa" : "#3f3f46" }]}>
+          Centralize the catalog that will be available for online purchases and synchronize it
+          with your in-store inventory.
+        </Text>
+      </View>
+      <View
+        style={[
+          styles.body,
+          {
+            backgroundColor: isDark ? "#18181b" : "#ffffff",
+            shadowOpacity: isDark ? 0 : 0.05,
+            borderWidth: isDark ? StyleSheet.hairlineWidth : 0,
+            borderColor: isDark ? "#27272a" : "transparent",
+          },
+        ]}
+      >
+        <Text style={[styles.bodyText, { color: isDark ? "#e4e4e7" : "#27272a" }]}>
+          This area is under construction. Soon you will be able to manage highlighted products,
+          promotional bundles, and fulfillment integrations for your e-commerce channels.
+        </Text>
+        <Text style={[styles.bodyText, { color: isDark ? "#e4e4e7" : "#27272a" }]}>
+          For now, continue using the existing products section to manage inventory and pricing. We
+          will migrate those workflows here as part of the upcoming refactor.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    paddingHorizontal: 32,
+    paddingVertical: 40,
+    gap: 24,
+  },
+  header: {
+    gap: 12,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "700",
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  body: {
+    gap: 16,
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  bodyText: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { View, Text, Pressable, StyleSheet, useColorScheme, useWindowDimensions } from "react-native";
+import { Link, usePathname } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+
+const MENU_ITEMS = [
+  {
+    label: "Workspace",
+    href: "/",
+    icon: "grid-outline" as const,
+  },
+  {
+    label: "Barbershop online products",
+    href: "/barbershop-online-products",
+    icon: "cart-outline" as const,
+  },
+  {
+    label: "Barbershop news",
+    href: "/barbershop-news",
+    icon: "newspaper-outline" as const,
+  },
+];
+
+export type DashboardLayoutProps = {
+  children: React.ReactNode;
+};
+
+export function DashboardLayout({ children }: DashboardLayoutProps): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const { width } = useWindowDimensions();
+  const shouldAutoCollapse = width < 960;
+  const [isCollapsed, setIsCollapsed] = useState(shouldAutoCollapse);
+  const [hasManualOverride, setHasManualOverride] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!hasManualOverride) {
+      setIsCollapsed(shouldAutoCollapse);
+    }
+  }, [hasManualOverride, shouldAutoCollapse]);
+
+  const isNewRouteActive = useMemo(
+    () => MENU_ITEMS.some((item) => item.href !== "/" && pathname.startsWith(item.href)),
+    [pathname],
+  );
+
+  const menuItems = useMemo(
+    () =>
+      MENU_ITEMS.map((item) => {
+        const isActive =
+          item.href === "/" ? !isNewRouteActive : pathname.startsWith(item.href);
+
+        return {
+          ...item,
+          isActive,
+        };
+      }),
+    [isNewRouteActive, pathname],
+  );
+
+  const containerBackground = isDark ? "#0f0f0f" : "#f4f4f5";
+  const sidebarBackground = isDark ? "#1c1c1e" : "#ffffff";
+  const sidebarBorder = isDark ? "#27272a" : "#e4e4e7";
+  const iconColor = isDark ? "#f4f4f5" : "#18181b";
+  const activeItemBackground = isDark ? "#2c2c2e" : "#e4e4e7";
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: containerBackground },
+      ]}
+    >
+      <View
+        style={[
+          styles.sidebar,
+          { backgroundColor: sidebarBackground, borderRightColor: sidebarBorder },
+          isCollapsed && styles.sidebarCollapsed,
+        ]}
+      >
+        <View style={styles.menuHeader}>
+          {!isCollapsed && (
+            <Text style={[styles.menuTitle, { color: isDark ? "#f8f8f8" : "#18181b" }]}>Menu</Text>
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={isCollapsed ? "Expand navigation" : "Collapse navigation"}
+            onPress={() => {
+              setHasManualOverride(true);
+              setIsCollapsed((prev) => !prev);
+            }}
+            style={styles.toggleButton}
+          >
+            <Ionicons
+              name={isCollapsed ? "chevron-forward" : "chevron-back"}
+              size={20}
+              color={iconColor}
+            />
+          </Pressable>
+        </View>
+
+        <View style={styles.menuItems}>
+          {menuItems.map((item) => (
+            <Link key={item.href} href={item.href} asChild>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.menuItem,
+                  item.isActive && {
+                    backgroundColor: activeItemBackground,
+                  },
+                  pressed && {
+                    opacity: 0.7,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name={item.icon}
+                  size={20}
+                  color={iconColor}
+                />
+                {!isCollapsed && (
+                  <Text style={[styles.menuItemLabel, { color: iconColor }]}> 
+                    {item.label}
+                  </Text>
+                )}
+              </Pressable>
+            </Link>
+          ))}
+        </View>
+      </View>
+      <View style={[styles.content, { backgroundColor: containerBackground }]}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: "row",
+  },
+  sidebar: {
+    width: 260,
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: "transparent",
+    gap: 16,
+  },
+  sidebarCollapsed: {
+    width: 72,
+    paddingHorizontal: 8,
+  },
+  menuHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  menuTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  toggleButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  menuItems: {
+    gap: 8,
+  },
+  menuItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+  },
+  menuItemLabel: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  content: {
+    flex: 1,
+  },
+});
+
+export default DashboardLayout;


### PR DESCRIPTION
## Summary
- add a collapsible dashboard shell that wraps the router with a left-side navigation menu
- register placeholder routes for barbershop online products and barbershop news within the new menu
- ensure the layout and pages adapt to light/dark themes and keep existing workspace screens accessible

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fa56cd717c8327bea1e5d2950a8897