### PR TITLE
Add collapsible TanStack menu and initial routed pages

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,19 +1,7 @@
 import React from "react";
 
-import AuthenticatedApp from "../src/app/AuthenticatedApp";
-import { cashRegisterRenderer } from "./cash-register";
-import { bookingsRenderer } from "./bookings";
-import { productsRenderer } from "./products";
-import { servicesRenderer } from "./services";
+import { TanstackAppRouterProvider } from "../src/router/tanstack/router";
 
 export default function Index(): React.ReactElement {
-  return (
-    <AuthenticatedApp
-      initialScreen="home"
-      renderBookings={bookingsRenderer}
-      renderCashRegister={cashRegisterRenderer}
-      renderProducts={productsRenderer}
-      renderServices={servicesRenderer}
-    />
-  );
+  return <TanstackAppRouterProvider />;
 }

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,7 @@ config.resolver = config.resolver || {};
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
   "expo-router": path.resolve(projectRoot, "src/router/expo-router"),
+  "@tanstack/react-router": path.resolve(projectRoot, "src/router/tanstack"),
 };
 
 module.exports = config;

--- a/src/app/routes/BarbershopNewsRoute.tsx
+++ b/src/app/routes/BarbershopNewsRoute.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+const NEWS_ITEMS = [
+  {
+    id: "ai-consults",
+    headline: "AI consultations expanding",
+    body:
+      "Soon, stylists will be able to launch AI-driven consultations that pull customer history and preferences into each booking.",
+  },
+  {
+    id: "inventory-sync",
+    headline: "Inventory sync beta",
+    body:
+      "The inventory team is integrating supplier feeds so online sales and in-shop stock always match in real time.",
+  },
+  {
+    id: "community",
+    headline: "Community spotlight",
+    body:
+      "Share barbershop stories from around the world. The newsroom will surface top stories directly inside the dashboard.",
+  },
+];
+
+export function BarbershopNewsRoute(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.hero}>
+        <Text style={styles.heroEyebrow}>What's new</Text>
+        <Text style={styles.heroTitle}>Barbershop news</Text>
+        <Text style={styles.heroSubtitle}>
+          Track product releases, platform updates, and community highlights without leaving the workspace.
+        </Text>
+      </View>
+      <View style={styles.newsList}>
+        {NEWS_ITEMS.map((item) => (
+          <View key={item.id} style={styles.newsCard}>
+            <Text style={styles.newsHeadline}>{item.headline}</Text>
+            <Text style={styles.newsBody}>{item.body}</Text>
+          </View>
+        ))}
+      </View>
+      <View style={styles.footer}>
+        <Text style={styles.footerHeading}>Stay tuned</Text>
+        <Text style={styles.footerCopy}>
+          This lightweight newsroom lives inside the TanStack router space. We'll gradually migrate the legacy
+          dashboard panels here as the refactor evolves.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 32,
+    gap: 28,
+    backgroundColor: "#0f172a",
+  },
+  hero: {
+    gap: 10,
+  },
+  heroEyebrow: {
+    color: "#38bdf8",
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1.5,
+  },
+  heroTitle: {
+    fontSize: 30,
+    fontWeight: "800",
+    color: "#f8fafc",
+  },
+  heroSubtitle: {
+    color: "#cbd5f5",
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  newsList: {
+    gap: 16,
+  },
+  newsCard: {
+    backgroundColor: "#111c36",
+    padding: 20,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#1d2845",
+    gap: 8,
+  },
+  newsHeadline: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#f1f5f9",
+  },
+  newsBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#cbd5f5",
+  },
+  footer: {
+    backgroundColor: "#0b1120",
+    borderRadius: 16,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#1d2845",
+    gap: 8,
+  },
+  footerHeading: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#f8fafc",
+  },
+  footerCopy: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#cbd5f5",
+  },
+});
+
+export default BarbershopNewsRoute;

