### PR TITLE
Add assertions for transcription payload

### DIFF
--- a/tests/openai/openaiClient.test.ts
+++ b/tests/openai/openaiClient.test.ts
@@ -138,6 +138,16 @@ describe("createOpenAIClient", () => {
 
       expect(transcript).toBe("Hello world");
       expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(appendMock).toHaveBeenNthCalledWith(1, "model", "gpt-4o-mini-transcribe");
+      expect(appendMock).toHaveBeenNthCalledWith(
+        2,
+        "file",
+        expect.objectContaining({
+          uri: "file:///test.m4a",
+          name: "voice-message.m4a",
+          type: "audio/m4a",
+        }),
+      );
 
       const [url, requestInit] = fetchImpl.mock.calls[0] ?? [];
       expect(url).toBe("/api/transcribe");


### PR DESCRIPTION
## Summary
- ensure the transcription test verifies FormData receives the model and file payloads
- validate default file metadata is applied when appending URI-based audio

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_69091cc71c548327ac43088a16e6f9e4