### PR TITLE
Clarify list_bookings date requirement

### DIFF
--- a/src/lib/bookingAgent.ts
+++ b/src/lib/bookingAgent.ts
@@ -54,7 +54,7 @@ function buildToolDefinitions(services: Service[]) {
       function: {
         name: "list_bookings",
         description:
-          "Return the existing bookings. If a date is provided, only return bookings for that day. Always include the booking id, service id, barber id, and timeslot.",
+          "Return the existing bookings for a specific date. Always include the booking id, service id, barber id, and timeslot.",
         parameters: {
           type: "object",
           properties: {
@@ -174,7 +174,7 @@ function buildToolDefinitions(services: Service[]) {
   ];
 }
 
-async function listBookings(args: { date?: string }, serviceMap: Map<string, Service>): Promise<unknown> {
+async function listBookings(args: { date: string }, serviceMap: Map<string, Service>): Promise<unknown> {
   if (!args?.date) {
     return { error: "date is required" };
   }


### PR DESCRIPTION
## Summary
- update the list_bookings tool description to state that a date must be supplied
- align the listBookings helper signature with the required date argument

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69091cc1e77c83278caeabf865401f0e