### PR TITLE
docs: clarify article usage in local settings instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Azure Static Web Apps automatically discovers the Azure Functions application be
    npm install
    (cd api && npm install)
    ```
-3. Add a `api/local.settings.json` file (excluded from git) with your secrets:
+3. Add an `api/local.settings.json` file (excluded from git) with your secrets:
    ```json
    {
      "IsEncrypted": false,


### PR DESCRIPTION
## Summary
- clarify the article used when referring to `api/local.settings.json` for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69091cc3ad008327acbf3a10a4506020