### PR TITLE
Add TanStack router experimental menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
     "@supabase/supabase-js": "^2.75.0",
+    "@tanstack/react-router": "^1.83.6",
     "expo": "~54.0.13",
     "expo-localization": "~17.0.7",
     "react": "19.0.0",

--- a/src/app/AuthenticatedApp.tsx
+++ b/src/app/AuthenticatedApp.tsx
@@ -98,6 +98,7 @@ import ServicePackageForm from "../components/ServicePackageForm";
 import FilterToggle from "../components/FilterToggle";
 import DateTimeInput from "../components/DateTimeInput";
 import { DonutChart } from "../components/DonutChart";
+import { RefactorRouterPanel } from "../components/refactor/RefactorRouterPanel";
 
 /* Novo: formulário de usuário (com date_of_birth e salvando no Supabase) */
 import UserForm from "../components/UserForm";
@@ -1330,7 +1331,7 @@ const LANGUAGE_OPTIONS: { code: SupportedLanguage; label: string }[] = [
 type ThemeName = "dark" | "light";
 type ThemePreference = "system" | ThemeName;
 
-type ThemeColors = {
+export type ThemeColors = {
   bg: string;
   surface: string;
   sidebarBg: string;
@@ -3728,7 +3729,9 @@ function AuthenticatedApp({
   }, [colors.bg]);
 
   return (
-    <View style={[styles.appShell, { backgroundColor: colors.bg }]}>
+    <View style={[styles.appContainer, { backgroundColor: colors.bg }]}> 
+      <RefactorRouterPanel colors={colors} />
+      <View style={[styles.appShell, { backgroundColor: colors.bg }]}> 
       {!sidebarOpen && (
         <Pressable
           onPress={() => setSidebarOpen(true)}
@@ -5668,6 +5671,7 @@ const SHADOW = Platform.select({
 });
 
 const createStyles = (colors: ThemeColors) => StyleSheet.create({
+  appContainer: { flex: 1, flexDirection: "row" },
   appShell: { flex: 1 },
   menuFab: {
     position: "absolute",

--- a/src/app/refactor/BarbershopNewsScreen.tsx
+++ b/src/app/refactor/BarbershopNewsScreen.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Text, View, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import { useRefactorMenuContext } from "../../components/refactor/RefactorMenuContext";
+
+export function BarbershopNewsScreen(): React.ReactElement {
+  const { colors } = useRefactorMenuContext();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.border }]}> 
+      <View style={[styles.header, { borderBottomColor: colors.border }]}> 
+        <Ionicons name="megaphone-outline" size={20} color={colors.accent} />
+        <Text style={[styles.title, { color: colors.text }]}>Barbershop news</Text>
+      </View>
+      <Text style={[styles.paragraph, { color: colors.subtext }]}> 
+        Centralize communications about product updates, marketing pushes, and local community events. The collapsible layout
+        ensures the newsroom stays accessible without overwhelming stylists focused on daily tasks.
+      </Text>
+      <Text style={[styles.paragraph, { color: colors.subtext }]}> 
+        Future iterations can subscribe to Supabase feeds or CMS entries. TanStack Router keeps these explorations scoped so we can
+        ship improvements incrementally.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingBottom: 8,
+    marginBottom: 4,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  paragraph: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/src/app/refactor/BarbershopOnlineProductsScreen.tsx
+++ b/src/app/refactor/BarbershopOnlineProductsScreen.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Text, View, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import { useRefactorMenuContext } from "../../components/refactor/RefactorMenuContext";
+
+export function BarbershopOnlineProductsScreen(): React.ReactElement {
+  const { colors } = useRefactorMenuContext();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.border }]}> 
+      <View style={[styles.header, { borderBottomColor: colors.border }]}> 
+        <Ionicons name="bag-handle-outline" size={20} color={colors.accent} />
+        <Text style={[styles.title, { color: colors.text }]}>Barbershop online products</Text>
+      </View>
+      <Text style={[styles.paragraph, { color: colors.subtext }]}> 
+        Showcase curated inventory and launch targeted campaigns for your digital storefront. This new section is powered by
+        TanStack Router so we can migrate existing commerce flows gradually without disrupting the current dashboard.
+      </Text>
+      <Text style={[styles.paragraph, { color: colors.subtext }]}> 
+        Start planning the content architecture for subscriptions, featured bundles, and seasonal highlights. The router keeps
+        navigation isolated, allowing the team to iterate on this experiment safely.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingBottom: 8,
+    marginBottom: 4,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  paragraph: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/src/app/refactor/RefactorWelcomeScreen.tsx
+++ b/src/app/refactor/RefactorWelcomeScreen.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { useRefactorMenuContext } from "../../components/refactor/RefactorMenuContext";
+
+export function RefactorWelcomeScreen(): React.ReactElement {
+  const { colors } = useRefactorMenuContext();
+
+  return (
+    <View style={[styles.container, { borderColor: colors.border, backgroundColor: colors.surface }]}> 
+      <Text style={[styles.title, { color: colors.text }]}>Select an experimental page</Text>
+      <Text style={[styles.description, { color: colors.subtext }]}> 
+        Use the collapsible menu to preview new experiences we are building with TanStack Router. This area will host the
+        refactored navigation as existing screens migrate over time.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/src/components/refactor/RefactorMenuContext.tsx
+++ b/src/components/refactor/RefactorMenuContext.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import type { ThemeColors } from "../../app/AuthenticatedApp";
+
+export type RefactorMenuContextValue = {
+  colors: ThemeColors;
+  collapsed: boolean;
+  expand: () => void;
+  collapse: () => void;
+  toggle: () => void;
+  dimensions: {
+    collapsed: number;
+    expanded: number;
+  };
+};
+
+export const RefactorMenuContext = React.createContext<RefactorMenuContextValue | undefined>(undefined);
+
+export function useRefactorMenuContext(): RefactorMenuContextValue {
+  const context = React.useContext(RefactorMenuContext);
+  if (!context) {
+    throw new Error("useRefactorMenuContext must be used within a RefactorMenuContext provider");
+  }
+  return context;
+}

--- a/src/components/refactor/RefactorRouterPanel.tsx
+++ b/src/components/refactor/RefactorRouterPanel.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { StyleSheet, Text, View, Pressable, useWindowDimensions, ScrollView } from "react-native";
+import { createMemoryHistory, createRootRouteWithContext, createRoute, createRouter, Outlet, RouterProvider, useRouter, useRouterState } from "@tanstack/react-router";
+import { Ionicons } from "@expo/vector-icons";
+
+import type { ThemeColors } from "../../app/AuthenticatedApp";
+import { RefactorMenuContext, type RefactorMenuContextValue, useRefactorMenuContext } from "./RefactorMenuContext";
+import { BarbershopOnlineProductsScreen } from "../../app/refactor/BarbershopOnlineProductsScreen";
+import { BarbershopNewsScreen } from "../../app/refactor/BarbershopNewsScreen";
+import { RefactorWelcomeScreen } from "../../app/refactor/RefactorWelcomeScreen";
+
+const rootRoute = createRootRouteWithContext<RefactorMenuContextValue>()({
+  component: RefactorMenuLayout,
+});
+
+const onlineProductsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/online-products",
+  component: BarbershopOnlineProductsScreen,
+});
+
+const newsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/news",
+  component: BarbershopNewsScreen,
+});
+
+const welcomeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: RefactorWelcomeScreen,
+});
+
+const routeTree = rootRoute.addChildren([welcomeRoute, onlineProductsRoute, newsRoute]);
+
+function createRefactorRouter() {
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory(),
+    defaultPreload: "intent",
+  });
+}
+
+type RefactorRouterPanelProps = {
+  colors: ThemeColors;
+};
+
+export function RefactorRouterPanel({ colors }: RefactorRouterPanelProps): React.ReactElement {
+  const { width: windowWidth } = useWindowDimensions();
+  const collapsedWidth = 64;
+  const expandedWidth = useMemo(() => {
+    const preferred = Math.max(280, Math.min(360, windowWidth * 0.35));
+    return Number.isFinite(preferred) ? preferred : 280;
+  }, [windowWidth]);
+
+  const [collapsed, setCollapsed] = useState(true);
+  const toggle = useCallback(() => setCollapsed((prev) => !prev), []);
+  const expand = useCallback(() => setCollapsed(false), []);
+  const collapse = useCallback(() => setCollapsed(true), []);
+
+  const [router] = useState(() => createRefactorRouter());
+
+  const contextValue = useMemo<RefactorMenuContextValue>(
+    () => ({ colors, collapsed, expand, collapse, toggle, dimensions: { collapsed: collapsedWidth, expanded: expandedWidth } }),
+    [colors, collapsed, expand, collapse, toggle, collapsedWidth, expandedWidth],
+  );
+
+  useEffect(() => {
+    router.update({ context: contextValue });
+  }, [router, contextValue]);
+
+  return (
+    <RefactorMenuContext.Provider value={contextValue}>
+      <View
+        style={{
+          width: collapsed ? collapsedWidth : expandedWidth,
+          backgroundColor: colors.sidebarBg,
+          alignSelf: "stretch",
+        }}
+      >
+        <RouterProvider router={router} />
+      </View>
+    </RefactorMenuContext.Provider>
+  );
+}
+
+type MenuItem = {
+  path: string;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+};
+
+const MENU_ITEMS: MenuItem[] = [
+  { path: "/online-products", label: "Barbershop online products", icon: "cart-outline" },
+  { path: "/news", label: "Barbershop news", icon: "newspaper-outline" },
+];
+
+function RefactorMenuLayout(): React.ReactElement {
+  const { colors, collapsed, toggle, expand, collapse, dimensions } = useRefactorMenuContext();
+  const router = useRouter();
+  const { location } = useRouterState({ select: (state) => ({ location: state.location }) });
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      router.navigate({ to: path });
+      expand();
+    },
+    [router, expand],
+  );
+
+  const activePath = location.pathname;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          width: collapsed ? dimensions.collapsed : dimensions.expanded,
+          borderRightColor: colors.border,
+          backgroundColor: colors.sidebarBg,
+        },
+      ]}
+    >
+      <View style={[styles.header, { borderBottomColor: colors.border }]}> 
+        <Pressable
+          onPress={toggle}
+          style={[styles.toggleButton, { borderColor: colors.border, backgroundColor: colors.surface }]}
+          accessibilityRole="button"
+          accessibilityLabel={collapsed ? "Expand experimental menu" : "Collapse experimental menu"}
+        >
+          <Ionicons
+            name={collapsed ? "chevron-forward" : "chevron-back"}
+            size={18}
+            color={colors.subtext}
+          />
+        </Pressable>
+        {!collapsed ? (
+          <View style={styles.titleArea}>
+            <Ionicons name="construct-outline" size={18} color={colors.subtext} />
+            <Text style={[styles.title, { color: colors.subtext }]}>Labs</Text>
+          </View>
+        ) : null}
+      </View>
+
+      <View style={styles.menuList}>
+        {MENU_ITEMS.map((item) => {
+          const isActive = activePath === item.path;
+          return (
+            <Pressable
+              key={item.path}
+              onPress={() => handleNavigate(item.path)}
+              style={[
+                styles.menuItem,
+                {
+                  backgroundColor: isActive ? colors.accent : "transparent",
+                  borderColor: isActive ? colors.accent : "transparent",
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${item.label}`}
+            >
+              <Ionicons
+                name={item.icon}
+                size={18}
+                color={isActive ? colors.accentFgOn : colors.subtext}
+              />
+              {!collapsed ? (
+                <Text
+                  style={[
+                    styles.menuItemLabel,
+                    { color: isActive ? colors.accentFgOn : colors.subtext },
+                  ]}
+                >
+                  {item.label}
+                </Text>
+              ) : null}
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {!collapsed ? (
+        <ScrollView
+          style={[styles.contentArea, { borderTopColor: colors.border, backgroundColor: colors.surface }]}
+          contentContainerStyle={{ padding: 16 }}
+        >
+          <Outlet />
+        </ScrollView>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 0,
+    alignSelf: "stretch",
+    borderRightWidth: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderBottomWidth: 1,
+  },
+  toggleButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  titleArea: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  title: {
+    fontWeight: "700",
+    fontSize: 14,
+    letterSpacing: 0.2,
+  },
+  menuList: {
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  menuItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    borderWidth: 1,
+  },
+  menuItemLabel: {
+    fontWeight: "700",
+    fontSize: 13,
+  },
+  contentArea: {
+    flex: 1,
+    borderTopWidth: 1,
+  },
+});
+
+export type RefactorRouter = ReturnType<typeof createRefactorRouter>;
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: RefactorRouter;
+  }
+}


### PR DESCRIPTION
## Summary
- add a TanStack Router powered "Labs" panel that coexists with the current dashboard layout
- create collapsible navigation entries for the new barbershop online products and news placeholder screens
- expose shared menu context and styles so future pages can migrate into the experimental router safely

## Testing
- npm install *(fails: registry returned 403 for @tanstack/react-router in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5b4c369483278d1a41f824f3eb5c