### PR TITLE
Remove back navigation from barbershop profile

### DIFF
--- a/app/barbershop-settings.tsx
+++ b/app/barbershop-settings.tsx
@@ -24,7 +24,6 @@ export function BarbershopSettingsScreen({
   barbershopSuccess,
   handleBarbershopFieldChange,
   handleSaveBarbershop,
-  handleNavigateToSettings,
   handleRetryBarbershop,
 }: BarbershopSettingsScreenProps): React.ReactElement {
   return (
@@ -123,17 +122,6 @@ export function BarbershopSettingsScreen({
             gap: 12,
           }}
         >
-          <Pressable
-            onPress={handleNavigateToSettings}
-            style={[styles.smallBtn, { borderColor: colors.border }]}
-            accessibilityRole="button"
-            accessibilityLabel={barbershopPageCopy.actions.back}
-          >
-            <Text style={{ color: colors.subtext, fontWeight: "800" }}>
-              {barbershopPageCopy.actions.back}
-            </Text>
-          </Pressable>
-
           {barbershop ? (
             <Pressable
               onPress={handleSaveBarbershop}

--- a/src/app/AuthenticatedApp.tsx
+++ b/src/app/AuthenticatedApp.tsx
@@ -256,7 +256,6 @@ const LANGUAGE_COPY = {
       actions: {
         save: "Save changes",
         saving: "Saving…",
-        back: "Back to settings",
         retry: "Try again",
       },
       feedback: {
@@ -1451,7 +1450,6 @@ export type BarbershopSettingsScreenProps = {
   barbershopSuccess: string | null;
   handleBarbershopFieldChange: (field: "name" | "slug" | "timezone", value: string) => void;
   handleSaveBarbershop: () => Promise<void>;
-  handleNavigateToSettings: () => void;
   handleRetryBarbershop: () => Promise<void>;
 };
 
@@ -1499,7 +1497,6 @@ const defaultBarbershopSettingsRenderer: BarbershopSettingsScreenRenderer = ({
   barbershopSuccess,
   handleBarbershopFieldChange,
   handleSaveBarbershop,
-  handleNavigateToSettings,
   handleRetryBarbershop,
 }) => (
   <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: isCompactLayout ? 16 : 20, gap: 16 }}>
@@ -1597,17 +1594,6 @@ const defaultBarbershopSettingsRenderer: BarbershopSettingsScreenRenderer = ({
           gap: 12,
         }}
       >
-        <Pressable
-          onPress={handleNavigateToSettings}
-          style={[styles.smallBtn, { borderColor: colors.border }]}
-          accessibilityRole="button"
-          accessibilityLabel={barbershopPageCopy.actions.back}
-        >
-          <Text style={{ color: colors.subtext, fontWeight: "800" }}>
-            {barbershopPageCopy.actions.back}
-          </Text>
-        </Pressable>
-
         {barbershop ? (
           <Pressable
             onPress={handleSaveBarbershop}
@@ -4577,7 +4563,6 @@ function AuthenticatedApp({
         barbershopSuccess,
         handleBarbershopFieldChange,
         handleSaveBarbershop,
-        handleNavigateToSettings: () => handleNavigate("settings"),
         handleRetryBarbershop,
       })
     ) : activeScreen === "settings" ? (


### PR DESCRIPTION
## Summary
- remove the "Back to settings" action from the barbershop profile copy and UI
- update barbershop settings renderer props to reflect the removed navigation handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900bc1ead988327a33b9741a8883526