### PR TITLE
Add coverage for cash register fallback and quantity validation

### DIFF
--- a/tests/cashRegister/cashRegister.test.ts
+++ b/tests/cashRegister/cashRegister.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { calculateEntryAmount } from "../../src/lib/cashRegister";
+import { calculateEntryAmount, recordServiceSale } from "../../src/lib/cashRegister";
 
 describe("calculateEntryAmount", () => {
   it("multiplies the unit amount by quantity when provided", () => {
@@ -8,5 +8,39 @@ describe("calculateEntryAmount", () => {
 
   it("falls back to the default price and still multiplies by quantity", () => {
     expect(calculateEntryAmount(null, 4, 800)).toBe(3200);
+  });
+
+  it("returns 0 when the fallback value cannot be converted to a number", () => {
+    expect(calculateEntryAmount(null, 2, Number("abc"))).toBe(0);
+    expect(calculateEntryAmount(null, 2, Number.NaN)).toBe(0);
+  });
+
+  it("rounds the total when the fallback value contains decimals", () => {
+    expect(calculateEntryAmount(null, 3, 100.4)).toBe(301);
+    expect(calculateEntryAmount(null, 3, 100.5)).toBe(302);
+  });
+});
+
+describe("validation of quantities", () => {
+  it("throws when quantity is zero", async () => {
+    await expect(
+      recordServiceSale({
+        serviceId: "svc_1",
+        serviceName: "Test service",
+        unitPriceCents: 1500,
+        quantity: 0,
+      }),
+    ).rejects.toThrow("Quantity must be greater than zero");
+  });
+
+  it("throws when quantity is negative", async () => {
+    await expect(
+      recordServiceSale({
+        serviceId: "svc_2",
+        serviceName: "Test service",
+        unitPriceCents: 1500,
+        quantity: -2,
+      }),
+    ).rejects.toThrow("Quantity must be greater than zero");
   });
 });


### PR DESCRIPTION
## Summary
- add calculateEntryAmount tests for non-numeric fallbacks and decimal rounding
- cover quantity validation errors through recordServiceSale

## Testing
- npm test -- tests/cashRegister/cashRegister.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b494f10448327aa79d737cc9fdeec)