### PR TITLE
Add new menu layout with barbershop online products and news pages

### DIFF
--- a/app/new-menu/_layout.tsx
+++ b/app/new-menu/_layout.tsx
@@ -1,0 +1,175 @@
+import React, { useMemo, useState } from "react";
+import { Link, Slot, usePathname } from "expo-router";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+} from "react-native";
+
+type MenuItem = {
+  href: string;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap | keyof typeof MaterialCommunityIcons.glyphMap;
+  iconLibrary?: "ion" | "material";
+  accessibilityLabel: string;
+};
+
+const MENU_ITEMS: MenuItem[] = [
+  {
+    href: "/new-menu/barbershop-online-products",
+    label: "Barbershop online products",
+    icon: "cart-outline",
+    accessibilityLabel: "Go to barbershop online products",
+  },
+  {
+    href: "/new-menu/barbershop-news",
+    label: "Barbershop news",
+    icon: "newspaper-outline",
+    accessibilityLabel: "Go to barbershop news",
+  },
+  {
+    href: "/",
+    label: "Back to current dashboard",
+    icon: "content-cut",
+    iconLibrary: "material",
+    accessibilityLabel: "Back to the existing AIBarber dashboard",
+  },
+];
+
+const COLLAPSED_WIDTH = 72;
+const EXPANDED_WIDTH = 260;
+
+export default function NewMenuLayout(): React.ReactElement {
+  const pathname = usePathname();
+  const { width } = useWindowDimensions();
+  const [collapsed, setCollapsed] = useState(width < 720);
+
+  const activeHref = useMemo(() => {
+    if (!pathname) return undefined;
+    const match = MENU_ITEMS.find((item) => pathname.startsWith(item.href));
+    if (match) return match.href;
+    return undefined;
+  }, [pathname]);
+
+  return (
+    <View style={styles.root}>
+      <View
+        style={[
+          styles.sidebar,
+          { width: collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH },
+        ]}
+      >
+        <Pressable
+          onPress={() => setCollapsed((current) => !current)}
+          accessibilityRole="button"
+          accessibilityLabel={collapsed ? "Expand navigation menu" : "Collapse navigation menu"}
+          style={styles.toggle}
+        >
+          <Ionicons
+            name={collapsed ? "chevron-forward" : "chevron-back"}
+            size={20}
+            color="#ffffff"
+          />
+        </Pressable>
+        <View style={styles.brandRow}>
+          <MaterialCommunityIcons name="content-cut" size={22} color="#ffffff" />
+          {!collapsed && <Text style={styles.brandText}>AIBarber</Text>}
+        </View>
+        <View style={styles.menuItems}>
+          {MENU_ITEMS.map((item) => {
+            const selected = activeHref === item.href;
+            const IconComponent = item.iconLibrary === "material" ? MaterialCommunityIcons : Ionicons;
+            return (
+              <Link key={item.href} href={item.href} asChild>
+                <Pressable
+                  style={[styles.menuItem, selected && styles.menuItemActive]}
+                  accessibilityRole="link"
+                  accessibilityLabel={item.accessibilityLabel}
+                >
+                  <IconComponent
+                    name={item.icon as never}
+                    size={22}
+                    color={selected ? "#111827" : "#e5e7eb"}
+                  />
+                  {!collapsed && (
+                    <Text style={[styles.menuItemText, selected && styles.menuItemTextActive]}>
+                      {item.label}
+                    </Text>
+                  )}
+                </Pressable>
+              </Link>
+            );
+          })}
+        </View>
+      </View>
+      <View style={styles.contentArea}>
+        <Slot />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "row",
+    backgroundColor: "#0f172a",
+  },
+  sidebar: {
+    paddingTop: 32,
+    paddingHorizontal: 12,
+    backgroundColor: "#111c33",
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: "rgba(255,255,255,0.12)",
+  },
+  toggle: {
+    alignSelf: "flex-end",
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.08)",
+  },
+  brandRow: {
+    marginTop: 24,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  brandText: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+  menuItems: {
+    marginTop: 32,
+    gap: 6,
+  },
+  menuItem: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  menuItemActive: {
+    backgroundColor: "#facc15",
+  },
+  menuItemText: {
+    color: "#e5e7eb",
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  menuItemTextActive: {
+    color: "#111827",
+  },
+  contentArea: {
+    flex: 1,
+    backgroundColor: "#f9fafb",
+  },
+});

--- a/app/new-menu/barbershop-news.tsx
+++ b/app/new-menu/barbershop-news.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+
+const NEWS_ITEMS = [
+  {
+    title: "AI-driven grooming tips",
+    description:
+      "Share weekly AI-personalized grooming articles that your customers can read from any device.",
+  },
+  {
+    title: "Launch new campaigns",
+    description:
+      "Coordinate marketing pushes, newsletter topics, and announcements before they go live.",
+  },
+  {
+    title: "Track engagement",
+    description:
+      "Soon you will visualize reach, clicks, and bookings attributed to each content piece.",
+  },
+];
+
+export default function BarbershopNews(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.headerCard}>
+        <Text style={styles.title}>Barbershop news</Text>
+        <Text style={styles.subtitle}>
+          Curate announcements, campaigns, and storytelling for the community around your shop.
+        </Text>
+        <Text style={styles.body}>
+          While we finish migrating the legacy screens, this space helps us validate the navigation
+          model and responsive behavior of the new collapsible menu. Use the options on the left to
+          return to the existing dashboard whenever you need to manage daily operations.
+        </Text>
+      </View>
+      <View style={styles.grid}>
+        {NEWS_ITEMS.map((item) => (
+          <View key={item.title} style={styles.gridCard}>
+            <Text style={styles.gridTitle}>{item.title}</Text>
+            <Text style={styles.gridBody}>{item.description}</Text>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 32,
+    gap: 28,
+  },
+  headerCard: {
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "#374151",
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#4b5563",
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 16,
+  },
+  gridCard: {
+    flexBasis: 280,
+    flexGrow: 1,
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  gridTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#1f2937",
+    marginBottom: 10,
+  },
+  gridBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#4b5563",
+  },
+});

--- a/app/new-menu/barbershop-online-products.tsx
+++ b/app/new-menu/barbershop-online-products.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+
+export default function BarbershopOnlineProducts(): React.ReactElement {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Barbershop online products</Text>
+        <Text style={styles.subtitle}>
+          Centralize the digital products that keep your barbershop in the spotlight.
+        </Text>
+        <Text style={styles.body}>
+          This page is the first step in migrating the AIBarber dashboard to the new Expo Router
+          layout. Here you will orchestrate catalog curation, integrations with ecommerce tools,
+          and upcoming automations. For now it serves as a placeholder so we can progressively
+          onboard existing workflows without disrupting the current experience.
+        </Text>
+      </View>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>What comes next?</Text>
+        <Text style={styles.body}>
+          In the next iterations we will plug real datasets, expose synchronization statuses, and
+          allow product managers to configure availability and pricing directly inside this view.
+          Because the new menu lives alongside the current application, you can explore the future
+          navigation without losing access to today&apos;s tools.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 32,
+    gap: 24,
+  },
+  card: {
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "#374151",
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#4b5563",
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#1f2937",
+    marginBottom: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- add a new Expo Router layout under `/new-menu` with a collapsible left sidebar
- surface navigation targets for the barbershop online products and barbershop news screens
- keep a link back to the existing dashboard so the new structure coexists with current flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa630ba8e483278ca9c438d3770683