### PR TITLE
Move TanStack menu to the right side

### DIFF
--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -5,7 +5,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 
 const MENU_WIDTH = 248;
-const MENU_WIDTH_COLLAPSED = 68;
 
 type MenuItem = {
   key: string;
@@ -53,61 +52,69 @@ export function TanstackNavigationLayout(): React.ReactElement {
 
   return (
     <View style={styles.root}>
-      <View
-        style={[
-          styles.sidebar,
-          { width: collapsed ? MENU_WIDTH_COLLAPSED : MENU_WIDTH },
-        ]}
-      >
-        <Pressable
-          onPress={() => setCollapsed((current) => !current)}
-          style={({ pressed }) => [
-            styles.toggle,
-            pressed && styles.togglePressed,
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel={collapsed ? "Expand tanstack navigation" : "Collapse tanstack navigation"}
-        >
-          <Ionicons
-            name={collapsed ? "chevron-forward" : "chevron-back"}
-            size={18}
-            color="#f8fafc"
-          />
-        </Pressable>
-        <View style={styles.menuContainer}>
-          {MENU_ITEMS.map((item) => {
-            const active = pathname === item.to;
-            return (
-              <Pressable
-                key={item.key}
-                onPress={() => handleNavigate(item)}
-                style={({ pressed }) => [
-                  styles.menuItem,
-                  active && styles.menuItemActive,
-                  pressed && !active && styles.menuItemPressed,
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel={item.label}
-              >
-                <Ionicons
-                  name={item.icon}
-                  size={20}
-                  color={active ? "#38bdf8" : "#cbd5f5"}
-                />
-                {!collapsed ? (
-                  <View style={styles.menuCopy}>
-                    <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{item.label}</Text>
-                    <Text style={styles.menuDescription}>{item.description}</Text>
-                  </View>
-                ) : null}
-              </Pressable>
-            );
-          })}
-        </View>
-      </View>
       <View style={styles.content}>
         <Outlet />
       </View>
+      <View style={[styles.sidebarWrapper, { width: collapsed ? 0 : MENU_WIDTH }]}>
+        {!collapsed ? (
+          <View style={styles.sidebar}>
+            <Pressable
+              onPress={() => setCollapsed(true)}
+              style={({ pressed }) => [
+                styles.toggle,
+                styles.toggleExpanded,
+                pressed && styles.togglePressed,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Collapse tanstack navigation"
+            >
+              <Ionicons name="chevron-forward" size={18} color="#f8fafc" />
+            </Pressable>
+            <View style={styles.menuContainer}>
+              {MENU_ITEMS.map((item) => {
+                const active = pathname === item.to;
+                return (
+                  <Pressable
+                    key={item.key}
+                    onPress={() => handleNavigate(item)}
+                    style={({ pressed }) => [
+                      styles.menuItem,
+                      active && styles.menuItemActive,
+                      pressed && !active && styles.menuItemPressed,
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={item.label}
+                  >
+                    <Ionicons
+                      name={item.icon}
+                      size={20}
+                      color={active ? "#38bdf8" : "#cbd5f5"}
+                    />
+                    <View style={styles.menuCopy}>
+                      <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{item.label}</Text>
+                      <Text style={styles.menuDescription}>{item.description}</Text>
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+        ) : null}
+      </View>
+      {collapsed ? (
+        <Pressable
+          onPress={() => setCollapsed(false)}
+          style={({ pressed }) => [
+            styles.toggle,
+            styles.toggleFloating,
+            pressed && styles.togglePressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Expand tanstack navigation"
+        >
+          <Ionicons name="chevron-back" size={18} color="#f8fafc" />
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -116,25 +123,48 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     flexDirection: "row",
+    position: "relative",
     backgroundColor: "#020817",
   },
+  content: {
+    flex: 1,
+  },
+  sidebarWrapper: {
+    position: "relative",
+    overflow: "visible",
+    flexShrink: 0,
+  },
   sidebar: {
+    flex: 1,
     backgroundColor: "#0b1120",
     paddingTop: 24,
     paddingBottom: 24,
-    borderRightWidth: 1,
-    borderRightColor: "#1e293b",
+    borderLeftWidth: 1,
+    borderLeftColor: "#1e293b",
   },
   toggle: {
-    alignSelf: "flex-end",
-    marginRight: 16,
-    marginBottom: 16,
     width: 36,
     height: 36,
     borderRadius: 18,
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: "#1e293b",
+  },
+  toggleExpanded: {
+    alignSelf: "flex-start",
+    marginLeft: 16,
+    marginBottom: 16,
+  },
+  toggleFloating: {
+    position: "absolute",
+    right: 24,
+    top: 104,
+    zIndex: 10,
+    shadowColor: "#000",
+    shadowOpacity: 0.3,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 12,
+    elevation: 8,
   },
   togglePressed: {
     backgroundColor: "#1f2a48",
@@ -175,9 +205,6 @@ const styles = StyleSheet.create({
     color: "#94a3b8",
     fontSize: 12,
     lineHeight: 16,
-  },
-  content: {
-    flex: 1,
   },
 });
 


### PR DESCRIPTION
## Summary
- move the TanStack router sidebar to the right side of the layout so content remains on the left
- hide the navigation panel when collapsed and replace it with a floating expand toggle
- adjust toggle styling and shadowing to match the new floating placement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa69de2c1083278a1ba3d8d9974f0c