### PR TITLE
Make TanStack navigation overlay and collapsed by default

### DIFF
--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -43,7 +43,7 @@ const MENU_ITEMS: MenuItem[] = [
 export function TanstackNavigationLayout(): React.ReactElement {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
-  const [collapsed, setCollapsed] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(true);
 
   const handleNavigate = React.useCallback(
     (item: MenuItem) => {
@@ -114,16 +114,20 @@ export function TanstackNavigationLayout(): React.ReactElement {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    flexDirection: "row",
     backgroundColor: "#020817",
     position: "relative",
   },
   sidebar: {
     backgroundColor: "#0b1120",
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: 0,
     paddingTop: 24,
     paddingBottom: 24,
     borderLeftWidth: 1,
     borderLeftColor: "#1e293b",
+    zIndex: 10,
   },
   toggle: {
     alignSelf: "flex-start",


### PR DESCRIPTION
## Summary
- collapse the TanStack navigation menu by default to match the desired initial state
- render the navigation sidebar as an overlay so expanding it no longer shifts the underlying content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbaa90da2c8327893c83b9faa9eabe