### PR TITLE
Add services management route to TanStack navigation

### DIFF
--- a/src/app/routes/ServicesRoute.tsx
+++ b/src/app/routes/ServicesRoute.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import Services from "../../../app/services";
+
+export function ServicesRoute(): React.ReactElement {
+  return <Services />;
+}
+
+export default ServicesRoute;

--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -25,6 +25,13 @@ const MENU_ITEMS: MenuItem[] = [
     description: "Keep working with the current scheduling tools.",
   },
   {
+    key: "services",
+    label: "Services management",
+    to: "/services",
+    icon: "cut-outline",
+    description: "Manage service offerings and experiment with catalog updates.",
+  },
+  {
     key: "online-products",
     label: "Barbershop online products",
     to: "/online-products",

--- a/src/router/tanstack/router.tsx
+++ b/src/router/tanstack/router.tsx
@@ -6,6 +6,7 @@ import TanstackNavigationLayout from "../../app/routes/TanstackNavigationLayout"
 import LegacyDashboardRoute from "../../app/routes/LegacyDashboardRoute";
 import BarbershopOnlineProductsRoute from "../../app/routes/BarbershopOnlineProductsRoute";
 import BarbershopNewsRoute from "../../app/routes/BarbershopNewsRoute";
+import ServicesRoute from "../../app/routes/ServicesRoute";
 
 const rootRoute = createRootRoute({
   component: TanstackNavigationLayout,
@@ -27,6 +28,12 @@ createRoute({
   getParentRoute: () => rootRoute,
   path: "news",
   component: BarbershopNewsRoute,
+});
+
+createRoute({
+  getParentRoute: () => rootRoute,
+  path: "services",
+  component: ServicesRoute,
 });
 
 const router = createRouter({ routeTree: rootRoute, defaultPath: "/" });


### PR DESCRIPTION
## Summary
- add a services management entry to the TanStack navigation layout
- register a TanStack route that renders the existing services screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbfc5f8628832788e5e20961dc2ab0