--- a/src/app/routes/BarbershopOnlineProductsRoute.tsx
+++ b/src/app/routes/BarbershopOnlineProductsRoute.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+const FEATURED_PRODUCTS = [
+  {
+    id: "kits",
+    title: "Curated grooming kits",
+    description:
+      "Bundle clippers, styling products, and aftercare essentials to create irresistible online offers.",
+  },
+  {
+    id: "subscriptions",
+    title: "Subscription refills",
+    description:
+      "Automate recurring deliveries for beard oil, shampoo, and pomades so loyal clients never run out.",
+  },
+  {
+    id: "limited",
+    title: "Limited seasonal drops",
+    description:
+      "Highlight exclusive drops to create urgency and keep the digital storefront feeling fresh.",
+  },
+];
+
+export function BarbershopOnlineProductsRoute(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Barbershop online products</Text>
+        <Text style={styles.subtitle}>
+          Craft the upcoming e-commerce experience. Curate product bundles, subscriptions, and highlight
+          promotions while we prepare the full migration to the new router.
+        </Text>
+      </View>
+      <View style={styles.cardGrid}>
+        {FEATURED_PRODUCTS.map((product) => (
+          <View key={product.id} style={styles.card}>
+            <Text style={styles.cardTitle}>{product.title}</Text>
+            <Text style={styles.cardDescription}>{product.description}</Text>
+          </View>
+        ))}
+      </View>
+      <View style={styles.footer}>
+        <Text style={styles.footerTitle}>Coming up next</Text>
+        <Text style={styles.footerDescription}>
+          This page will soon connect to live catalog data and checkout flows. The new TanStack router layout
+          keeps it side-by-side with the current dashboard, easing the upcoming refactor.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 32,
+    gap: 32,
+    backgroundColor: "#0b1120",
+  },
+  header: {
+    gap: 12,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: "#f8fafc",
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+    color: "#cbd5f5",
+  },
+  cardGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 20,
+  },
+  card: {
+    flexBasis: "45%",
+    minWidth: 240,
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 12,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#f1f5f9",
+  },
+  cardDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#cbd5f5",
+  },
+  footer: {
+    gap: 8,
+    padding: 20,
+    borderRadius: 12,
+    backgroundColor: "#111827",
+    borderWidth: 1,
+    borderColor: "#1f2937",
+  },
+  footerTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#f8fafc",
+  },
+  footerDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#cbd5f5",
+  },
+});
+
+export default BarbershopOnlineProductsRoute;

--- a/src/app/routes/LegacyDashboardRoute.tsx
+++ b/src/app/routes/LegacyDashboardRoute.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import AuthenticatedApp from "../AuthenticatedApp";
+import { bookingsRenderer } from "../../../app/bookings";
+import { cashRegisterRenderer } from "../../../app/cash-register";
+import { productsRenderer } from "../../../app/products";
+import { servicesRenderer } from "../../../app/services";
+
+export function LegacyDashboardRoute(): React.ReactElement {
+  return (
+    <AuthenticatedApp
+      initialScreen="home"
+      renderBookings={bookingsRenderer}
+      renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
+    />
+  );
+}
+
+export default LegacyDashboardRoute;

