### PR TITLE
Fix cash register amount calculation

### DIFF
--- a/src/lib/cashRegister.ts
+++ b/src/lib/cashRegister.ts
@@ -172,11 +172,11 @@ const persistEntry = async (input: NormalizedEntryInput): Promise<CashEntry> => 
   return persistEntryInSupabase(input);
 };
 
-const ensureAmount = (unit: number | null, quantity: number, fallback: number) => {
+export const calculateEntryAmount = (unit: number | null, quantity: number, fallback: number) => {
   if (unit === null) {
     const numeric = Number(fallback);
     if (!Number.isFinite(numeric)) return 0;
-    return Math.round(numeric);
+    return Math.round(numeric * quantity);
   }
   return unit * quantity;
 };
@@ -185,7 +185,7 @@ export async function recordServiceSale(input: ServiceSaleInput): Promise<CashEn
   const quantity = ensureQuantity(input.quantity, 1);
   const unit = ensureUnitAmount(input.unitPriceCents);
   const sourceName = normalizeSourceName(input.serviceName, "Service sale");
-  const amount = ensureAmount(unit, quantity, input.unitPriceCents);
+  const amount = calculateEntryAmount(unit, quantity, input.unitPriceCents);
 
   return persistEntry({
     type: "service_sale",
@@ -203,7 +203,7 @@ export async function recordProductSale(input: ProductSaleInput): Promise<CashEn
   const quantity = ensureQuantity(input.quantity, 1);
   const unit = ensureUnitAmount(input.unitPriceCents);
   const sourceName = normalizeSourceName(input.productName, "Product sale");
-  const amount = ensureAmount(unit, quantity, input.unitPriceCents);
+  const amount = calculateEntryAmount(unit, quantity, input.unitPriceCents);
 
   return persistEntry({
     type: "product_sale",

--- a/tests/cashRegister/cashRegister.test.ts
+++ b/tests/cashRegister/cashRegister.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { calculateEntryAmount } from "../../src/lib/cashRegister";
+
+describe("calculateEntryAmount", () => {
+  it("multiplies the unit amount by quantity when provided", () => {
+    expect(calculateEntryAmount(1250, 3, 1250)).toBe(3750);
+  });
+
+  it("falls back to the default price and still multiplies by quantity", () => {
+    expect(calculateEntryAmount(null, 4, 800)).toBe(3200);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure cash register amount calculations multiply fallback pricing by quantity
- expose the amount helper for reuse and test the normal and fallback paths

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4445d41c8327a1eca3c1b9d36252)