### PR TITLE
Add services route to TanStack navigation

### DIFF
--- a/src/app/routes/ServicesRoute.tsx
+++ b/src/app/routes/ServicesRoute.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import AuthenticatedApp from "../AuthenticatedApp";
+import { bookingsRenderer } from "../../../app/bookings";
+import { cashRegisterRenderer } from "../../../app/cash-register";
+import { productsRenderer } from "../../../app/products";
+import { servicesRenderer } from "../../../app/services";
+
+export function ServicesRoute(): React.ReactElement {
+  return (
+    <AuthenticatedApp
+      initialScreen="services"
+      renderBookings={bookingsRenderer}
+      renderCashRegister={cashRegisterRenderer}
+      renderProducts={productsRenderer}
+      renderServices={servicesRenderer}
+    />
+  );
+}
+
+export default ServicesRoute;

--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -25,6 +25,13 @@ const MENU_ITEMS: MenuItem[] = [
     description: "Keep working with the current scheduling tools.",
   },
   {
+    key: "services",
+    label: "Services",
+    to: "/services",
+    icon: "cut-outline",
+    description: "Manage the catalog of services offered in the barbershop.",
+  },
+  {
     key: "online-products",
     label: "Barbershop online products",
     to: "/online-products",

--- a/src/router/tanstack/router.tsx
+++ b/src/router/tanstack/router.tsx
@@ -6,6 +6,7 @@ import TanstackNavigationLayout from "../../app/routes/TanstackNavigationLayout"
 import LegacyDashboardRoute from "../../app/routes/LegacyDashboardRoute";
 import BarbershopOnlineProductsRoute from "../../app/routes/BarbershopOnlineProductsRoute";
 import BarbershopNewsRoute from "../../app/routes/BarbershopNewsRoute";
+import ServicesRoute from "../../app/routes/ServicesRoute";
 
 const rootRoute = createRootRoute({
   component: TanstackNavigationLayout,
@@ -15,6 +16,12 @@ createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   component: LegacyDashboardRoute,
+});
+
+createRoute({
+  getParentRoute: () => rootRoute,
+  path: "services",
+  component: ServicesRoute,
 });
 
 createRoute({


### PR DESCRIPTION
## Summary
- add a dedicated Services route to the TanStack router layout
- expose the services screen through the TanStack sidebar menu

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbfa6d114483279411839f64b17bc5