### PR TITLE
Add shared theme context and update Tanstack menu styling

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { Slot } from "expo-router";
 
 import { AuthGate } from "../src/components/AuthGate";
+import { ThemeProvider } from "../src/contexts/ThemeContext";
 
 export default function RootLayout(): React.ReactElement {
   return (
-    <AuthGate>
-      <Slot />
-    </AuthGate>
+    <ThemeProvider>
+      <AuthGate>
+        <Slot />
+      </AuthGate>
+    </ThemeProvider>
   );
 }

--- a/src/app/AuthenticatedApp.tsx
+++ b/src/app/AuthenticatedApp.tsx
@@ -12,7 +12,6 @@ import {
   Modal,
   TextInput,
   useWindowDimensions,
-  useColorScheme,
   Linking,
 } from "react-native";
 import { MaterialCommunityIcons, Ionicons } from "@expo/vector-icons";
@@ -38,16 +37,18 @@ import {
 import { polyglotProductName, polyglotProducts, polyglotServices } from "../lib/polyglot";
 import { COMPONENT_COPY } from "../locales/componentCopy";
 import { useOptionalLanguageContext } from "../contexts/LanguageContext";
+import { useThemeContext } from "../contexts/ThemeContext";
 import { getInitialLanguage, type SupportedLanguage } from "../locales/language";
 import type { RecurrenceFrequency } from "../locales/types";
 import { getEmailConfirmationRedirectUrl } from "../lib/auth";
 import { getBarbershopForOwner, updateBarbershop, type Barbershop } from "../lib/barbershops";
-import { fetchUserPreferences, saveUserPreferences } from "../lib/userPreferences";
+import { fetchUserPreferences } from "../lib/userPreferences";
 import { supabase, isSupabaseConfigured } from "../lib/supabase";
 import { applyAlpha, mixHexColor, tintHexColor } from "../utils/color";
 import { buildDateTime, getCurrentTimeString, getTodayDateKey, normalizeTimeInput } from "../utils/datetime";
 import { parseSignedCurrency, sanitizeSignedCurrencyInput } from "../utils/currency";
-import { DEFAULT_THEME_PREFERENCE, type ThemeName, type ThemePreference } from "../theme/preferences";
+import type { ThemePreference } from "../theme/preferences";
+import type { ThemeColors } from "../theme/theme";
 
 const SLOT_MINUTES = 15;
 const WHATSAPP_BRAND_COLOR = "#25D366";
@@ -1336,43 +1337,6 @@ const LANGUAGE_OPTIONS: { code: SupportedLanguage; label: string }[] = [
   { code: "pt", label: "Português (BR)" },
 ];
 
-type ThemeColors = {
-  bg: string;
-  surface: string;
-  sidebarBg: string;
-  border: string;
-  text: string;
-  subtext: string;
-  accent: string;
-  accentFgOn: string;
-  danger: string;
-};
-
-const THEMES: Record<ThemeName, ThemeColors> = {
-  dark: {
-    bg: "#0b0d13",
-    surface: "rgba(255,255,255,0.045)",
-    sidebarBg: "#111827",
-    border: "rgba(255,255,255,0.07)",
-    text: "#e5e7eb",
-    subtext: "#cbd5e1",
-    accent: "#60a5fa",
-    accentFgOn: "#091016",
-    danger: "#ef4444",
-  },
-  light: {
-    bg: "#f8fafc",
-    surface: "rgba(15,23,42,0.06)",
-    sidebarBg: "#ffffff",
-    border: "rgba(15,23,42,0.12)",
-    text: "#0f172a",
-    subtext: "#475569",
-    accent: "#2563eb",
-    accentFgOn: "#f8fafc",
-    danger: "#dc2626",
-  },
-};
-
 const THEME_OPTIONS: { value: ThemePreference }[] = [
   { value: "system" },
   { value: "light" },
@@ -1846,59 +1810,32 @@ function AuthenticatedApp({
     const entries = teamCopy.roles.map((role) => [role.value, role.label]);
     return Object.fromEntries(entries) as Record<string, string>;
   }, [teamCopy.roles]);
-  const colorScheme = useColorScheme();
-  const [themePreference, setThemePreferenceState] = useState<ThemePreference>(DEFAULT_THEME_PREFERENCE);
-  const [themePreferenceReady, setThemePreferenceReady] = useState<boolean>(() => !isSupabaseConfigured());
-  const pendingThemePreferenceRef = useRef<ThemePreference | null>(null);
-  const resolvedTheme = themePreference === "system" ? (colorScheme === "dark" ? "dark" : "light") : themePreference;
-  const colors = useMemo(() => THEMES[resolvedTheme], [resolvedTheme]);
+  const { colors, resolvedTheme, themePreference, setThemePreference, ready: themePreferenceReady } =
+    useThemeContext();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const languageReady = languageContext ? languageContext.ready : fallbackLanguageReady;
   const preferencesReady = themePreferenceReady && languageReady;
-  const persistUserPreferences = useCallback(
-    async (updates: { appearance?: ThemePreference; language?: SupportedLanguage }) => {
-      if (!isSupabaseConfigured()) {
-        return;
-      }
 
-      const userId = currentUser?.id;
-      if (!userId) {
-        return;
-      }
-
-      try {
-        await saveUserPreferences(userId, updates);
-      } catch (error) {
-        console.error("Failed to save user preferences", error);
-      }
-    },
-    [currentUser?.id],
-  );
   useEffect(() => {
+    if (languageContext) {
+      return;
+    }
+
     if (!isSupabaseConfigured()) {
-      setThemePreferenceReady(true);
-      if (!languageContext) {
-        setFallbackLanguageReady(true);
-      }
+      setFallbackLanguageReady(true);
       return;
     }
 
     const userId = currentUser?.id;
     if (!userId) {
       if (!currentUserLoading) {
-        setThemePreferenceReady(true);
-        if (!languageContext) {
-          setFallbackLanguageReady(true);
-        }
+        setFallbackLanguageReady(true);
       }
       return;
     }
 
     let isMounted = true;
-    setThemePreferenceReady(false);
-    if (!languageContext) {
-      setFallbackLanguageReady(false);
-    }
+    setFallbackLanguageReady(false);
 
     const loadPreferences = async () => {
       try {
@@ -1907,76 +1844,24 @@ function AuthenticatedApp({
           return;
         }
 
-        const pendingThemePreference = pendingThemePreferenceRef.current;
-
-        if (pendingThemePreference) {
-          setThemePreferenceState(pendingThemePreference);
-        } else if (preferences?.appearance) {
-          setThemePreferenceState(preferences.appearance);
-        }
-
-        if (!languageContext && preferences?.language) {
+        if (preferences?.language) {
           setFallbackLanguage(preferences.language);
         }
       } catch (error) {
-        console.error("Failed to load user preferences", error);
-        if (!languageContext && isMounted) {
-          setFallbackLanguageReady(true);
-        }
+        console.error("Failed to load language preference", error);
       } finally {
         if (isMounted) {
-          setThemePreferenceReady(true);
-          if (!languageContext) {
-            setFallbackLanguageReady(true);
-          }
+          setFallbackLanguageReady(true);
         }
       }
     };
 
-    loadPreferences();
+    void loadPreferences();
 
     return () => {
       isMounted = false;
     };
   }, [currentUser?.id, currentUserLoading, languageContext, setFallbackLanguage]);
-  useEffect(() => {
-    if (!isSupabaseConfigured()) {
-      return;
-    }
-
-    if (!themePreferenceReady) {
-      return;
-    }
-
-    if (!currentUser?.id) {
-      return;
-    }
-
-    if (!pendingThemePreferenceRef.current) {
-      return;
-    }
-
-    const nextPreference = pendingThemePreferenceRef.current;
-    pendingThemePreferenceRef.current = null;
-    void persistUserPreferences({ appearance: nextPreference });
-  }, [currentUser?.id, persistUserPreferences, themePreferenceReady]);
-  const setThemePreference = useCallback(
-    (next: ThemePreference) => {
-      setThemePreferenceState(next);
-
-      if (!isSupabaseConfigured()) {
-        return;
-      }
-
-      if (!currentUser?.id || !themePreferenceReady) {
-        pendingThemePreferenceRef.current = next;
-        return;
-      }
-
-      void persistUserPreferences({ appearance: next });
-    },
-    [currentUser?.id, persistUserPreferences, themePreferenceReady],
-  );
   const emailConfirmationCopy = copy.settingsPage.emailConfirmation;
   const [barbershop, setBarbershop] = useState<Barbershop | null>(null);
   const [barbershopForm, setBarbershopForm] = useState<{ name: string; slug: string; timezone: string }>(() => ({

--- a/src/app/routes/TanstackNavigationLayout.tsx
+++ b/src/app/routes/TanstackNavigationLayout.tsx
@@ -5,8 +5,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { LanguageProvider, useLanguageContext } from "../../contexts/LanguageContext";
+import { useThemeContext } from "../../contexts/ThemeContext";
 import type { SupportedLanguage } from "../../locales/language";
 import { isSupabaseConfigured, supabase } from "../../lib/supabase";
+import type { ThemeColors } from "../../theme/theme";
 
 const MENU_WIDTH = 248;
 const LEGACY_MENU_ICON_TOP = Platform.select<number>({ ios: 52, android: 40, default: 24 });
@@ -91,6 +93,79 @@ const LOGOUT_COPY: Record<
   },
 };
 
+type MenuTheme = {
+  rootBackground: string;
+  sidebarBackground: string;
+  sidebarBorderColor: string;
+  toggleBackground: string;
+  togglePressedBackground: string;
+  toggleIconColor: string;
+  floatingToggleBackground: string;
+  floatingToggleBorderColor: string;
+  iconActiveColor: string;
+  iconInactiveColor: string;
+  itemActiveBackground: string;
+  itemActiveBorderColor: string;
+  itemPressedBackground: string;
+  labelColor: string;
+  labelActiveColor: string;
+  footerBorderColor: string;
+  logoutBorderColor: string;
+  logoutPressedBackground: string;
+  logoutLabelColor: string;
+  logoutIconColor: string;
+};
+
+function getMenuTheme(resolvedTheme: "light" | "dark", colors: ThemeColors): MenuTheme {
+  if (resolvedTheme === "dark") {
+    return {
+      rootBackground: colors.bg,
+      sidebarBackground: colors.sidebarBg,
+      sidebarBorderColor: "#1e293b",
+      toggleBackground: "#1e293b",
+      togglePressedBackground: "#1f2a48",
+      toggleIconColor: "#f8fafc",
+      floatingToggleBackground: "#1e293b",
+      floatingToggleBorderColor: "#1e293b",
+      iconActiveColor: colors.accent,
+      iconInactiveColor: "#cbd5f5",
+      itemActiveBackground: "#0f172a",
+      itemActiveBorderColor: colors.accent,
+      itemPressedBackground: "#0f172a",
+      labelColor: colors.text,
+      labelActiveColor: colors.accent,
+      footerBorderColor: "#1e293b",
+      logoutBorderColor: "rgba(248, 113, 113, 0.4)",
+      logoutPressedBackground: "rgba(248, 113, 113, 0.12)",
+      logoutLabelColor: "#f87171",
+      logoutIconColor: "#f87171",
+    };
+  }
+
+  return {
+    rootBackground: colors.bg,
+    sidebarBackground: colors.sidebarBg,
+    sidebarBorderColor: "#e2e8f0",
+    toggleBackground: "#e2e8f0",
+    togglePressedBackground: "#cbd5f5",
+    toggleIconColor: colors.text,
+    floatingToggleBackground: colors.sidebarBg,
+    floatingToggleBorderColor: "#cbd5f5",
+    iconActiveColor: colors.accent,
+    iconInactiveColor: "#64748b",
+    itemActiveBackground: "#dbeafe",
+    itemActiveBorderColor: colors.accent,
+    itemPressedBackground: "#e2e8f0",
+    labelColor: colors.text,
+    labelActiveColor: colors.accent,
+    footerBorderColor: "#e2e8f0",
+    logoutBorderColor: "rgba(220, 38, 38, 0.35)",
+    logoutPressedBackground: "rgba(220, 38, 38, 0.08)",
+    logoutLabelColor: colors.danger,
+    logoutIconColor: colors.danger,
+  };
+}
+
 function TanstackNavigationLayoutContent(): React.ReactElement {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -99,6 +174,9 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
   const { language } = useLanguageContext();
   const labels = MENU_LABELS[language];
   const logoutCopy = LOGOUT_COPY[language];
+  const { colors: themeColors, resolvedTheme } = useThemeContext();
+  const menuTheme = React.useMemo(() => getMenuTheme(resolvedTheme, themeColors), [resolvedTheme, themeColors]);
+  const styles = React.useMemo(() => createStyles(menuTheme), [menuTheme]);
 
   const handleNavigate = React.useCallback(
     (item: MenuItem) => {
@@ -148,7 +226,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
             accessibilityRole="button"
             accessibilityLabel="Collapse tanstack navigation"
           >
-            <Ionicons name="chevron-forward" size={18} color="#f8fafc" />
+            <Ionicons name="chevron-forward" size={18} color={menuTheme.toggleIconColor} />
           </Pressable>
           <View style={styles.menuBody}>
             <ScrollView
@@ -174,7 +252,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
                     <Ionicons
                       name={item.icon}
                       size={20}
-                      color={active ? "#38bdf8" : "#cbd5f5"}
+                      color={active ? menuTheme.iconActiveColor : menuTheme.iconInactiveColor}
                     />
                     <View style={styles.menuCopy}>
                       <Text style={[styles.menuLabel, active && styles.menuLabelActive]}>{label}</Text>
@@ -197,7 +275,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
                 accessibilityLabel={logoutCopy.accessibility}
                 accessibilityState={{ disabled: loggingOut }}
               >
-                <Ionicons name="log-out-outline" size={20} color="#f87171" />
+                <Ionicons name="log-out-outline" size={20} color={menuTheme.logoutIconColor} />
                 <View style={styles.menuCopy}>
                   <Text style={[styles.menuLabel, styles.menuLogoutLabel]}>{logoutCopy.label}</Text>
                 </View>
@@ -213,7 +291,7 @@ function TanstackNavigationLayoutContent(): React.ReactElement {
           accessibilityRole="button"
           accessibilityLabel="Expand tanstack navigation"
         >
-          <Ionicons name="chevron-back" size={18} color="#f8fafc" />
+          <Ionicons name="chevron-back" size={18} color={menuTheme.toggleIconColor} />
         </Pressable>
       ) : null}
     </View>
@@ -228,112 +306,113 @@ export function TanstackNavigationLayout(): React.ReactElement {
   );
 }
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: "#020817",
-    position: "relative",
-  },
-  sidebar: {
-    backgroundColor: "#0b1120",
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    right: 0,
-    paddingTop: 24,
-    paddingBottom: 24,
-    borderLeftWidth: 1,
-    borderLeftColor: "#1e293b",
-    zIndex: 10,
-  },
-  menuBody: {
-    flex: 1,
-  },
-  toggle: {
-    alignSelf: "flex-start",
-    marginLeft: 16,
-    marginBottom: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#1e293b",
-  },
-  togglePressed: {
-    backgroundColor: "#1f2a48",
-  },
-  floatingToggle: {
-    position: "absolute",
-    top: FLOATING_TOGGLE_TOP,
-    right: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#1e293b",
-    borderWidth: 1,
-    borderColor: "#1e293b",
-    zIndex: 20,
-  },
-  menuContainer: {
-    gap: 12,
-    paddingHorizontal: 12,
-    paddingBottom: 24,
-  },
-  menuScroll: {
-    flex: 1,
-  },
-  menuItem: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-  },
-  menuItemActive: {
-    backgroundColor: "#0f172a",
-    borderWidth: 1,
-    borderColor: "#38bdf8",
-  },
-  menuItemPressed: {
-    backgroundColor: "#0f172a",
-  },
-  menuCopy: {
-    flex: 1,
-    gap: 0,
-  },
-  menuLabel: {
-    color: "#e2e8f0",
-    fontWeight: "700",
-  },
-  menuLabelActive: {
-    color: "#38bdf8",
-  },
-  menuFooter: {
-    paddingHorizontal: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: "#1e293b",
-  },
-  menuLogout: {
-    borderWidth: 1,
-    borderColor: "rgba(248, 113, 113, 0.4)",
-  },
-  menuLogoutPressed: {
-    backgroundColor: "rgba(248, 113, 113, 0.12)",
-  },
-  menuLogoutLabel: {
-    color: "#f87171",
-  },
-  menuLogoutDisabled: {
-    opacity: 0.6,
-  },
-  content: {
-    flex: 1,
-  },
-});
+const createStyles = (theme: MenuTheme) =>
+  StyleSheet.create({
+    root: {
+      flex: 1,
+      backgroundColor: theme.rootBackground,
+      position: "relative",
+    },
+    sidebar: {
+      backgroundColor: theme.sidebarBackground,
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      right: 0,
+      paddingTop: 24,
+      paddingBottom: 24,
+      borderLeftWidth: 1,
+      borderLeftColor: theme.sidebarBorderColor,
+      zIndex: 10,
+    },
+    menuBody: {
+      flex: 1,
+    },
+    toggle: {
+      alignSelf: "flex-start",
+      marginLeft: 16,
+      marginBottom: 16,
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: theme.toggleBackground,
+    },
+    togglePressed: {
+      backgroundColor: theme.togglePressedBackground,
+    },
+    floatingToggle: {
+      position: "absolute",
+      top: FLOATING_TOGGLE_TOP,
+      right: 16,
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: theme.floatingToggleBackground,
+      borderWidth: 1,
+      borderColor: theme.floatingToggleBorderColor,
+      zIndex: 20,
+    },
+    menuContainer: {
+      gap: 12,
+      paddingHorizontal: 12,
+      paddingBottom: 24,
+    },
+    menuScroll: {
+      flex: 1,
+    },
+    menuItem: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: 12,
+    },
+    menuItemActive: {
+      backgroundColor: theme.itemActiveBackground,
+      borderWidth: 1,
+      borderColor: theme.itemActiveBorderColor,
+    },
+    menuItemPressed: {
+      backgroundColor: theme.itemPressedBackground,
+    },
+    menuCopy: {
+      flex: 1,
+      gap: 0,
+    },
+    menuLabel: {
+      color: theme.labelColor,
+      fontWeight: "700",
+    },
+    menuLabelActive: {
+      color: theme.labelActiveColor,
+    },
+    menuFooter: {
+      paddingHorizontal: 12,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: theme.footerBorderColor,
+    },
+    menuLogout: {
+      borderWidth: 1,
+      borderColor: theme.logoutBorderColor,
+    },
+    menuLogoutPressed: {
+      backgroundColor: theme.logoutPressedBackground,
+    },
+    menuLogoutLabel: {
+      color: theme.logoutLabelColor,
+    },
+    menuLogoutDisabled: {
+      opacity: 0.6,
+    },
+    content: {
+      flex: 1,
+    },
+  });
 
 export default TanstackNavigationLayout;

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { useColorScheme } from "react-native";
+
+import { fetchUserPreferences, saveUserPreferences } from "../lib/userPreferences";
+import { isSupabaseConfigured, supabase } from "../lib/supabase";
+import { DEFAULT_THEME_PREFERENCE, type ThemeName, type ThemePreference } from "../theme/preferences";
+import { THEMES, type ThemeColors } from "../theme/theme";
+
+type ThemeContextValue = {
+  colors: ThemeColors;
+  themePreference: ThemePreference;
+  resolvedTheme: ThemeName;
+  setThemePreference: (next: ThemePreference) => void;
+  ready: boolean;
+};
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+export function ThemeProvider({ children }: ThemeProviderProps): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const [themePreference, setThemePreferenceState] = React.useState<ThemePreference>(
+    DEFAULT_THEME_PREFERENCE,
+  );
+  const [preferencesReady, setPreferencesReady] = React.useState<boolean>(() => !isSupabaseConfigured());
+  const [userId, setUserId] = React.useState<string | null>(null);
+  const pendingPreferenceRef = React.useRef<ThemePreference | null>(null);
+
+  React.useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      setUserId(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    const resolveInitialUser = async () => {
+      try {
+        const { data, error } = await supabase.auth.getUser();
+        if (!isMounted) {
+          return;
+        }
+
+        if (error) {
+          console.error("Failed to resolve authenticated user for theme preferences", error);
+          setUserId(null);
+          return;
+        }
+
+        setUserId(data.user?.id ?? null);
+      } catch (error) {
+        console.error("Failed to resolve authenticated user for theme preferences", error);
+        if (isMounted) {
+          setUserId(null);
+        }
+      }
+    };
+
+    void resolveInitialUser();
+
+    const { data, error } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) {
+        return;
+      }
+      setUserId(session?.user?.id ?? null);
+    });
+
+    if (error) {
+      console.error("Failed to subscribe to auth changes for theme preferences", error);
+    }
+
+    return () => {
+      isMounted = false;
+      data?.subscription.unsubscribe();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      setPreferencesReady(true);
+      return;
+    }
+
+    const currentUserId = userId;
+
+    if (!currentUserId) {
+      setPreferencesReady(true);
+      return;
+    }
+
+    let isMounted = true;
+    setPreferencesReady(false);
+
+    const loadPreferences = async () => {
+      try {
+        const preferences = await fetchUserPreferences(currentUserId);
+        if (!isMounted) {
+          return;
+        }
+
+        const pendingPreference = pendingPreferenceRef.current;
+        if (pendingPreference) {
+          setThemePreferenceState(pendingPreference);
+          return;
+        }
+
+        if (preferences?.appearance) {
+          setThemePreferenceState(preferences.appearance);
+        } else {
+          setThemePreferenceState(DEFAULT_THEME_PREFERENCE);
+        }
+      } catch (error) {
+        console.error("Failed to load theme preference", error);
+      } finally {
+        if (isMounted) {
+          setPreferencesReady(true);
+        }
+      }
+    };
+
+    void loadPreferences();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  React.useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      return;
+    }
+
+    if (!preferencesReady) {
+      return;
+    }
+
+    if (!userId) {
+      return;
+    }
+
+    const pending = pendingPreferenceRef.current;
+    if (!pending) {
+      return;
+    }
+
+    pendingPreferenceRef.current = null;
+    void saveUserPreferences(userId, { appearance: pending }).catch((error) => {
+      console.error("Failed to persist theme preference", error);
+    });
+  }, [preferencesReady, userId]);
+
+  const resolvedTheme: ThemeName = React.useMemo(() => {
+    if (themePreference === "system") {
+      return colorScheme === "dark" ? "dark" : "light";
+    }
+    return themePreference;
+  }, [colorScheme, themePreference]);
+
+  const colors = React.useMemo(() => THEMES[resolvedTheme], [resolvedTheme]);
+
+  const setThemePreference = React.useCallback(
+    (next: ThemePreference) => {
+      setThemePreferenceState(next);
+
+      if (!isSupabaseConfigured()) {
+        return;
+      }
+
+      if (!userId || !preferencesReady) {
+        pendingPreferenceRef.current = next;
+        return;
+      }
+
+      void saveUserPreferences(userId, { appearance: next }).catch((error) => {
+        console.error("Failed to persist theme preference", error);
+      });
+    },
+    [preferencesReady, userId],
+  );
+
+  const value = React.useMemo(
+    () => ({ colors, themePreference, resolvedTheme, setThemePreference, ready: preferencesReady }),
+    [colors, themePreference, resolvedTheme, setThemePreference, preferencesReady],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeContext(): ThemeContextValue {
+  const context = React.useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export function useOptionalThemeContext(): ThemeContextValue | undefined {
+  return React.useContext(ThemeContext);
+}
+
+export { ThemeContext };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,38 @@
+import type { ThemeName } from "./preferences";
+
+export type ThemeColors = {
+  bg: string;
+  surface: string;
+  sidebarBg: string;
+  border: string;
+  text: string;
+  subtext: string;
+  accent: string;
+  accentFgOn: string;
+  danger: string;
+};
+
+export const THEMES: Record<ThemeName, ThemeColors> = {
+  dark: {
+    bg: "#0b0d13",
+    surface: "rgba(255,255,255,0.045)",
+    sidebarBg: "#111827",
+    border: "rgba(255,255,255,0.07)",
+    text: "#e5e7eb",
+    subtext: "#cbd5e1",
+    accent: "#60a5fa",
+    accentFgOn: "#091016",
+    danger: "#ef4444",
+  },
+  light: {
+    bg: "#f8fafc",
+    surface: "rgba(15,23,42,0.06)",
+    sidebarBg: "#ffffff",
+    border: "rgba(15,23,42,0.12)",
+    text: "#0f172a",
+    subtext: "#475569",
+    accent: "#2563eb",
+    accentFgOn: "#f8fafc",
+    danger: "#dc2626",
+  },
+};


### PR DESCRIPTION
## Summary
- add a shared theme provider to load and persist user theme preferences
- update AuthenticatedApp to consume the shared theme context and simplify fallback language loading
- restyle the TanStack navigation menu to read theme colors and support light and dark modes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690037d568c88327ac9420cabe7b1b5d