### PR TITLE
Ensure client booking route resolves on Azure

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,18 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/api/*"]
+  },
+  "routes": [
+    {
+      "route": "/client-booking",
+      "rewrite": "/index.html",
+      "allowedRoles": ["anonymous", "authenticated"]
+    },
+    {
+      "route": "/client-booking/*",
+      "rewrite": "/index.html",
+      "allowedRoles": ["anonymous", "authenticated"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a `staticwebapp.config.json` with a SPA navigation fallback so Azure rewrites unknown routes to `index.html`
- explicitly rewrite `/client-booking` routes to the SPA entry point while keeping API requests untouched

## Testing
- not run (configuration-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193f8e46088327a76e103c195f28f4)