### PR TITLE
Show floating toggle when Tanstack menu is collapsed

### DIFF
--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 
 const MENU_WIDTH = 248;
-const MENU_WIDTH_COLLAPSED = 68;
 
 type MenuItem = {
   key: string;
@@ -53,58 +52,61 @@ export function TanstackNavigationLayout(): React.ReactElement {
 
   return (
     <View style={styles.root}>
-      <View
-        style={[
-          styles.sidebar,
-          { width: collapsed ? MENU_WIDTH_COLLAPSED : MENU_WIDTH },
-        ]}
-      >
+      {collapsed ? (
         <Pressable
-          onPress={() => setCollapsed((current) => !current)}
+          onPress={() => setCollapsed(false)}
           style={({ pressed }) => [
-            styles.toggle,
-            pressed && styles.togglePressed,
+            styles.floatingToggle,
+            pressed && styles.floatingTogglePressed,
           ]}
           accessibilityRole="button"
-          accessibilityLabel={collapsed ? "Expand tanstack navigation" : "Collapse tanstack navigation"}
+          accessibilityLabel="Expand tanstack navigation"
         >
-          <Ionicons
-            name={collapsed ? "chevron-forward" : "chevron-back"}
-            size={18}
-            color="#f8fafc"
-          />
+          <MaterialCommunityIcons name="menu" size={22} color="#f8fafc" />
         </Pressable>
-        <View style={styles.menuContainer}>
-          {MENU_ITEMS.map((item) => {
-            const active = pathname === item.to;
-            return (
-              <Pressable
-                key={item.key}
-                onPress={() => handleNavigate(item)}
-                style={({ pressed }) => [
-                  styles.menuItem,
-                  active && styles.menuItemActive,
-                  pressed && !active && styles.menuItemPressed,
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel={item.label}
-              >
-                <Ionicons
-                  name={item.icon}
-                  size={20}
-                  color={active ? "#38bdf8" : "#cbd5f5"}
-                />
-                {!collapsed ? (
+      ) : (
+        <View style={[styles.sidebar, { width: MENU_WIDTH }]}>
+          <Pressable
+            onPress={() => setCollapsed(true)}
+            style={({ pressed }) => [
+              styles.toggle,
+              pressed && styles.togglePressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Collapse tanstack navigation"
+          >
+            <Ionicons name="chevron-back" size={18} color="#f8fafc" />
+          </Pressable>
+          <View style={styles.menuContainer}>
+            {MENU_ITEMS.map((item) => {
+              const active = pathname === item.to;
+              return (
+                <Pressable
+                  key={item.key}
+                  onPress={() => handleNavigate(item)}
+                  style={({ pressed }) => [
+                    styles.menuItem,
+                    active && styles.menuItemActive,
+                    pressed && !active && styles.menuItemPressed,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={item.label}
+                >
+                  <Ionicons
+                    name={item.icon}
+                    size={20}
+                    color={active ? "#38bdf8" : "#cbd5f5"}
+                  />
                   <View style={styles.menuCopy}>
                     <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{item.label}</Text>
                     <Text style={styles.menuDescription}>{item.description}</Text>
                   </View>
-                ) : null}
-              </Pressable>
-            );
-          })}
+                </Pressable>
+              );
+            })}
+          </View>
         </View>
-      </View>
+      )}
       <View style={styles.content}>
         <Outlet />
       </View>
@@ -117,6 +119,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "row",
     backgroundColor: "#020817",
+    position: "relative",
   },
   sidebar: {
     backgroundColor: "#0b1120",
@@ -124,6 +127,27 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
     borderRightWidth: 1,
     borderRightColor: "#1e293b",
+  },
+  floatingToggle: {
+    position: "absolute",
+    top: 24,
+    right: 24,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#1e293b",
+    borderWidth: 1,
+    borderColor: "#1e293b",
+    shadowColor: "#000",
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+  },
+  floatingTogglePressed: {
+    backgroundColor: "#1f2a48",
   },
   toggle: {
     alignSelf: "flex-end",


### PR DESCRIPTION
## Summary
- hide the Tanstack navigation sidebar when collapsed
- add a floating expand button styled like the legacy menu toggle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa6eaaa84c8327a852ca8aff0c32f8