--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
+
+const MENU_WIDTH = 248;
+const MENU_WIDTH_COLLAPSED = 68;
+
+type MenuItem = {
+  key: string;
+  label: string;
+  to: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  description: string;
+};
+
+const MENU_ITEMS: MenuItem[] = [
+  {
+    key: "legacy",
+    label: "Legacy dashboard",
+    to: "/",
+    icon: "grid-outline",
+    description: "Keep working with the current scheduling tools.",
+  },
+  {
+    key: "online-products",
+    label: "Barbershop online products",
+    to: "/online-products",
+    icon: "cart-outline",
+    description: "Draft the future e-commerce experience.",
+  },
+  {
+    key: "news",
+    label: "Barbershop news",
+    to: "/news",
+    icon: "newspaper-outline",
+    description: "Read about fresh platform updates and stories.",
+  },
+];
+
+export function TanstackNavigationLayout(): React.ReactElement {
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  const handleNavigate = React.useCallback(
+    (item: MenuItem) => {
+      navigate({ to: item.to });
+    },
+    [navigate],
+  );
+
+  return (
+    <View style={styles.root}>
+      <View
+        style={[
+          styles.sidebar,
+          { width: collapsed ? MENU_WIDTH_COLLAPSED : MENU_WIDTH },
+        ]}
+      >
+        <Pressable
+          onPress={() => setCollapsed((current) => !current)}
+          style={({ pressed }) => [
+            styles.toggle,
+            pressed && styles.togglePressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={collapsed ? "Expand tanstack navigation" : "Collapse tanstack navigation"}
+        >
+          <Ionicons
+            name={collapsed ? "chevron-forward" : "chevron-back"}
+            size={18}
+            color="#f8fafc"
+          />
+        </Pressable>
+        <View style={styles.menuContainer}>
+          {MENU_ITEMS.map((item) => {
+            const active = pathname === item.to;
+            return (
+              <Pressable
+                key={item.key}
+                onPress={() => handleNavigate(item)}
+                style={({ pressed }) => [
+                  styles.menuItem,
+                  active && styles.menuItemActive,
+                  pressed && !active && styles.menuItemPressed,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={item.label}
+              >
+                <Ionicons
+                  name={item.icon}
+                  size={20}
+                  color={active ? "#38bdf8" : "#cbd5f5"}
+                />
+                {!collapsed ? (
+                  <View style={styles.menuCopy}>
+                    <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{item.label}</Text>
+                    <Text style={styles.menuDescription}>{item.description}</Text>
+                  </View>
+                ) : null}
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+      <View style={styles.content}>
+        <Outlet />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "row",
+    backgroundColor: "#020817",
+  },
+  sidebar: {
+    backgroundColor: "#0b1120",
+    paddingTop: 24,
+    paddingBottom: 24,
+    borderRightWidth: 1,
+    borderRightColor: "#1e293b",
+  },
+  toggle: {
+    alignSelf: "flex-end",
+    marginRight: 16,
+    marginBottom: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#1e293b",
+  },
+  togglePressed: {
+    backgroundColor: "#1f2a48",
+  },
+  menuContainer: {
+    flex: 1,
+    gap: 12,
+    paddingHorizontal: 12,
+  },
+  menuItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+  },
+  menuItemActive: {
+    backgroundColor: "#0f172a",
+    borderWidth: 1,
+    borderColor: "#38bdf8",
+  },
+  menuItemPressed: {
+    backgroundColor: "#0f172a",
+  },
+  menuCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  menuLabel: {
+    color: "#e2e8f0",
+    fontWeight: "700",
+  },
+  menuLabelActive: {
+    color: "#38bdf8",
+  },
+  menuDescription: {
+    color: "#94a3b8",
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  content: {
+    flex: 1,
+  },
+});
+
+export default TanstackNavigationLayout;

--- a/src/router/tanstack/index.tsx
+++ b/src/router/tanstack/index.tsx
@@ -1,0 +1,242 @@
+import React, { useContext, useMemo, useState } from "react";
+
+export type RouteComponent = React.ComponentType;
+
+export type RouteNode = {
+  id: string;
+  path: string;
+  component: RouteComponent;
+  parent?: RouteNode;
+  children: RouteNode[];
+};
+
+type CreateRouteOptions = {
+  getParentRoute: () => RouteNode;
+  path: string;
+  component: RouteComponent;
+};
+
+type CreateRootRouteOptions = {
+  component: RouteComponent;
+};
+
+export type RouterState = {
+  location: {
+    pathname: string;
+  };
+};
+
+type RouterMatch = RouteNode;
+
+type RouterInstance = {
+  routeTree: RouteNode;
+  defaultPath: string;
+  matchRoutes: (pathname: string) => RouterMatch[];
+};
+
+type RouterProviderProps = {
+  router: RouterInstance;
+};
+
+type RouterNavigateOptions = {
+  to: string;
+};
+
+type RouterContextValue = {
+  state: RouterState;
+  matches: RouterMatch[];
+  navigate: (options: RouterNavigateOptions) => void;
+};
+
+const RouterContext = React.createContext<RouterContextValue | null>(null);
+const OutletContext = React.createContext<React.ReactNode>(null);
+
+let routeIdCounter = 0;
+
+function ensureLeadingSlash(path: string): string {
+  if (!path.startsWith("/")) {
+    return `/${path}`;
+  }
+  return path || "/";
+}
+
+function normalizePath(path: string): string {
+  if (!path) return "/";
+  const withLeading = ensureLeadingSlash(path);
+  return withLeading === "" ? "/" : withLeading;
+}
+
+function trimSlashes(path: string): string {
+  return path.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function findDefaultPath(routeTree: RouteNode): string {
+  const indexChild = routeTree.children.find((child) => child.path === "/" || child.path === "");
+  if (indexChild) {
+    return normalizePath(indexChild.path || "/");
+  }
+  const firstChild = routeTree.children[0];
+  if (firstChild) {
+    return normalizePath(firstChild.path);
+  }
+  return "/";
+}
+
+function matchRouteTree(routeTree: RouteNode, pathname: string): RouterMatch[] {
+  const matches: RouterMatch[] = [routeTree];
+  const trimmed = trimSlashes(pathname);
+  if (!trimmed) {
+    const indexChild = routeTree.children.find((child) => child.path === "/" || child.path === "");
+    if (indexChild) {
+      matches.push(indexChild);
+    }
+    return matches;
+  }
+
+  const segments = trimmed.split("/");
+  let current = routeTree;
+
+  for (const segment of segments) {
+    const next = current.children.find((child) => {
+      const candidate = trimSlashes(child.path || "");
+      return candidate === segment;
+    });
+
+    if (!next) {
+      break;
+    }
+    matches.push(next);
+    current = next;
+  }
+
+  if (matches.length === 1) {
+    const indexChild = routeTree.children.find((child) => child.path === "/" || child.path === "");
+    if (indexChild) {
+      matches.push(indexChild);
+    }
+  }
+
+  return matches;
+}
+
+function buildElementFromMatches(matches: RouterMatch[]): React.ReactElement | null {
+  let element: React.ReactNode = null;
+
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const match = matches[index];
+    const MatchComponent = match.component;
+    element = (
+      <OutletContext.Provider value={element}>
+        <MatchComponent />
+      </OutletContext.Provider>
+    );
+  }
+
+  return element as React.ReactElement | null;
+}
+
+export function createRootRoute(options: CreateRootRouteOptions): RouteNode {
+  return {
+    id: `__root__-${routeIdCounter++}`,
+    path: "/",
+    component: options.component,
+    children: [],
+  };
+}
+
+export function createRoute(options: CreateRouteOptions): RouteNode {
+  const parent = options.getParentRoute();
+  const route: RouteNode = {
+    id: `${parent.id}-${routeIdCounter++}`,
+    path: options.path,
+    component: options.component,
+    parent,
+    children: [],
+  };
+
+  parent.children.push(route);
+  return route;
+}
+
+export function createRouter({
+  routeTree,
+  defaultPath,
+}: {
+  routeTree: RouteNode;
+  defaultPath?: string;
+}): RouterInstance {
+  return {
+    routeTree,
+    defaultPath: defaultPath ? normalizePath(defaultPath) : findDefaultPath(routeTree),
+    matchRoutes: (pathname: string) => matchRouteTree(routeTree, normalizePath(pathname)),
+  };
+}
+
+export function RouterProvider({ router }: RouterProviderProps): React.ReactElement {
+  const [pathname, setPathname] = useState(router.defaultPath);
+
+  const matches = useMemo(() => {
+    const resolvedMatches = router.matchRoutes(pathname);
+    if (resolvedMatches.length > 1) {
+      return resolvedMatches;
+    }
+    return router.matchRoutes(router.defaultPath);
+  }, [router, pathname]);
+
+  const state = useMemo<RouterState>(() => ({ location: { pathname } }), [pathname]);
+
+  const navigate = React.useCallback(
+    (options: RouterNavigateOptions) => {
+      setPathname(normalizePath(options.to));
+    },
+    [],
+  );
+
+  const contextValue = useMemo<RouterContextValue>(
+    () => ({
+      state,
+      matches,
+      navigate,
+    }),
+    [state, matches, navigate],
+  );
+
+  const element = useMemo(() => buildElementFromMatches(matches), [matches]);
+
+  return (
+    <RouterContext.Provider value={contextValue}>{element}</RouterContext.Provider>
+  );
+}
+
+function useRouterContext(): RouterContextValue {
+  const ctx = useContext(RouterContext);
+  if (!ctx) {
+    throw new Error("useRouterContext must be used within a RouterProvider");
+  }
+  return ctx;
+}
+
+export function Outlet(): React.ReactElement | null {
+  const child = useContext(OutletContext);
+  if (!child) {
+    return null;
+  }
+  return <>{child}</>;
+}
+
+export function useNavigate(): (options: RouterNavigateOptions) => void {
+  const { navigate } = useRouterContext();
+  return navigate;
+}
+
+export function useRouterState<TSelected = RouterState>({
+  select,
+}: {
+  select?: (state: RouterState) => TSelected;
+} = {}): TSelected {
+  const { state } = useRouterContext();
+  return select ? select(state) : ((state as unknown) as TSelected);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Register {}

--- a/src/router/tanstack/router.tsx
+++ b/src/router/tanstack/router.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import { RouterProvider, createRootRoute, createRoute, createRouter } from "@tanstack/react-router";
+
+import TanstackNavigationLayout from "../../app/routes/TanstackNavigationLayout";
+import LegacyDashboardRoute from "../../app/routes/LegacyDashboardRoute";
+import BarbershopOnlineProductsRoute from "../../app/routes/BarbershopOnlineProductsRoute";
+import BarbershopNewsRoute from "../../app/routes/BarbershopNewsRoute";
+
+const rootRoute = createRootRoute({
+  component: TanstackNavigationLayout,
+});
+
+createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: LegacyDashboardRoute,
+});
+
+createRoute({
+  getParentRoute: () => rootRoute,
+  path: "online-products",
+  component: BarbershopOnlineProductsRoute,
+});
+
+createRoute({
+  getParentRoute: () => rootRoute,
+  path: "news",
+  component: BarbershopNewsRoute,
+});
+
+const router = createRouter({ routeTree: rootRoute, defaultPath: "/" });
+
+export function TanstackAppRouterProvider(): React.ReactElement {
+  return <RouterProvider router={router} />;
+}
+
+export { router };
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "expo-router": ["src/router/expo-router/index"],
-      "expo-router/*": ["src/router/expo-router/*"]
+      "expo-router/*": ["src/router/expo-router/*"],
+      "@tanstack/react-router": ["src/router/tanstack/index"],
+      "@tanstack/react-router/*": ["src/router/tanstack/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a local TanStack Router shim and configure metro/tsconfig aliases for it
- introduce a collapsible left navigation layout powered by the shimmed router
- create routed screens for the legacy dashboard, barbershop online products, and barbershop news

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa630138fc8327846e42150c61fcf0