### PR TITLE
Enable back navigation history on barbershop profile page

### DIFF
--- a/app/barbershop-settings.tsx
+++ b/app/barbershop-settings.tsx
@@ -24,7 +24,8 @@ export function BarbershopSettingsScreen({
   barbershopSuccess,
   handleBarbershopFieldChange,
   handleSaveBarbershop,
-  handleNavigateToSettings,
+  canNavigateBack,
+  handleGoBack,
   handleRetryBarbershop,
 }: BarbershopSettingsScreenProps): React.ReactElement {
   return (
@@ -123,8 +124,9 @@ export function BarbershopSettingsScreen({
             gap: 12,
           }}
         >
+        {canNavigateBack ? (
           <Pressable
-            onPress={handleNavigateToSettings}
+            onPress={handleGoBack}
             style={[styles.smallBtn, { borderColor: colors.border }]}
             accessibilityRole="button"
             accessibilityLabel={barbershopPageCopy.actions.back}
@@ -133,6 +135,7 @@ export function BarbershopSettingsScreen({
               {barbershopPageCopy.actions.back}
             </Text>
           </Pressable>
+        ) : null}
 
           {barbershop ? (
             <Pressable


### PR DESCRIPTION
## Summary
- replace the hard-coded "Back to settings" action with a history-aware back button on the barbershop profile screen
- track navigation history inside the authenticated app so the barbershop profile can return to the previously visited screen

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_6900b7a93944832793034d1f7586616e