### PR TITLE
Handle unknown occurrence reasons

### DIFF
--- a/src/components/OccurrencePreviewModal.tsx
+++ b/src/components/OccurrencePreviewModal.tsx
@@ -55,7 +55,9 @@ export default function OccurrencePreviewModal({
                   ? it.reason
                   : it.reason === "conflict"
                     ? copy.status.conflict
-                    : copy.status.outsideHours;
+                    : it.reason === "outside-hours"
+                      ? copy.status.outsideHours
+                      : copy.status.unknown;
               const color = it.ok ? colors.text : colors.danger;
               return (
                 <View key={idx} style={[styles.row, { borderColor: colors.border, backgroundColor: colors.surface }]}>

--- a/src/locales/componentCopy.ts
+++ b/src/locales/componentCopy.ts
@@ -330,6 +330,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         ok: "OK",
         conflict: "Conflict",
         outsideHours: "Outside hours",
+        unknown: "Unknown error",
       },
       actions: {
         back: "Back",
@@ -372,6 +373,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         ok: "OK",
         conflict: "Conflict",
         outsideHours: "Outside hours",
+        unknown: "Unknown error",
       },
       actions: {
         back: "Back",
@@ -687,6 +689,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         ok: "OK",
         conflict: "Conflito",
         outsideHours: "Fora do horário",
+        unknown: "Erro desconhecido",
       },
       actions: {
         back: "Voltar",
@@ -729,6 +732,7 @@ export const COMPONENT_COPY: Record<SupportedLanguage, ComponentCopy> = {
         ok: "OK",
         conflict: "Conflito",
         outsideHours: "Fora do horário",
+        unknown: "Erro desconhecido",
       },
       actions: {
         back: "Voltar",

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -256,6 +256,7 @@ export type OccurrencePreviewCopy = {
     ok: string;
     conflict: string;
     outsideHours: string;
+    unknown: string;
   };
   actions: {
     back: string;

--- a/tests/components/OccurrencePreviewModal.test.ts
+++ b/tests/components/OccurrencePreviewModal.test.ts
@@ -25,4 +25,24 @@ describe("OccurrencePreviewModal", () => {
 
     expect(html).toContain("Barber unavailable for this slot");
   });
+
+  it("shows a neutral fallback when a failure reason is missing", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OccurrencePreviewModal, {
+        visible: true,
+        items: [
+          {
+            date: "2024-01-02",
+            start: "10:00",
+            end: "11:00",
+            ok: false,
+          },
+        ],
+        onClose: () => {},
+        onConfirm: () => {},
+      })
+    );
+
+    expect(html).toContain("Unknown error");
+  });
 });


### PR DESCRIPTION
## Summary
- add explicit status copy for unknown occurrence preview failures in all locales
- render missing or unrecognized failure reasons with a neutral fallback instead of outside-hours
- expand occurrence preview modal tests to cover unknown reason handling

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4b4227208327bf51128db0d893bd)