### PR TITLE
Handle mixed-case provided token headers

### DIFF
--- a/api/_shared/utils.js
+++ b/api/_shared/utils.js
@@ -12,8 +12,7 @@ function jsonResponse(status, body) {
 
 function getProvidedToken(req) {
   if (!req || typeof req !== "object" || !req.headers) return undefined;
-  const headers = req.headers;
-  return headers["x-api-key"] || headers["x-functions-key"];
+  return getHeader(req, "x-api-key") ?? getHeader(req, "x-functions-key");
 }
 
 function getHeader(req, name) {

--- a/tests/api/utils.test.ts
+++ b/tests/api/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+const { getProvidedToken } = require("../../api/_shared/utils");
+
+describe("getProvidedToken", () => {
+  it("returns token for lowercase headers", () => {
+    const req = { headers: { "x-api-key": "lowercase-token" } };
+    expect(getProvidedToken(req)).toBe("lowercase-token");
+  });
+
+  it("returns token for uppercase headers", () => {
+    const req = { headers: { "X-API-KEY": "uppercase-token" } };
+    expect(getProvidedToken(req)).toBe("uppercase-token");
+  });
+
+  it("falls back to functions key regardless of case", () => {
+    const req = { headers: { "X-FUNCTIONS-KEY": "functions-token" } };
+    expect(getProvidedToken(req)).toBe("functions-token");
+  });
+
+  it("returns undefined when no token provided", () => {
+    const req = { headers: { other: "value" } };
+    expect(getProvidedToken(req)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- update getProvidedToken to use the shared header lookup so API key headers are case-insensitive
- add unit coverage confirming uppercase x-api-key and x-functions-key headers are accepted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69091cc921308327a2f21084b1bc3f5b