### PR TITLE
Update OpenAI client test title

### DIFF
--- a/tests/openai/openaiClient.test.ts
+++ b/tests/openai/openaiClient.test.ts
@@ -57,7 +57,7 @@ describe("createOpenAIClient", () => {
     expect(response.choices[0]?.message.content).toBe("Hello");
   });
 
-  it("surfaced backend errors returned by the proxy", async () => {
+  it("surfaces backend errors returned by the proxy", async () => {
     process.env.EXPO_PUBLIC_OPENAI_PROXY_TOKEN = "test-token";
     const { createOpenAIClient } = await importOpenAI();
 


### PR DESCRIPTION
## Summary
- adjust the test description for backend error handling in the OpenAI client tests

## Testing
- npm test -- --run tests/openai/openaiClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6900c4e4d8c4832781a398621c03ed85