### PR TITLE
Add theme context and align Tanstack navigation with theme

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { Slot } from "expo-router";
 
 import { AuthGate } from "../src/components/AuthGate";
+import { ThemeProvider } from "../src/contexts/ThemeContext";
 
 export default function RootLayout(): React.ReactElement {
   return (
     <AuthGate>
-      <Slot />
+      <ThemeProvider>
+        <Slot />
+      </ThemeProvider>
     </AuthGate>
   );
 }

--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -5,8 +5,11 @@ import { Ionicons } from "@expo/vector-icons";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { LanguageProvider, useLanguageContext } from "../../contexts/LanguageContext";
+import { useOptionalThemeContext } from "../../contexts/ThemeContext";
 import type { SupportedLanguage } from "../../locales/language";
 import { isSupabaseConfigured, supabase } from "../../lib/supabase";
+import { THEMES, type ThemeColors } from "../../theme/colors";
+import { applyAlpha } from "../../utils/color";
 
 const MENU_WIDTH = 248;
 const LEGACY_MENU_ICON_TOP = Platform.select<number>({ ios: 52, android: 40, default: 24 });
@@ -97,8 +100,11 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
   const [collapsed, setCollapsed] = React.useState(true);
   const [loggingOut, setLoggingOut] = React.useState(false);
   const { language } = useLanguageContext();
+  const themeContext = useOptionalThemeContext();
+  const themeColors = themeContext?.colors ?? THEMES.dark;
   const labels = MENU_LABELS[language];
   const logoutCopy = LOGOUT_COPY[language];
+  const styles = React.useMemo(() => createStyles(themeColors), [themeColors]);
 
   const handleNavigate = React.useCallback(
     (item: MenuItem) => {
@@ -148,7 +154,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
             accessibilityRole="button"
             accessibilityLabel="Collapse tanstack navigation"
           >
-            <Ionicons name="chevron-forward" size={18} color="#f8fafc" />
+            <Ionicons name="chevron-forward" size={18} color={themeColors.text} />
           </Pressable>
           <View style={styles.menuBody}>
             <ScrollView
@@ -174,7 +180,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
                     <Ionicons
                       name={item.icon}
                       size={20}
-                      color={active ? "#38bdf8" : "#cbd5f5"}
+                      color={active ? themeColors.accent : themeColors.subtext}
                     />
                     <View style={styles.menuCopy}>
                       <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{label}</Text>
@@ -197,7 +203,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
                 accessibilityLabel={logoutCopy.accessibility}
                 accessibilityState={{ disabled: loggingOut }}
               >
-                <Ionicons name="log-out-outline" size={20} color="#f87171" />
+                <Ionicons name="log-out-outline" size={20} color={themeColors.danger} />
                 <View style={styles.menuCopy}>
                   <Text style={[styles.menuLabel, styles.menuLogoutLabel]}>{logoutCopy.label}</Text>
                 </View>
@@ -213,7 +219,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
           accessibilityRole="button"
           accessibilityLabel="Expand tanstack navigation"
         >
-          <Ionicons name="chevron-back" size={18} color="#f8fafc" />
+          <Ionicons name="chevron-back" size={18} color={themeColors.text} />
         </Pressable>
       ) : null}
     </View>
