### PR TITLE
Add coverage for occurrence preview modal

### DIFF
--- a/src/components/OccurrencePreviewModal.tsx
+++ b/src/components/OccurrencePreviewModal.tsx
@@ -73,6 +73,7 @@ export default function OccurrencePreviewModal({
             </Pressable>
             <Pressable
               disabled={okCount === 0}
+              accessibilityState={{ disabled: okCount === 0 }}
               style={[
                 styles.btn,
                 {

--- a/tests/components/OccurrencePreviewModal.test.ts
+++ b/tests/components/OccurrencePreviewModal.test.ts
@@ -25,4 +25,55 @@ describe("OccurrencePreviewModal", () => {
 
     expect(html).toContain("Barber unavailable for this slot");
   });
+
+  it("renders translated labels for conflict and outside-hours statuses", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OccurrencePreviewModal, {
+        visible: true,
+        items: [
+          { date: "2024-02-01", start: "10:00", end: "11:00", ok: false, reason: "conflict" },
+          { date: "2024-02-02", start: "12:00", end: "13:00", ok: false, reason: "outside-hours" },
+        ],
+        onClose: () => {},
+        onConfirm: () => {},
+      })
+    );
+
+    expect(html).toContain("Conflict");
+    expect(html).toContain("Outside hours");
+  });
+
+  it("indicates a disabled confirm state when there are no successful occurrences", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OccurrencePreviewModal, {
+        visible: true,
+        items: [
+          { date: "2024-03-01", start: "09:00", end: "10:00", ok: false, reason: "conflict" },
+          { date: "2024-03-02", start: "11:00", end: "12:00", ok: false, reason: "outside-hours" },
+        ],
+        onClose: () => {},
+        onConfirm: () => {},
+      })
+    );
+
+    expect(html).toContain("0 will be created");
+    expect(html).toContain("Create 0");
+  });
+
+  it("summarizes the number of created and skipped occurrences", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OccurrencePreviewModal, {
+        visible: true,
+        items: [
+          { date: "2024-04-01", start: "09:00", end: "10:00", ok: true },
+          { date: "2024-04-02", start: "11:00", end: "12:00", ok: true },
+          { date: "2024-04-03", start: "13:00", end: "14:00", ok: false, reason: "conflict" },
+        ],
+        onClose: () => {},
+        onConfirm: () => {},
+      })
+    );
+
+    expect(html).toContain("2 will be created • 1 skipped");
+  });
 });


### PR DESCRIPTION
## Summary
- extend occurrence preview modal tests to cover status translations, disabled confirm state, and summary counts
- add accessibility disabled state to confirm button for zero successful occurrences

## Testing
- npm test -- tests/components/OccurrencePreviewModal.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4b4456688327ae3da7c313b5f762)