### PR TITLE
Require OpenAI proxy token configuration

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -105,12 +105,17 @@ export function createOpenAIClient(config: OpenAIClientConfig): OpenAIClient {
   const transcriptionUrl = config.transcriptionUrl ?? AUDIO_TRANSCRIPTION_URL;
   const fetchImpl = config.fetchImpl ?? fetch;
   const isConfigured =
-    typeof apiUrl === "string" && apiUrl.length > 0 && typeof transcriptionUrl === "string" && transcriptionUrl.length > 0;
+    typeof apiUrl === "string" &&
+    apiUrl.length > 0 &&
+    typeof transcriptionUrl === "string" &&
+    transcriptionUrl.length > 0 &&
+    typeof OPENAI_PROXY_TOKEN === "string" &&
+    OPENAI_PROXY_TOKEN.length > 0;
 
   const ensureConfigured = () => {
     if (!isConfigured) {
       throw new Error(
-        "OpenAI service is not configured. Ensure the backend has an OPENAI_API_KEY secret set.",
+        "OpenAI service is not configured. Ensure the backend has OPENAI_API_KEY and OPENAI_PROXY_TOKEN secrets set.",
       );
     }
   };


### PR DESCRIPTION
## Summary
- require the OpenAI proxy token to be present when determining client configuration
- refresh the OpenAI client unit tests to stub environment variables per test and assert token headers
- add coverage for the missing token scenario

## Testing
- npm test -- --run tests/openai/openaiClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6900c1c12e1c8327bb936431146621aa