### PR TITLE
Update local development instructions for Expo web server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,11 +33,12 @@ Azure Static Web Apps automatically discovers the Azure Functions application be
      }
    }
    ```
-4. Run both the SWA front-end and the Azure Functions backend locally using the SWA CLI or separate terminals:
+4. Run both the Expo web front-end and the Azure Functions backend locally using the SWA CLI or separate terminals:
    ```bash
-   npm run dev                 # front-end
+   npm run web -- --port 5173  # front-end (Expo web dev server)
    npm run start --prefix api  # backend (func start)
    ```
+   > Expo defaults to port 19006; passing `--port 5173` keeps the local server aligned with the SWA CLI example below.
 
 ## Secure Configuration and Secret Management
 - Store `OPENAI_API_KEY` and `OPENAI_PROXY_TOKEN` as application settings in Azure Static Web Apps (SWA). Do **not** commit these values to the repository.


### PR DESCRIPTION
## Summary
- clarify the local development step to reference the Expo web command actually used by the project
- document the recommended `--port 5173` flag so the Expo dev server aligns with the SWA CLI sample

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900c3a5c65c83278881999d971c6ce1