### PR TITLE
Add loading screen while applying user preferences

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -7,6 +7,7 @@ import { isSupabaseConfigured, supabase } from "../lib/supabase";
 type LanguageContextValue = {
   language: SupportedLanguage;
   setLanguage: (language: SupportedLanguage) => void;
+  ready: boolean;
 };
 
 const LanguageContext = React.createContext<LanguageContextValue | undefined>(undefined);
@@ -169,7 +170,10 @@ export function LanguageProvider({ children }: { children: React.ReactNode }): R
     [preferencesReady, persistUpdates, userId],
   );
 
-  const value = React.useMemo(() => ({ language, setLanguage }), [language, setLanguage]);
+  const value = React.useMemo(
+    () => ({ language, setLanguage, ready: preferencesReady }),
+    [language, setLanguage, preferencesReady],
+  );
 
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- add localized loading copy for the initial loading screen
- gate the dashboard behind a loading state until theme and language preferences resolve
- expose the language preference readiness flag through the language context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690033d646708327ab13906d5c7d295b