@@ -228,112 +234,113 @@ export function TanstackNavigationLayout(): React.ReactElement {
   );
 }
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: "#020817",
-    position: "relative",
-  },
-  sidebar: {
-    backgroundColor: "#0b1120",
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    right: 0,
-    paddingTop: 24,
-    paddingBottom: 24,
-    borderLeftWidth: 1,
-    borderLeftColor: "#1e293b",
-    zIndex: 10,
-  },
-  menuBody: {
-    flex: 1,
-  },
-  toggle: {
-    alignSelf: "flex-start",
-    marginLeft: 16,
-    marginBottom: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#1e293b",
-  },
-  togglePressed: {
-    backgroundColor: "#1f2a48",
-  },
-  floatingToggle: {
-    position: "absolute",
-    top: FLOATING_TOGGLE_TOP,
-    right: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#1e293b",
-    borderWidth: 1,
-    borderColor: "#1e293b",
-    zIndex: 20,
-  },
-  menuContainer: {
-    gap: 12,
-    paddingHorizontal: 12,
-    paddingBottom: 24,
-  },
-  menuScroll: {
-    flex: 1,
-  },
-  menuItem: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-  },
-  menuItemActive: {
-    backgroundColor: "#0f172a",
-    borderWidth: 1,
-    borderColor: "#38bdf8",
-  },
-  menuItemPressed: {
-    backgroundColor: "#0f172a",
-  },
-  menuCopy: {
-    flex: 1,
-    gap: 0,
-  },
-  menuLabel: {
-    color: "#e2e8f0",
-    fontWeight: "700",
-  },
-  menuLabelActive: {
-    color: "#38bdf8",
-  },
-  menuFooter: {
-    paddingHorizontal: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: "#1e293b",
-  },
-  menuLogout: {
-    borderWidth: 1,
-    borderColor: "rgba(248, 113, 113, 0.4)",
-  },
-  menuLogoutPressed: {
-    backgroundColor: "rgba(248, 113, 113, 0.12)",
-  },
-  menuLogoutLabel: {
-    color: "#f87171",
-  },
-  menuLogoutDisabled: {
-    opacity: 0.6,
-  },
-  content: {
-    flex: 1,
-  },
-});
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    root: {
+      flex: 1,
+      backgroundColor: colors.bg,
+      position: "relative",
+    },
+    sidebar: {
+      backgroundColor: colors.sidebarBg,
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      right: 0,
+      paddingTop: 24,
+      paddingBottom: 24,
+      borderLeftWidth: 1,
+      borderLeftColor: colors.border,
+      zIndex: 10,
+    },
+    menuBody: {
+      flex: 1,
+    },
+    toggle: {
+      alignSelf: "flex-start",
+      marginLeft: 16,
+      marginBottom: 16,
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: applyAlpha(colors.subtext, 0.14),
+    },
+    togglePressed: {
+      backgroundColor: applyAlpha(colors.subtext, 0.22),
+    },
+    floatingToggle: {
+      position: "absolute",
+      top: FLOATING_TOGGLE_TOP,
+      right: 16,
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: colors.sidebarBg,
+      borderWidth: 1,
+      borderColor: colors.border,
+      zIndex: 20,
+    },
+    menuContainer: {
+      gap: 12,
+      paddingHorizontal: 12,
+      paddingBottom: 24,
+    },
+    menuScroll: {
+      flex: 1,
+    },
+    menuItem: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: 12,
+    },
+    menuItemActive: {
+      backgroundColor: applyAlpha(colors.accent, 0.14),
+      borderWidth: 1,
+      borderColor: colors.accent,
+    },
+    menuItemPressed: {
+      backgroundColor: applyAlpha(colors.subtext, 0.12),
+    },
+    menuCopy: {
+      flex: 1,
+      gap: 0,
+    },
+    menuLabel: {
+      color: colors.text,
+      fontWeight: "700",
+    },
+    menuLabelActive: {
+      color: colors.accent,
+    },
+    menuFooter: {
+      paddingHorizontal: 12,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+    },
+    menuLogout: {
+      borderWidth: 1,
+      borderColor: applyAlpha(colors.danger, 0.4),
+    },
+    menuLogoutPressed: {
+      backgroundColor: applyAlpha(colors.danger, 0.12),
+    },
+    menuLogoutLabel: {
+      color: colors.danger,
+    },
+    menuLogoutDisabled: {
+      opacity: 0.6,
+    },
+    content: {
+      flex: 1,
+    },
+  });
 
 export default TanstackNavigationLayout;

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { useColorScheme } from "react-native";
+
+import { fetchUserPreferences, saveUserPreferences } from "../lib/userPreferences";
+import { isSupabaseConfigured, supabase } from "../lib/supabase";
+import { THEMES, type ThemeColors } from "../theme/colors";
+import { DEFAULT_THEME_PREFERENCE, type ThemeName, type ThemePreference } from "../theme/preferences";
+
+export type ThemeContextValue = {
+  themePreference: ThemePreference;
+  setThemePreference: (next: ThemePreference) => void;
+  resolvedTheme: ThemeName;
+  colors: ThemeColors;
+};
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const [themePreference, setThemePreferenceState] = React.useState<ThemePreference>(DEFAULT_THEME_PREFERENCE);
+  const [userId, setUserId] = React.useState<string | null>(null);
+  const [preferencesReady, setPreferencesReady] = React.useState<boolean>(() => !isSupabaseConfigured());
+  const pendingPreferenceRef = React.useRef<ThemePreference | null>(null);
+
+  const resolvedTheme = React.useMemo<ThemeName>(() => {
+    if (themePreference === "system") {
+      return colorScheme === "dark" ? "dark" : "light";
+    }
+    return themePreference;
+  }, [colorScheme, themePreference]);
+
+  const colors = React.useMemo(() => THEMES[resolvedTheme], [resolvedTheme]);
+
+  const persistPreference = React.useCallback(
+    async (appearance: ThemePreference) => {
+      if (!isSupabaseConfigured()) {
+        return;
+      }
+
+      if (!userId) {
+        return;
+      }
+
+      try {
+        await saveUserPreferences(userId, { appearance });
+      } catch (error) {
+        console.error("Failed to save theme preference", error);
+      }
+    },
+    [userId],
+  );
+
+  React.useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      setUserId(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    const resolveInitialUser = async () => {
+      try {
+        const { data, error } = await supabase.auth.getUser();
+        if (error) {
+          throw error;
+        }
+
+        if (!isMounted) {
+          return;
+        }
+
+        setUserId(data.user?.id ?? null);
+      } catch (error) {
+        console.error("Failed to resolve authenticated user", error);
+        if (isMounted) {
+          setUserId(null);
+        }
+      }
+    };
+
+    void resolveInitialUser();
+
+    const { data, error } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setUserId(session?.user?.id ?? null);
+    });
+
+    if (error) {
+      console.error("Failed to subscribe to auth changes", error);
+    }
+
+    return () => {
+      isMounted = false;
+      data?.subscription.unsubscribe();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      setPreferencesReady(true);
+      return;
+    }
+
+    let isMounted = true;
+
+    setPreferencesReady(false);
+
+    if (!userId) {
+      setThemePreferenceState(DEFAULT_THEME_PREFERENCE);
+      setPreferencesReady(true);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const loadPreferences = async () => {
+      try {
+        const preferences = await fetchUserPreferences(userId);
+        if (!isMounted) {
+          return;
+        }
+
+        const pending = pendingPreferenceRef.current;
+
+        if (pending) {
+          setThemePreferenceState(pending);
+        } else if (preferences?.appearance) {
+          setThemePreferenceState(preferences.appearance);
+        } else {
+          setThemePreferenceState(DEFAULT_THEME_PREFERENCE);
+        }
+      } catch (error) {
+        console.error("Failed to load theme preference", error);
+      } finally {
+        if (isMounted) {
+          setPreferencesReady(true);
+        }
+      }
+    };
+
+    void loadPreferences();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  React.useEffect(() => {
+    if (!preferencesReady || !userId) {
+      return;
+    }
+
+    const pending = pendingPreferenceRef.current;
+    if (!pending) {
+      return;
+    }
+
+    pendingPreferenceRef.current = null;
+    void persistPreference(pending);
+  }, [persistPreference, preferencesReady, userId]);
+
+  const setThemePreference = React.useCallback(
+    (next: ThemePreference) => {
+      setThemePreferenceState(next);
+
+      if (!isSupabaseConfigured()) {
+        return;
+      }
+
+      if (!userId || !preferencesReady) {
+        pendingPreferenceRef.current = next;
+        return;
+      }
+
+      void persistPreference(next);
+    },
+    [persistPreference, preferencesReady, userId],
+  );
+
+  const value = React.useMemo<ThemeContextValue>(
+    () => ({ themePreference, setThemePreference, resolvedTheme, colors }),
+    [colors, resolvedTheme, setThemePreference, themePreference],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeContext(): ThemeContextValue {
+  const context = React.useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export function useOptionalThemeContext(): ThemeContextValue | undefined {
+  return React.useContext(ThemeContext);
+}
+
+export { ThemeContext };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,54 +1,38 @@
-export const palette = {
-  textPrimary: "#e5e7eb",
-  textSecondary: "#cbd5e1",
-  accentPrimary: "#60a5fa",
-  accentOnDark: "#091016",
-  danger: "#ef4444",
-  borderStrong: "rgba(255,255,255,0.12)",
-  borderMuted: "rgba(255,255,255,0.07)",
-  surfaceElevated: "rgba(255,255,255,0.06)",
-  surfaceSubtle: "rgba(255,255,255,0.045)",
-  backgroundDark: "#0b0d13",
-} as const;
+import type { ThemeName } from "./preferences";
 
-export const formCardColors = {
-  text: palette.textPrimary,
-  subtext: palette.textSecondary,
-  border: palette.borderStrong,
-  surface: palette.surfaceElevated,
-  accent: palette.accentPrimary,
-  accentFgOn: palette.accentOnDark,
-  danger: palette.danger,
-} as const;
+export type ThemeColors = {
+  bg: string;
+  surface: string;
+  sidebarBg: string;
+  border: string;
+  text: string;
+  subtext: string;
+  accent: string;
+  accentFgOn: string;
+  danger: string;
+};
 
-export type FormCardColors = typeof formCardColors;
-
-export const subtleFormCardColors = {
-  text: palette.textPrimary,
-  subtext: palette.textSecondary,
-  border: palette.borderMuted,
-  surface: palette.surfaceSubtle,
-  accent: palette.accentPrimary,
-  accentFgOn: palette.accentOnDark,
-  danger: palette.danger,
-} as const;
-
-export type SubtleFormCardColors = typeof subtleFormCardColors;
-
-export const modalColors = {
-  text: palette.textPrimary,
-  subtext: palette.textSecondary,
-  surface: palette.surfaceElevated,
-  border: palette.borderStrong,
-  accent: palette.accentPrimary,
-  bg: palette.backgroundDark,
-} as const;
-
-export type ModalColors = typeof modalColors;
-
-export const modalColorsWithDanger = {
-  ...modalColors,
-  danger: palette.danger,
-} as const;
-
-export type ModalColorsWithDanger = typeof modalColorsWithDanger;
+export const THEMES: Record<ThemeName, ThemeColors> = {
+  dark: {
+    bg: "#0b0d13",
+    surface: "rgba(255,255,255,0.045)",
+    sidebarBg: "#111827",
+    border: "rgba(255,255,255,0.07)",
+    text: "#e5e7eb",
+    subtext: "#cbd5e1",
+    accent: "#60a5fa",
+    accentFgOn: "#091016",
+    danger: "#ef4444",
+  },
+  light: {
+    bg: "#f8fafc",
+    surface: "rgba(15,23,42,0.06)",
+    sidebarBg: "#ffffff",
+    border: "rgba(15,23,42,0.12)",
+    text: "#0f172a",
+    subtext: "#475569",
+    accent: "#2563eb",
+    accentFgOn: "#f8fafc",
+    danger: "#dc2626",
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable ThemeContext and shared light/dark color palette
- update AuthenticatedApp and the Tanstack navigation layout to consume theme colors
- wrap the Expo layout with the ThemeProvider so the navigation reacts to theme changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690033cc1c308327a65ba724a1680421