### PR TITLE
Handle custom reasons in occurrence preview

### DIFF
--- a/src/components/OccurrencePreviewModal.tsx
+++ b/src/components/OccurrencePreviewModal.tsx
@@ -51,9 +51,11 @@ export default function OccurrencePreviewModal({
             {items.map((it, idx) => {
               const status = it.ok
                 ? copy.status.ok
-                : it.reason === "conflict"
-                  ? copy.status.conflict
-                  : copy.status.outsideHours;
+                : it.reason && !["conflict", "outside-hours"].includes(it.reason)
+                  ? it.reason
+                  : it.reason === "conflict"
+                    ? copy.status.conflict
+                    : copy.status.outsideHours;
               const color = it.ok ? colors.text : colors.danger;
               return (
                 <View key={idx} style={[styles.row, { borderColor: colors.border, backgroundColor: colors.surface }]}>

--- a/tests/components/OccurrencePreviewModal.test.ts
+++ b/tests/components/OccurrencePreviewModal.test.ts
@@ -1,0 +1,28 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import OccurrencePreviewModal from "../../src/components/OccurrencePreviewModal";
+
+describe("OccurrencePreviewModal", () => {
+  it("renders a provided custom reason verbatim for failed items", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OccurrencePreviewModal, {
+        visible: true,
+        items: [
+          {
+            date: "2024-01-01",
+            start: "09:00",
+            end: "10:00",
+            ok: false,
+            reason: "Barber unavailable for this slot",
+          },
+        ],
+        onClose: () => {},
+        onConfirm: () => {},
+      })
+    );
+
+    expect(html).toContain("Barber unavailable for this slot");
+  });
+});

--- a/tests/mocks/reactNativeStub.ts
+++ b/tests/mocks/reactNativeStub.ts
@@ -1,0 +1,11 @@
+import React from "react";
+
+const wrap = (tag: string) => ({ children }: { children?: React.ReactNode }) =>
+  React.createElement(tag, null, children);
+
+export const Modal = wrap("div");
+export const View = wrap("div");
+export const Text = wrap("span");
+export const Pressable = wrap("button");
+export const ScrollView = wrap("div");
+export const StyleSheet = { create: (styles: object) => styles };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     alias: {
       "expo-router": expoRouterAlias,
       "expo-router/entry": path.resolve(expoRouterAlias, "entry"),
+      "react-native": path.resolve(__dirname, "tests/mocks/reactNativeStub.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- display provided custom reasons for failed occurrences before falling back to default labels
- stub react-native for tests and add snapshot-style check for custom reason rendering

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b494e0d7c8327b1b235f79854536c)